### PR TITLE
feat: add GitHub Actions workflow for indexer tests

### DIFF
--- a/.github/workflows/actions-indexer-tests.yml
+++ b/.github/workflows/actions-indexer-tests.yml
@@ -1,0 +1,52 @@
+# .github/workflows/actions-indexer-tests.yml
+name: Actions Indexer Tests (PR pushes)
+
+on:
+    pull_request:
+        types: [opened, synchronize]
+        branches:
+            - dev
+            - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo/target
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - name: Cargo check (selected crates)
+        run: |
+          cargo check --locked \
+            -p actions-indexer \
+            -p actions-indexer-pipeline \
+            -p actions-indexer-shared \
+            -p actions-indexer-repository
+
+      - name: Cargo test (selected crates)
+        run: |
+          cargo test --locked --all-targets \
+            -p actions-indexer \
+            -p actions-indexer-pipeline \
+            -p actions-indexer-shared \
+            -p actions-indexer-repository

--- a/.github/workflows/actions-indexer-tests.yml
+++ b/.github/workflows/actions-indexer-tests.yml
@@ -1,5 +1,5 @@
 # .github/workflows/actions-indexer-tests.yml
-name: Actions Indexer Tests (PR pushes)
+name: Actions Indexer Tests
 
 on:
     pull_request:
@@ -20,7 +20,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  check-and-test:
+  actions-indexer-tests:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/actions-indexer-tests.yml
+++ b/.github/workflows/actions-indexer-tests.yml
@@ -7,6 +7,11 @@ on:
         branches:
             - dev
             - main
+        paths:
+            - 'actions-indexer/**'
+            - 'actions-indexer-pipeline/**'
+            - 'actions-indexer-shared/**'
+            - 'actions-indexer-repository/**'
 
 permissions:
   contents: read
@@ -33,6 +38,8 @@ jobs:
           cache-on-failure: true
 
       - name: Cargo test (selected crates)
+        env:
+          RUST_BACKTRACE: 1
         run: |
           cargo test --locked --all-targets \
             -p actions-indexer \

--- a/.github/workflows/actions-indexer-tests.yml
+++ b/.github/workflows/actions-indexer-tests.yml
@@ -35,14 +35,6 @@ jobs:
         with:
           cache-on-failure: true
 
-      - name: Cargo check (selected crates)
-        run: |
-          cargo check --locked \
-            -p actions-indexer \
-            -p actions-indexer-pipeline \
-            -p actions-indexer-shared \
-            -p actions-indexer-repository
-
       - name: Cargo test (selected crates)
         run: |
           cargo test --locked --all-targets \

--- a/.github/workflows/actions-indexer-tests.yml
+++ b/.github/workflows/actions-indexer-tests.yml
@@ -27,9 +27,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
-
       - name: Cache cargo/target
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/actions-unit-tests.yml
+++ b/.github/workflows/actions-unit-tests.yml
@@ -1,5 +1,5 @@
-# .github/workflows/actions-indexer-tests.yml
-name: Actions Indexer Tests
+# .github/workflows/actions-unit-tests.yml
+name: Actions Unit Tests
 
 on:
     pull_request:
@@ -25,7 +25,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  actions-indexer-tests:
+  actions-unit-tests:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/actions-unit-tests.yml
+++ b/.github/workflows/actions-unit-tests.yml
@@ -12,6 +12,7 @@ on:
             - 'actions-indexer-pipeline/**'
             - 'actions-indexer-shared/**'
             - 'actions-indexer-repository/**'
+            - '.github/workflows/actions-unit-tests.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
Add a Github Actions Workflow to run cargo tests over the `actions-indexer` related crates