### PR TITLE
fix(notif): update bounty relation type IDs to match curator-app

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3930,6 +3930,7 @@ name = "notification-e2e-tests"
 version = "0.1.0"
 dependencies = [
  "axum 0.7.9",
+ "grc-20",
  "hermes-kafka",
  "hermes-schema",
  "hex",

--- a/notification-service/e2e-tests/Cargo.toml
+++ b/notification-service/e2e-tests/Cargo.toml
@@ -12,6 +12,7 @@ tokio = { version = "1.42.0", features = ["macros", "rt-multi-thread", "sync", "
 axum = "0.7"
 sqlx = { version = "0.8.6", features = ["runtime-tokio", "postgres", "uuid", "chrono", "tls-rustls"] }
 prost = "0.13.5"
+grc-20 = "0.4.1"
 hmac = "0.12"
 sha2 = "0.10"
 hex = "0.4"

--- a/notification-service/e2e-tests/src/main.rs
+++ b/notification-service/e2e-tests/src/main.rs
@@ -67,14 +67,44 @@ const PROP_3E_REJECTED_BYTES: [u8; 16] = [0x05; 16];
 const PROP_1E_CREATED_BYTES: [u8; 16] = [0x31; 16];
 const PROP_0E_CREATED_BYTES: [u8; 16] = [0x32; 16];
 
+// Bounty test fixtures
+// Bounty space with 2 editors (receives interest notifications)
+const BOUNTY_SPACE_BYTES: [u8; 16] = [0xB1; 16];
+const BOUNTY_EDITOR_1_BYTES: [u8; 16] = [0xB2; 16];
+const BOUNTY_EDITOR_2_BYTES: [u8; 16] = [0xB3; 16];
+// Curator's personal space (the person expressing interest / receiving allocation)
+const CURATOR_SPACE_BYTES: [u8; 16] = [0xC1; 16];
+const CURATOR_ENTITY_BYTES: [u8; 16] = [0xC2; 16];
+// Bounty entity
+const BOUNTY_ENTITY_BYTES: [u8; 16] = [0xBE; 16];
+// Relation IDs
+const INTEREST_RELATION_BYTES: [u8; 16] = [0xE1; 16];
+const ALLOCATED_RELATION_BYTES: [u8; 16] = [0xE2; 16];
+const PAYOUT_RELATION_BYTES: [u8; 16] = [0xE3; 16];
+
+// Well-known bounty relation type UUIDs (must match models.rs)
+const INTEREST_TYPE_BYTES: [u8; 16] = [
+    0xff, 0x7e, 0x1b, 0x44, 0x44, 0xa2, 0x41, 0x91, 0x87, 0x32, 0x4e, 0x6c, 0x22, 0x2a, 0xfe, 0x07,
+];
+const ALLOCATED_TYPE_BYTES: [u8; 16] = [
+    0xcf, 0xeb, 0x64, 0x22, 0x23, 0xc5, 0x4d, 0xf4, 0xb3, 0xf9, 0x37, 0x5a, 0x48, 0x9d, 0x9e, 0x22,
+];
+const PAYOUT_TYPE_BYTES: [u8; 16] = [
+    0xfd, 0xda, 0xca, 0xae, 0x85, 0x13, 0x8a, 0x43, 0xec, 0x1a, 0x50, 0xff, 0x71, 0x56, 0x4d, 0x42,
+];
+
 const GOVERNANCE_TOPIC: &str = "space.governance";
+const KNOWLEDGE_EDITS_TOPIC: &str = "knowledge.edits";
 const NUM_WEBHOOKS: usize = 3;
 
 // Expected calls:
 // 3-editor space: 6 event types × 3 editors × 3 webhooks = 54
 // 1-editor space: 1 event type  × 1 editor  × 3 webhooks = 3
 // 0-editor space: 1 event type  × 0 editors × 3 webhooks = 0
-const EXPECTED_CALLS: usize = 54 + 3;
+// Bounty interest: 1 event × 2 editors × 3 webhooks = 6
+// Bounty allocated: 1 event × 1 curator × 3 webhooks = 3
+// Bounty payout: 1 event × 1 curator × 3 webhooks = 3
+const EXPECTED_CALLS: usize = 54 + 3 + 6 + 3 + 3;
 
 const ALL_EVENT_TYPES: &[&str] = &[
     "proposal_created",
@@ -83,6 +113,9 @@ const ALL_EVENT_TYPES: &[&str] = &[
     "proposal_executed",
     "proposal_settings_updated",
     "proposal_rejected",
+    "bounty_interest",
+    "bounty_allocated",
+    "bounty_payout",
 ];
 
 // ---------------------------------------------------------------------------
@@ -207,6 +240,55 @@ async fn seed_database(
     .execute(pool)
     .await?;
 
+    // Bounty space with 2 editors
+    let bounty_space = Uuid::from_bytes(BOUNTY_SPACE_BYTES);
+    for bytes in [BOUNTY_EDITOR_1_BYTES, BOUNTY_EDITOR_2_BYTES] {
+        sqlx::query(
+            "INSERT INTO editors (member_space_id, space_id) VALUES ($1, $2) \
+             ON CONFLICT DO NOTHING",
+        )
+        .bind(Uuid::from_bytes(bytes))
+        .bind(bounty_space)
+        .execute(pool)
+        .await?;
+    }
+
+    // Seed a relation so lookup_bounty_space can resolve BOUNTY_ENTITY -> BOUNTY_SPACE
+    // TYPE_RELATION_TYPE_ID = 8f151ba4-de20-4e3c-9cb4-99ddf96f48f1
+    sqlx::query(
+        "INSERT INTO relations (id, space_id, type_id, from_entity_id, to_entity_id, created_at, created_at_block) \
+         VALUES ($1, $2, '8f151ba4-de20-4e3c-9cb4-99ddf96f48f1'::uuid, $3, '362c1dbd-dc64-44bb-a3c4-652f38a642d7'::uuid, '0', '0') \
+         ON CONFLICT DO NOTHING",
+    )
+    .bind(Uuid::new_v4())
+    .bind(bounty_space)
+    .bind(Uuid::from_bytes(BOUNTY_ENTITY_BYTES))
+    .execute(pool)
+    .await?;
+
+    // Seed a space row for the bounty space (needed for lookup_entity_space JOIN)
+    sqlx::query("INSERT INTO spaces (id) VALUES ($1) ON CONFLICT DO NOTHING")
+        .bind(bounty_space)
+        .execute(pool)
+        .await?;
+
+    // Curator personal space (for allocated/payout resolution)
+    let curator_space = Uuid::from_bytes(CURATOR_SPACE_BYTES);
+    sqlx::query("INSERT INTO spaces (id) VALUES ($1) ON CONFLICT DO NOTHING")
+        .bind(curator_space)
+        .execute(pool)
+        .await?;
+
+    // Add curator as editor of their own space (for single-user notifications)
+    sqlx::query(
+        "INSERT INTO editors (member_space_id, space_id) VALUES ($1, $2) \
+         ON CONFLICT DO NOTHING",
+    )
+    .bind(curator_space)
+    .bind(curator_space)
+    .execute(pool)
+    .await?;
+
     Ok(())
 }
 
@@ -279,7 +361,13 @@ async fn produce_test_events(kafka_broker: &str) -> Result<(), Box<dyn std::erro
         settings: Some(make_settings()),
         meta: Some(make_meta(12345, 1700000000)),
     };
-    send_event(&producer, "PROPOSAL_CREATED", &msg.encode_to_vec(), "3e-created").await?;
+    send_event(
+        &producer,
+        "PROPOSAL_CREATED",
+        &msg.encode_to_vec(),
+        "3e-created",
+    )
+    .await?;
 
     let msg = hermes_schema::pb::governance::HermesProposalUpdated {
         space_id: SPACE_3E_BYTES.to_vec(),
@@ -290,7 +378,13 @@ async fn produce_test_events(kafka_broker: &str) -> Result<(), Box<dyn std::erro
         settings: Some(make_settings()),
         meta: Some(make_meta(12347, 1700002000)),
     };
-    send_event(&producer, "PROPOSAL_UPDATED", &msg.encode_to_vec(), "3e-updated").await?;
+    send_event(
+        &producer,
+        "PROPOSAL_UPDATED",
+        &msg.encode_to_vec(),
+        "3e-updated",
+    )
+    .await?;
 
     let msg = hermes_schema::pb::governance::HermesProposalVoted {
         voter_id: VOTER_ID_BYTES.to_vec(),
@@ -299,14 +393,26 @@ async fn produce_test_events(kafka_broker: &str) -> Result<(), Box<dyn std::erro
         vote: hermes_schema::pb::governance::ProposalVoteOption::VoteOptionYes as i32,
         meta: Some(make_meta(12348, 1700003000)),
     };
-    send_event(&producer, "PROPOSAL_VOTED", &msg.encode_to_vec(), "3e-voted").await?;
+    send_event(
+        &producer,
+        "PROPOSAL_VOTED",
+        &msg.encode_to_vec(),
+        "3e-voted",
+    )
+    .await?;
 
     let msg = hermes_schema::pb::governance::HermesProposalExecuted {
         space_id: SPACE_3E_BYTES.to_vec(),
         proposal_id: PROP_3E_EXECUTED_BYTES.to_vec(),
         meta: Some(make_meta(12346, 1700001000)),
     };
-    send_event(&producer, "PROPOSAL_EXECUTED", &msg.encode_to_vec(), "3e-executed").await?;
+    send_event(
+        &producer,
+        "PROPOSAL_EXECUTED",
+        &msg.encode_to_vec(),
+        "3e-executed",
+    )
+    .await?;
 
     let msg = hermes_schema::pb::governance::HermesProposalSettingsUpdated {
         space_id: SPACE_3E_BYTES.to_vec(),
@@ -321,7 +427,13 @@ async fn produce_test_events(kafka_broker: &str) -> Result<(), Box<dyn std::erro
         }),
         meta: Some(make_meta(12349, 1700004000)),
     };
-    send_event(&producer, "PROPOSAL_SETTINGS_UPDATED", &msg.encode_to_vec(), "3e-settings").await?;
+    send_event(
+        &producer,
+        "PROPOSAL_SETTINGS_UPDATED",
+        &msg.encode_to_vec(),
+        "3e-settings",
+    )
+    .await?;
 
     // === 1-editor space: PROPOSAL_CREATED only ===
 
@@ -334,7 +446,13 @@ async fn produce_test_events(kafka_broker: &str) -> Result<(), Box<dyn std::erro
         settings: Some(make_settings()),
         meta: Some(make_meta(20001, 1700010000)),
     };
-    send_event(&producer, "PROPOSAL_CREATED", &msg.encode_to_vec(), "1e-created").await?;
+    send_event(
+        &producer,
+        "PROPOSAL_CREATED",
+        &msg.encode_to_vec(),
+        "1e-created",
+    )
+    .await?;
 
     // === 0-editor space: PROPOSAL_CREATED only (expect zero calls) ===
 
@@ -347,9 +465,151 @@ async fn produce_test_events(kafka_broker: &str) -> Result<(), Box<dyn std::erro
         settings: Some(make_settings()),
         meta: Some(make_meta(30001, 1700020000)),
     };
-    send_event(&producer, "PROPOSAL_CREATED", &msg.encode_to_vec(), "0e-created").await?;
+    send_event(
+        &producer,
+        "PROPOSAL_CREATED",
+        &msg.encode_to_vec(),
+        "0e-created",
+    )
+    .await?;
+
+    // === Bounty events via knowledge.edits topic ===
+
+    let ke_topic = {
+        let prefix = hermes_kafka::get_topic_prefix();
+        format!("{}{}", prefix, KNOWLEDGE_EDITS_TOPIC)
+    };
+
+    // Interest: curator (in their personal space) → bounty entity
+    let interest_edit = make_bounty_hermes_edit(
+        INTEREST_RELATION_BYTES,
+        INTEREST_TYPE_BYTES,
+        CURATOR_ENTITY_BYTES,
+        BOUNTY_ENTITY_BYTES,
+        CURATOR_SPACE_BYTES,
+        None,
+        40001,
+        1700030000,
+        1,
+    );
+    let headers = rdkafka::message::OwnedHeaders::new();
+    producer
+        .send(
+            FutureRecord::to(&ke_topic)
+                .payload(&interest_edit.encode_to_vec())
+                .key("bounty-interest")
+                .headers(headers),
+            Duration::from_secs(10),
+        )
+        .await
+        .map_err(|(e, _)| e)?;
+
+    // Allocated: bounty entity → curator, in bounty space
+    let allocated_edit = make_bounty_hermes_edit(
+        ALLOCATED_RELATION_BYTES,
+        ALLOCATED_TYPE_BYTES,
+        BOUNTY_ENTITY_BYTES,
+        CURATOR_ENTITY_BYTES,
+        BOUNTY_SPACE_BYTES,
+        Some(CURATOR_SPACE_BYTES),
+        40002,
+        1700031000,
+        2,
+    );
+    let headers = rdkafka::message::OwnedHeaders::new();
+    producer
+        .send(
+            FutureRecord::to(&ke_topic)
+                .payload(&allocated_edit.encode_to_vec())
+                .key("bounty-allocated")
+                .headers(headers),
+            Duration::from_secs(10),
+        )
+        .await
+        .map_err(|(e, _)| e)?;
+
+    // Payout: bounty space → curator space
+    let payout_edit = make_bounty_hermes_edit(
+        PAYOUT_RELATION_BYTES,
+        PAYOUT_TYPE_BYTES,
+        BOUNTY_ENTITY_BYTES,
+        CURATOR_ENTITY_BYTES,
+        BOUNTY_SPACE_BYTES,
+        Some(CURATOR_SPACE_BYTES),
+        40003,
+        1700032000,
+        3,
+    );
+    let headers = rdkafka::message::OwnedHeaders::new();
+    producer
+        .send(
+            FutureRecord::to(&ke_topic)
+                .payload(&payout_edit.encode_to_vec())
+                .key("bounty-payout")
+                .headers(headers),
+            Duration::from_secs(10),
+        )
+        .await
+        .map_err(|(e, _)| e)?;
 
     Ok(())
+}
+
+/// Build a HermesEdit protobuf containing a single CreateRelation op.
+#[allow(clippy::too_many_arguments)]
+fn make_bounty_hermes_edit(
+    relation_id: [u8; 16],
+    relation_type: [u8; 16],
+    from: [u8; 16],
+    to: [u8; 16],
+    space_id: [u8; 16],
+    to_space: Option<[u8; 16]>,
+    block_number: u64,
+    created_at: u64,
+    sequence: u32,
+) -> hermes_schema::pb::knowledge::HermesEdit {
+    use std::borrow::Cow;
+
+    let edit = grc_20::Edit {
+        id: relation_id, // reuse relation_id as edit id for simplicity
+        name: Cow::Borrowed("bounty edit"),
+        authors: vec![from],
+        created_at: created_at as i64,
+        ops: vec![grc_20::Op::CreateRelation(grc_20::CreateRelation {
+            id: relation_id,
+            relation_type,
+            from,
+            from_is_value_ref: false,
+            to,
+            to_is_value_ref: false,
+            from_space: None,
+            from_version: None,
+            to_space,
+            to_version: None,
+            entity: None,
+            position: None,
+            context: None,
+        })],
+    };
+    let payload = grc_20::encode_edit(&edit).expect("GRC-20 encode should succeed");
+
+    hermes_schema::pb::knowledge::HermesEdit {
+        id: relation_id.to_vec(),
+        name: "bounty edit".into(),
+        payload,
+        authors: vec![from.to_vec()],
+        language: None,
+        space_id: space_id.to_vec(),
+        is_canonical: true,
+        meta: Some(hermes_schema::pb::blockchain_metadata::BlockchainMetadata {
+            created_at,
+            created_by: vec![],
+            block_number,
+            cursor: String::new(),
+            sequence,
+            is_last: false,
+        }),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -363,7 +623,10 @@ struct TestResults {
 
 impl TestResults {
     fn new() -> Self {
-        Self { passed: 0, failed: 0 }
+        Self {
+            passed: 0,
+            failed: 0,
+        }
     }
 
     fn check(&mut self, name: &str, ok: bool) {
@@ -405,10 +668,7 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
         .iter()
         .filter(|c| c.body["space_id"].as_str() == Some(space_0e.as_str()))
         .collect();
-    r.check(
-        "0-editor space: zero webhook calls",
-        calls_0e.is_empty(),
-    );
+    r.check("0-editor space: zero webhook calls", calls_0e.is_empty());
 
     // ===================================================================
     // 1-editor space: 1 event × 1 editor × 3 webhooks = 3 calls
@@ -489,9 +749,16 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
     // ===================================================================
     // Every call has user_space_id and it's a known editor
     // ===================================================================
+    let bounty_editor_1 = Uuid::from_bytes(BOUNTY_EDITOR_1_BYTES).to_string();
+    let bounty_editor_2 = Uuid::from_bytes(BOUNTY_EDITOR_2_BYTES).to_string();
+    let curator_space = Uuid::from_bytes(CURATOR_SPACE_BYTES).to_string();
+
     let all_known: Vec<String> = editors_3e
         .iter()
         .chain(std::iter::once(&editor_solo))
+        .chain(std::iter::once(&bounty_editor_1))
+        .chain(std::iter::once(&bounty_editor_2))
+        .chain(std::iter::once(&curator_space))
         .cloned()
         .collect();
 
@@ -510,22 +777,46 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
     // ===================================================================
     // No unexpected event types
     // ===================================================================
-    let known_types: std::collections::HashSet<&str> =
-        ALL_EVENT_TYPES.iter().copied().collect();
+    let known_types: std::collections::HashSet<&str> = ALL_EVENT_TYPES.iter().copied().collect();
     r.check(
         "no unexpected event types",
-        calls
-            .iter()
-            .all(|c| c.body["event_type"].as_str().map_or(false, |t| known_types.contains(t))),
+        calls.iter().all(|c| {
+            c.body["event_type"]
+                .as_str()
+                .map_or(false, |t| known_types.contains(t))
+        }),
     );
 
     // ===================================================================
     // HMAC signatures (spot-check one per event type)
     // ===================================================================
-    for et in ALL_EVENT_TYPES {
-        if let Some(call) = calls_3e.iter().find(|c| c.body["event_type"].as_str() == Some(et)) {
+    // Governance HMAC spot-checks
+    for et in &[
+        "proposal_created",
+        "proposal_updated",
+        "proposal_voted",
+        "proposal_executed",
+        "proposal_settings_updated",
+        "proposal_rejected",
+    ] {
+        if let Some(call) = calls_3e
+            .iter()
+            .find(|c| c.body["event_type"].as_str() == Some(et))
+        {
             r.check(
                 &format!("3e {}: valid HMAC", et),
+                verify_hmac(webhook_secret, &call.raw_body, &call.signature),
+            );
+        }
+    }
+    // Bounty HMAC spot-checks
+    for et in &["bounty_interest", "bounty_allocated", "bounty_payout"] {
+        if let Some(call) = calls
+            .iter()
+            .find(|c| c.body["event_type"].as_str() == Some(et))
+        {
+            r.check(
+                &format!("bounty {}: valid HMAC", et),
                 verify_hmac(webhook_secret, &call.raw_body, &call.signature),
             );
         }
@@ -549,19 +840,17 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
     // Each unique (event_type, user_space_id) pair should have a unique key.
     // Multiple webhooks receive the same key for the same user — that's correct.
     // So the number of distinct keys should equal events × users, not total calls.
-    r.check(
-        "idempotency keys are unique per (event, user) pair",
-        {
-            let keys: std::collections::HashSet<&str> = calls
-                .iter()
-                .map(|c| c.idempotency_key.as_str())
-                .collect();
-            // 3-editor space: 6 events × 3 editors = 18 distinct keys
-            // 1-editor space: 1 event × 1 editor = 1 distinct key
-            // Total: 19
-            keys.len() == 19
-        },
-    );
+    r.check("idempotency keys are unique per (event, user) pair", {
+        let keys: std::collections::HashSet<&str> =
+            calls.iter().map(|c| c.idempotency_key.as_str()).collect();
+        // 3-editor space: 6 events × 3 editors = 18 distinct keys
+        // 1-editor space: 1 event × 1 editor = 1 distinct key
+        // Bounty interest: 1 event × 2 editors = 2 distinct keys
+        // Bounty allocated: 1 event × 1 curator = 1 distinct key
+        // Bounty payout: 1 event × 1 curator = 1 distinct key
+        // Total: 23
+        keys.len() == 23
+    });
 
     // ===================================================================
     // Comprehensive per-event-type payload validation
@@ -571,7 +860,12 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
     let voter = Uuid::from_bytes(VOTER_ID_BYTES).to_string();
 
     // Helper: validate common fields present on every notification
-    let check_common = |r: &mut TestResults, prefix: &str, call: &WebhookCall, expected_space: &str, expected_block: Option<u64>, expected_ts: Option<u64>| {
+    let check_common = |r: &mut TestResults,
+                        prefix: &str,
+                        call: &WebhookCall,
+                        expected_space: &str,
+                        expected_block: Option<u64>,
+                        expected_ts: Option<u64>| {
         r.check(
             &format!("{}: has version 1", prefix),
             call.body["version"].as_u64() == Some(1),
@@ -612,100 +906,303 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
     };
 
     // --- proposal_created ---
-    if let Some(call) = calls_3e.iter().find(|c| c.body["event_type"].as_str() == Some("proposal_created")) {
+    if let Some(call) = calls_3e
+        .iter()
+        .find(|c| c.body["event_type"].as_str() == Some("proposal_created"))
+    {
         let prefix = "3e proposal_created";
         let pid = Uuid::from_bytes(PROP_3E_CREATED_BYTES).to_string();
-        check_common(&mut r, prefix, call, &space_3e, Some(12345), Some(1700000000));
-        r.check(&format!("{}: correct proposal_id", prefix), call.body["proposal_id"].as_str() == Some(pid.as_str()));
-        r.check(&format!("{}: has proposer_id", prefix), call.body["proposer_id"].as_str() == Some(proposer.as_str()));
-        r.check(&format!("{}: voting_mode is 'fast'", prefix), call.body["voting_mode"].as_str() == Some("fast"));
-        r.check(&format!("{}: has actions array", prefix), call.body["actions"].is_array());
-        r.check(&format!("{}: has settings object", prefix), call.body["settings"].is_object());
+        check_common(
+            &mut r,
+            prefix,
+            call,
+            &space_3e,
+            Some(12345),
+            Some(1700000000),
+        );
+        r.check(
+            &format!("{}: correct proposal_id", prefix),
+            call.body["proposal_id"].as_str() == Some(pid.as_str()),
+        );
+        r.check(
+            &format!("{}: has proposer_id", prefix),
+            call.body["proposer_id"].as_str() == Some(proposer.as_str()),
+        );
+        r.check(
+            &format!("{}: voting_mode is 'fast'", prefix),
+            call.body["voting_mode"].as_str() == Some("fast"),
+        );
+        r.check(
+            &format!("{}: has actions array", prefix),
+            call.body["actions"].is_array(),
+        );
+        r.check(
+            &format!("{}: has settings object", prefix),
+            call.body["settings"].is_object(),
+        );
         if call.body["settings"].is_object() {
-            r.check(&format!("{}: settings.start_date", prefix), call.body["settings"]["start_date"].as_u64() == Some(1700000000));
-            r.check(&format!("{}: settings.end_date", prefix), call.body["settings"]["end_date"].as_u64() == Some(1700086400));
-            r.check(&format!("{}: settings.voting_mode", prefix), call.body["settings"]["voting_mode"].as_str() == Some("fast"));
-            r.check(&format!("{}: settings.quorum", prefix), call.body["settings"]["quorum"].as_u64() == Some(1));
+            r.check(
+                &format!("{}: settings.start_date", prefix),
+                call.body["settings"]["start_date"].as_u64() == Some(1700000000),
+            );
+            r.check(
+                &format!("{}: settings.end_date", prefix),
+                call.body["settings"]["end_date"].as_u64() == Some(1700086400),
+            );
+            r.check(
+                &format!("{}: settings.voting_mode", prefix),
+                call.body["settings"]["voting_mode"].as_str() == Some("fast"),
+            );
+            r.check(
+                &format!("{}: settings.quorum", prefix),
+                call.body["settings"]["quorum"].as_u64() == Some(1),
+            );
         }
-        r.check(&format!("{}: no voter_id", prefix), call.body.get("voter_id").is_none());
-        r.check(&format!("{}: no vote", prefix), call.body.get("vote").is_none());
+        r.check(
+            &format!("{}: no voter_id", prefix),
+            call.body.get("voter_id").is_none(),
+        );
+        r.check(
+            &format!("{}: no vote", prefix),
+            call.body.get("vote").is_none(),
+        );
     }
 
     // --- proposal_updated ---
-    if let Some(call) = calls_3e.iter().find(|c| c.body["event_type"].as_str() == Some("proposal_updated")) {
+    if let Some(call) = calls_3e
+        .iter()
+        .find(|c| c.body["event_type"].as_str() == Some("proposal_updated"))
+    {
         let prefix = "3e proposal_updated";
         let pid = Uuid::from_bytes(PROP_3E_UPDATED_BYTES).to_string();
-        check_common(&mut r, prefix, call, &space_3e, Some(12347), Some(1700002000));
-        r.check(&format!("{}: correct proposal_id", prefix), call.body["proposal_id"].as_str() == Some(pid.as_str()));
-        r.check(&format!("{}: has proposer_id", prefix), call.body["proposer_id"].as_str() == Some(proposer.as_str()));
-        r.check(&format!("{}: voting_mode is 'fast'", prefix), call.body["voting_mode"].as_str() == Some("fast"));
-        r.check(&format!("{}: has actions array", prefix), call.body["actions"].is_array());
-        r.check(&format!("{}: has settings object", prefix), call.body["settings"].is_object());
-        r.check(&format!("{}: no voter_id", prefix), call.body.get("voter_id").is_none());
-        r.check(&format!("{}: no vote", prefix), call.body.get("vote").is_none());
+        check_common(
+            &mut r,
+            prefix,
+            call,
+            &space_3e,
+            Some(12347),
+            Some(1700002000),
+        );
+        r.check(
+            &format!("{}: correct proposal_id", prefix),
+            call.body["proposal_id"].as_str() == Some(pid.as_str()),
+        );
+        r.check(
+            &format!("{}: has proposer_id", prefix),
+            call.body["proposer_id"].as_str() == Some(proposer.as_str()),
+        );
+        r.check(
+            &format!("{}: voting_mode is 'fast'", prefix),
+            call.body["voting_mode"].as_str() == Some("fast"),
+        );
+        r.check(
+            &format!("{}: has actions array", prefix),
+            call.body["actions"].is_array(),
+        );
+        r.check(
+            &format!("{}: has settings object", prefix),
+            call.body["settings"].is_object(),
+        );
+        r.check(
+            &format!("{}: no voter_id", prefix),
+            call.body.get("voter_id").is_none(),
+        );
+        r.check(
+            &format!("{}: no vote", prefix),
+            call.body.get("vote").is_none(),
+        );
     }
 
     // --- proposal_voted ---
-    if let Some(call) = calls_3e.iter().find(|c| c.body["event_type"].as_str() == Some("proposal_voted")) {
+    if let Some(call) = calls_3e
+        .iter()
+        .find(|c| c.body["event_type"].as_str() == Some("proposal_voted"))
+    {
         let prefix = "3e proposal_voted";
         let pid = Uuid::from_bytes(PROP_3E_VOTED_BYTES).to_string();
-        check_common(&mut r, prefix, call, &space_3e, Some(12348), Some(1700003000));
-        r.check(&format!("{}: correct proposal_id", prefix), call.body["proposal_id"].as_str() == Some(pid.as_str()));
-        r.check(&format!("{}: correct voter_id", prefix), call.body["voter_id"].as_str() == Some(voter.as_str()));
-        r.check(&format!("{}: vote is 'yes'", prefix), call.body["vote"].as_str() == Some("yes"));
-        r.check(&format!("{}: no proposer_id", prefix), call.body.get("proposer_id").is_none());
-        r.check(&format!("{}: no voting_mode", prefix), call.body.get("voting_mode").is_none());
-        r.check(&format!("{}: no actions", prefix), call.body.get("actions").is_none());
-        r.check(&format!("{}: no settings", prefix), call.body.get("settings").is_none());
+        check_common(
+            &mut r,
+            prefix,
+            call,
+            &space_3e,
+            Some(12348),
+            Some(1700003000),
+        );
+        r.check(
+            &format!("{}: correct proposal_id", prefix),
+            call.body["proposal_id"].as_str() == Some(pid.as_str()),
+        );
+        r.check(
+            &format!("{}: correct voter_id", prefix),
+            call.body["voter_id"].as_str() == Some(voter.as_str()),
+        );
+        r.check(
+            &format!("{}: vote is 'yes'", prefix),
+            call.body["vote"].as_str() == Some("yes"),
+        );
+        r.check(
+            &format!("{}: no proposer_id", prefix),
+            call.body.get("proposer_id").is_none(),
+        );
+        r.check(
+            &format!("{}: no voting_mode", prefix),
+            call.body.get("voting_mode").is_none(),
+        );
+        r.check(
+            &format!("{}: no actions", prefix),
+            call.body.get("actions").is_none(),
+        );
+        r.check(
+            &format!("{}: no settings", prefix),
+            call.body.get("settings").is_none(),
+        );
     }
 
     // --- proposal_executed ---
-    if let Some(call) = calls_3e.iter().find(|c| c.body["event_type"].as_str() == Some("proposal_executed")) {
+    if let Some(call) = calls_3e
+        .iter()
+        .find(|c| c.body["event_type"].as_str() == Some("proposal_executed"))
+    {
         let prefix = "3e proposal_executed";
         let pid = Uuid::from_bytes(PROP_3E_EXECUTED_BYTES).to_string();
-        check_common(&mut r, prefix, call, &space_3e, Some(12346), Some(1700001000));
-        r.check(&format!("{}: correct proposal_id", prefix), call.body["proposal_id"].as_str() == Some(pid.as_str()));
-        r.check(&format!("{}: no proposer_id", prefix), call.body.get("proposer_id").is_none());
-        r.check(&format!("{}: no voter_id", prefix), call.body.get("voter_id").is_none());
-        r.check(&format!("{}: no vote", prefix), call.body.get("vote").is_none());
-        r.check(&format!("{}: no voting_mode", prefix), call.body.get("voting_mode").is_none());
-        r.check(&format!("{}: no actions", prefix), call.body.get("actions").is_none());
-        r.check(&format!("{}: no settings", prefix), call.body.get("settings").is_none());
+        check_common(
+            &mut r,
+            prefix,
+            call,
+            &space_3e,
+            Some(12346),
+            Some(1700001000),
+        );
+        r.check(
+            &format!("{}: correct proposal_id", prefix),
+            call.body["proposal_id"].as_str() == Some(pid.as_str()),
+        );
+        r.check(
+            &format!("{}: no proposer_id", prefix),
+            call.body.get("proposer_id").is_none(),
+        );
+        r.check(
+            &format!("{}: no voter_id", prefix),
+            call.body.get("voter_id").is_none(),
+        );
+        r.check(
+            &format!("{}: no vote", prefix),
+            call.body.get("vote").is_none(),
+        );
+        r.check(
+            &format!("{}: no voting_mode", prefix),
+            call.body.get("voting_mode").is_none(),
+        );
+        r.check(
+            &format!("{}: no actions", prefix),
+            call.body.get("actions").is_none(),
+        );
+        r.check(
+            &format!("{}: no settings", prefix),
+            call.body.get("settings").is_none(),
+        );
     }
 
     // --- proposal_settings_updated ---
-    if let Some(call) = calls_3e.iter().find(|c| c.body["event_type"].as_str() == Some("proposal_settings_updated")) {
+    if let Some(call) = calls_3e
+        .iter()
+        .find(|c| c.body["event_type"].as_str() == Some("proposal_settings_updated"))
+    {
         let prefix = "3e proposal_settings_updated";
         let pid = Uuid::from_bytes(PROP_3E_SETTINGS_BYTES).to_string();
-        check_common(&mut r, prefix, call, &space_3e, Some(12349), Some(1700004000));
-        r.check(&format!("{}: correct proposal_id", prefix), call.body["proposal_id"].as_str() == Some(pid.as_str()));
-        r.check(&format!("{}: voting_mode is 'slow'", prefix), call.body["voting_mode"].as_str() == Some("slow"));
-        r.check(&format!("{}: has settings object", prefix), call.body["settings"].is_object());
+        check_common(
+            &mut r,
+            prefix,
+            call,
+            &space_3e,
+            Some(12349),
+            Some(1700004000),
+        );
+        r.check(
+            &format!("{}: correct proposal_id", prefix),
+            call.body["proposal_id"].as_str() == Some(pid.as_str()),
+        );
+        r.check(
+            &format!("{}: voting_mode is 'slow'", prefix),
+            call.body["voting_mode"].as_str() == Some("slow"),
+        );
+        r.check(
+            &format!("{}: has settings object", prefix),
+            call.body["settings"].is_object(),
+        );
         if call.body["settings"].is_object() {
-            r.check(&format!("{}: settings.end_date", prefix), call.body["settings"]["end_date"].as_u64() == Some(1700172800));
-            r.check(&format!("{}: settings.voting_mode 'slow'", prefix), call.body["settings"]["voting_mode"].as_str() == Some("slow"));
-            r.check(&format!("{}: settings.quorum 5", prefix), call.body["settings"]["quorum"].as_u64() == Some(5));
-            r.check(&format!("{}: settings.percentage_threshold 5000000", prefix), call.body["settings"]["percentage_threshold"].as_u64() == Some(5000000));
+            r.check(
+                &format!("{}: settings.end_date", prefix),
+                call.body["settings"]["end_date"].as_u64() == Some(1700172800),
+            );
+            r.check(
+                &format!("{}: settings.voting_mode 'slow'", prefix),
+                call.body["settings"]["voting_mode"].as_str() == Some("slow"),
+            );
+            r.check(
+                &format!("{}: settings.quorum 5", prefix),
+                call.body["settings"]["quorum"].as_u64() == Some(5),
+            );
+            r.check(
+                &format!("{}: settings.percentage_threshold 5000000", prefix),
+                call.body["settings"]["percentage_threshold"].as_u64() == Some(5000000),
+            );
         }
-        r.check(&format!("{}: no proposer_id", prefix), call.body.get("proposer_id").is_none());
-        r.check(&format!("{}: no voter_id", prefix), call.body.get("voter_id").is_none());
-        r.check(&format!("{}: no actions", prefix), call.body.get("actions").is_none());
+        r.check(
+            &format!("{}: no proposer_id", prefix),
+            call.body.get("proposer_id").is_none(),
+        );
+        r.check(
+            &format!("{}: no voter_id", prefix),
+            call.body.get("voter_id").is_none(),
+        );
+        r.check(
+            &format!("{}: no actions", prefix),
+            call.body.get("actions").is_none(),
+        );
     }
 
     // --- proposal_rejected ---
-    if let Some(call) = calls_3e.iter().find(|c| c.body["event_type"].as_str() == Some("proposal_rejected")) {
+    if let Some(call) = calls_3e
+        .iter()
+        .find(|c| c.body["event_type"].as_str() == Some("proposal_rejected"))
+    {
         let prefix = "3e proposal_rejected";
         let pid = Uuid::from_bytes(PROP_3E_REJECTED_BYTES).to_string();
         let proposed_by = Uuid::from_bytes(PROPOSER_ID_BYTES).to_string();
         check_common(&mut r, prefix, call, &space_3e, None, None);
-        r.check(&format!("{}: correct proposal_id", prefix), call.body["proposal_id"].as_str() == Some(pid.as_str()));
-        r.check(&format!("{}: has proposer_id", prefix), call.body["proposer_id"].as_str() == Some(proposed_by.as_str()));
-        r.check(&format!("{}: has timestamp", prefix), call.body["timestamp"].is_number());
-        r.check(&format!("{}: no voter_id", prefix), call.body.get("voter_id").is_none());
-        r.check(&format!("{}: no vote", prefix), call.body.get("vote").is_none());
-        r.check(&format!("{}: no voting_mode", prefix), call.body.get("voting_mode").is_none());
-        r.check(&format!("{}: no actions", prefix), call.body.get("actions").is_none());
-        r.check(&format!("{}: no settings", prefix), call.body.get("settings").is_none());
+        r.check(
+            &format!("{}: correct proposal_id", prefix),
+            call.body["proposal_id"].as_str() == Some(pid.as_str()),
+        );
+        r.check(
+            &format!("{}: has proposer_id", prefix),
+            call.body["proposer_id"].as_str() == Some(proposed_by.as_str()),
+        );
+        r.check(
+            &format!("{}: has timestamp", prefix),
+            call.body["timestamp"].is_number(),
+        );
+        r.check(
+            &format!("{}: no voter_id", prefix),
+            call.body.get("voter_id").is_none(),
+        );
+        r.check(
+            &format!("{}: no vote", prefix),
+            call.body.get("vote").is_none(),
+        );
+        r.check(
+            &format!("{}: no voting_mode", prefix),
+            call.body.get("voting_mode").is_none(),
+        );
+        r.check(
+            &format!("{}: no actions", prefix),
+            call.body.get("actions").is_none(),
+        );
+        r.check(
+            &format!("{}: no settings", prefix),
+            call.body.get("settings").is_none(),
+        );
     }
 
     // --- 1-editor space: proposal_created ---
@@ -715,9 +1212,22 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
     }) {
         let prefix = "1e proposal_created";
         let pid = Uuid::from_bytes(PROP_1E_CREATED_BYTES).to_string();
-        check_common(&mut r, prefix, call, &space_1e, Some(20001), Some(1700010000));
-        r.check(&format!("{}: correct proposal_id", prefix), call.body["proposal_id"].as_str() == Some(pid.as_str()));
-        r.check(&format!("{}: correct user_space_id", prefix), call.body["user_space_id"].as_str() == Some(editor_solo.as_str()));
+        check_common(
+            &mut r,
+            prefix,
+            call,
+            &space_1e,
+            Some(20001),
+            Some(1700010000),
+        );
+        r.check(
+            &format!("{}: correct proposal_id", prefix),
+            call.body["proposal_id"].as_str() == Some(pid.as_str()),
+        );
+        r.check(
+            &format!("{}: correct user_space_id", prefix),
+            call.body["user_space_id"].as_str() == Some(editor_solo.as_str()),
+        );
     }
 
     // ===================================================================
@@ -740,6 +1250,112 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
         }),
     );
 
+    // ===================================================================
+    // Bounty event verification
+    // ===================================================================
+
+    let bounty_space = Uuid::from_bytes(BOUNTY_SPACE_BYTES).to_string();
+    let bounty_entity = Uuid::from_bytes(BOUNTY_ENTITY_BYTES).to_string();
+    let interest_rel = Uuid::from_bytes(INTEREST_RELATION_BYTES).to_string();
+    let allocated_rel = Uuid::from_bytes(ALLOCATED_RELATION_BYTES).to_string();
+    let payout_rel = Uuid::from_bytes(PAYOUT_RELATION_BYTES).to_string();
+
+    // --- bounty_interest: 2 editors × 3 webhooks = 6 calls ---
+    let interest_calls: Vec<_> = calls
+        .iter()
+        .filter(|c| c.body["event_type"].as_str() == Some("bounty_interest"))
+        .collect();
+    r.check(
+        "bounty_interest: 6 calls (2 editors x 3 webhooks)",
+        interest_calls.len() == 6,
+    );
+    if let Some(call) = interest_calls.first() {
+        r.check(
+            "bounty_interest: category is 'bounty'",
+            call.body["category"].as_str() == Some("bounty"),
+        );
+        r.check(
+            "bounty_interest: correct bounty_entity_id",
+            call.body["bounty_entity_id"].as_str() == Some(bounty_entity.as_str()),
+        );
+        r.check(
+            "bounty_interest: correct relation_id",
+            call.body["relation_id"].as_str() == Some(interest_rel.as_str()),
+        );
+        r.check(
+            "bounty_interest: has bounty_space_id",
+            call.body["bounty_space_id"].as_str() == Some(bounty_space.as_str()),
+        );
+        r.check(
+            "bounty_interest: no governance fields",
+            call.body.get("proposal_id").is_none()
+                && call.body.get("voter_id").is_none()
+                && call.body.get("proposer_id").is_none(),
+        );
+    }
+    // Each bounty editor gets exactly 3 deliveries
+    for editor_str in [&bounty_editor_1, &bounty_editor_2] {
+        let n = interest_calls
+            .iter()
+            .filter(|c| c.body["user_space_id"].as_str() == Some(editor_str.as_str()))
+            .count();
+        r.check(
+            &format!(
+                "bounty_interest: editor {}.. got 3 deliveries",
+                &editor_str[..8]
+            ),
+            n == 3,
+        );
+    }
+
+    // --- bounty_allocated: 1 curator × 3 webhooks = 3 calls ---
+    let allocated_calls: Vec<_> = calls
+        .iter()
+        .filter(|c| c.body["event_type"].as_str() == Some("bounty_allocated"))
+        .collect();
+    r.check(
+        "bounty_allocated: 3 calls (1 curator x 3 webhooks)",
+        allocated_calls.len() == 3,
+    );
+    if let Some(call) = allocated_calls.first() {
+        r.check(
+            "bounty_allocated: category is 'bounty'",
+            call.body["category"].as_str() == Some("bounty"),
+        );
+        r.check(
+            "bounty_allocated: correct relation_id",
+            call.body["relation_id"].as_str() == Some(allocated_rel.as_str()),
+        );
+        r.check(
+            "bounty_allocated: curator is recipient",
+            call.body["user_space_id"].as_str() == Some(curator_space.as_str()),
+        );
+    }
+
+    // --- bounty_payout: 1 curator × 3 webhooks = 3 calls ---
+    let payout_calls: Vec<_> = calls
+        .iter()
+        .filter(|c| c.body["event_type"].as_str() == Some("bounty_payout"))
+        .collect();
+    r.check(
+        "bounty_payout: 3 calls (1 curator x 3 webhooks)",
+        payout_calls.len() == 3,
+    );
+    if let Some(call) = payout_calls.first() {
+        r.check(
+            "bounty_payout: category is 'bounty'",
+            call.body["category"].as_str() == Some("bounty"),
+        );
+        r.check(
+            "bounty_payout: correct relation_id",
+            call.body["relation_id"].as_str() == Some(payout_rel.as_str()),
+        );
+        r.check(
+            "bounty_payout: curator is recipient",
+            call.body["user_space_id"].as_str() == Some(curator_space.as_str()),
+        );
+    }
+
     r
 }
 
@@ -750,8 +1366,7 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
 #[tokio::main]
 async fn main() {
     let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
-    let kafka_broker =
-        env::var("KAFKA_BROKER").unwrap_or_else(|_| "localhost:9092".to_string());
+    let kafka_broker = env::var("KAFKA_BROKER").unwrap_or_else(|_| "localhost:9092".to_string());
     let webhook_port: u16 = env::var("WEBHOOK_PORT")
         .unwrap_or_else(|_| "8765".to_string())
         .parse()
@@ -803,7 +1418,7 @@ async fn main() {
     produce_test_events(&kafka_broker)
         .await
         .expect("Failed to produce Kafka events");
-    println!("[3/5] Kafka events produced (7 events across 3 spaces)");
+    println!("[3/5] Kafka events produced (7 governance + 3 bounty events)");
 
     // 4. Wait for webhook calls
     // We wait for EXPECTED_CALLS, plus an extra grace period to catch false positives.
@@ -827,12 +1442,7 @@ async fn main() {
             let mut counts: HashMap<String, usize> = HashMap::new();
             for c in &calls {
                 *counts
-                    .entry(
-                        c.body["event_type"]
-                            .as_str()
-                            .unwrap_or("?")
-                            .to_string(),
-                    )
+                    .entry(c.body["event_type"].as_str().unwrap_or("?").to_string())
                     .or_default() += 1;
             }
             for (et, n) in &counts {

--- a/notification-service/notification-indexer/src/consumer.rs
+++ b/notification-service/notification-indexer/src/consumer.rs
@@ -1,4 +1,4 @@
-//! Kafka consumer for the space.governance topic.
+//! Kafka consumers for the space.governance and knowledge.edits topics.
 
 use hermes_kafka::get_topic_prefix;
 use prost::Message;
@@ -15,6 +15,9 @@ use crate::error::IndexerError;
 
 /// Base topic for governance events
 const GOVERNANCE_TOPIC: &str = "space.governance";
+
+/// Base topic for knowledge edit events
+const KNOWLEDGE_EDITS_TOPIC: &str = "knowledge.edits";
 
 /// Kafka consumer for governance events.
 pub struct KafkaConsumer {
@@ -169,4 +172,115 @@ pub fn parse_proposal_settings_updated(
 ) -> Result<hermes_schema::pb::governance::HermesProposalSettingsUpdated, IndexerError> {
     let msg = hermes_schema::pb::governance::HermesProposalSettingsUpdated::decode(payload)?;
     Ok(msg)
+}
+
+/// Parse a HermesEdit message from knowledge.edits Kafka payload.
+pub fn parse_hermes_edit(
+    payload: &[u8],
+) -> Result<hermes_schema::pb::knowledge::HermesEdit, IndexerError> {
+    let msg = hermes_schema::pb::knowledge::HermesEdit::decode(payload)?;
+    Ok(msg)
+}
+
+/// Kafka consumer for knowledge edit events.
+///
+/// Follows the same manual-commit pattern as `KafkaConsumer` but subscribes
+/// to the `knowledge.edits` topic.
+pub struct KnowledgeEditsConsumer {
+    consumer: StreamConsumer<DefaultConsumerContext>,
+    topic: String,
+}
+
+impl KnowledgeEditsConsumer {
+    /// Create a new knowledge edits consumer.
+    ///
+    /// Uses a separate consumer group suffix (`-knowledge-edits`) to avoid
+    /// conflicting with the governance consumer's offsets.
+    pub fn new(brokers: &str, group_id: &str) -> Result<Self, IndexerError> {
+        let ke_group_id = format!("{}-knowledge-edits", group_id);
+
+        let mut config = ClientConfig::new();
+        config
+            .set("bootstrap.servers", brokers)
+            .set("group.id", &ke_group_id)
+            .set("enable.auto.commit", "false")
+            .set("auto.offset.reset", "earliest")
+            .set("session.timeout.ms", "6000")
+            .set("fetch.max.bytes", "52428800")
+            .set("max.partition.fetch.bytes", "1048576")
+            .set("message.max.bytes", "10485760")
+            .set("max.poll.interval.ms", "300000");
+
+        // Optional SASL/SSL configuration
+        if let Ok(username) = env::var("KAFKA_USERNAME") {
+            config.set("security.protocol", "SASL_SSL");
+            config.set("sasl.mechanisms", "PLAIN");
+            config.set("sasl.username", &username);
+
+            let password = env::var("KAFKA_PASSWORD").map_err(|_| {
+                IndexerError::Config(
+                    "KAFKA_PASSWORD must be set when KAFKA_USERNAME is configured".into(),
+                )
+            })?;
+            config.set("sasl.password", &password);
+        }
+
+        // Optional custom CA certificate
+        if let Ok(ca_pem) = env::var("KAFKA_SSL_CA_PEM") {
+            config.set("ssl.ca.pem", &ca_pem);
+        }
+
+        let consumer: StreamConsumer = config.create()?;
+
+        let prefix = get_topic_prefix();
+        let topic = format!("{}{}", prefix, KNOWLEDGE_EDITS_TOPIC);
+
+        info!(
+            brokers = %brokers,
+            group_id = %ke_group_id,
+            topic = %topic,
+            "Created knowledge edits consumer"
+        );
+
+        Ok(Self { consumer, topic })
+    }
+
+    /// Subscribe to the knowledge.edits topic.
+    pub fn subscribe(&self) -> Result<(), IndexerError> {
+        self.consumer.subscribe(&[&self.topic])?;
+        info!(topic = %self.topic, "Subscribed to knowledge.edits topic");
+        Ok(())
+    }
+
+    /// Get a message stream from the consumer.
+    pub fn stream(&self) -> rdkafka::consumer::MessageStream<'_, DefaultConsumerContext> {
+        self.consumer.stream()
+    }
+
+    /// Commit a message offset.
+    pub fn commit_message(
+        &self,
+        topic: &str,
+        partition: i32,
+        offset: i64,
+    ) -> Result<(), IndexerError> {
+        let mut tpl = TopicPartitionList::new();
+        tpl.add_partition_offset(topic, partition, rdkafka::Offset::Offset(offset + 1))?;
+
+        self.consumer
+            .commit(&tpl, rdkafka::consumer::CommitMode::Async)?;
+
+        debug!(topic = %topic, partition = partition, offset = offset, "Committed knowledge edits offset");
+        Ok(())
+    }
+
+    /// Flush any pending async offset commits synchronously.
+    pub fn flush_commits(&self) {
+        if let Err(e) = self
+            .consumer
+            .commit_consumer_state(rdkafka::consumer::CommitMode::Sync)
+        {
+            error!(error = %e, "Failed to flush knowledge edits commits during shutdown");
+        }
+    }
 }

--- a/notification-service/notification-indexer/src/main.rs
+++ b/notification-service/notification-indexer/src/main.rs
@@ -16,14 +16,17 @@ use rdkafka::message::Message;
 use rdkafka::Timestamp;
 
 use notification_indexer::consumer::{
-    get_event_type, parse_proposal_created, parse_proposal_executed,
+    get_event_type, parse_hermes_edit, parse_proposal_created, parse_proposal_executed,
     parse_proposal_settings_updated, parse_proposal_updated, parse_proposal_voted, KafkaConsumer,
+    KnowledgeEditsConsumer,
 };
 use notification_indexer::consumer_lag::LagMonitor;
 use notification_indexer::error::IndexerError;
 use notification_indexer::models::{
-    build_rejection_event, handle_proposal_created, handle_proposal_executed,
-    handle_proposal_settings_updated, handle_proposal_updated, handle_proposal_voted,
+    build_rejection_event, extract_bounty_relations, handle_bounty_allocated,
+    handle_bounty_interest, handle_bounty_payout, handle_proposal_created,
+    handle_proposal_executed, handle_proposal_settings_updated, handle_proposal_updated,
+    handle_proposal_voted, BountyConfig, NotificationEventType,
 };
 use notification_indexer::storage::Storage;
 
@@ -162,9 +165,27 @@ async fn async_main() -> Result<(), IndexerError> {
         }
     };
 
+    // Knowledge edits consumer (optional, default disabled)
+    let knowledge_edits_enabled = env::var("KNOWLEDGE_EDITS_ENABLED")
+        .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
+        .unwrap_or(false);
+
+    if !knowledge_edits_enabled {
+        info!("Knowledge edits consumer disabled (set KNOWLEDGE_EDITS_ENABLED=true to enable)");
+    }
+
+    let bounty_config = BountyConfig::new();
+    info!(
+        interest = %bounty_config.interest_type_id,
+        allocated = %bounty_config.allocated_type_id,
+        payout = %bounty_config.payout_type_id,
+        "Bounty relation type config"
+    );
+
     // Set up shutdown signal
     let (shutdown_tx, mut shutdown_rx) = tokio::sync::broadcast::channel::<()>(1);
     let mut shutdown_rx2 = shutdown_tx.subscribe();
+    let mut shutdown_rx3 = shutdown_tx.subscribe();
 
     let _signal_handle = tokio::spawn(async move {
         tokio::signal::ctrl_c().await.ok();
@@ -252,6 +273,294 @@ async fn async_main() -> Result<(), IndexerError> {
             }
         }
     });
+
+    // Spawn knowledge edits consumer task (if enabled)
+    let ke_handle: Option<tokio::task::JoinHandle<()>> = if knowledge_edits_enabled {
+        let ke_kafka_broker = kafka_broker.clone();
+        let ke_kafka_group_id = kafka_group_id.clone();
+        let ke_bd = block_delay;
+        let ke_bd_timeout = block_delay_timeout_secs;
+        let ke_min_age = min_age_secs;
+        let ke_stor = Storage::new(storage.pool().clone());
+        let ke_cfg = bounty_config;
+
+        Some(tokio::spawn(async move {
+            // Create consumer inside the task so it's fully owned
+            let kec = match KnowledgeEditsConsumer::new(&ke_kafka_broker, &ke_kafka_group_id) {
+                Ok(c) => c,
+                Err(e) => {
+                    error!(error = %e, "Failed to create knowledge edits consumer");
+                    return;
+                }
+            };
+            if let Err(e) = kec.subscribe() {
+                error!(error = %e, "Failed to subscribe to knowledge.edits");
+                return;
+            }
+
+            let mut ke_stream = kec.stream();
+            let mut ke_processed: u64 = 0;
+            let mut ke_errors: u64 = 0;
+
+            info!("Knowledge edits consumer loop started");
+
+            loop {
+                tokio::select! {
+                    _ = shutdown_rx3.recv() => {
+                        info!("Knowledge edits consumer shutting down");
+                        break;
+                    }
+                    message = ke_stream.next() => {
+                        match message {
+                            Some(Ok(msg)) => {
+                                let topic = msg.topic().to_string();
+                                let partition = msg.partition();
+                                let offset = msg.offset();
+
+                                // Skip old messages
+                                if ke_min_age > 0 {
+                                    let now_ms = SystemTime::now()
+                                        .duration_since(UNIX_EPOCH)
+                                        .map(|d| d.as_millis() as i64)
+                                        .unwrap_or(0);
+                                    let too_old = match msg.timestamp() {
+                                        Timestamp::CreateTime(ts) | Timestamp::LogAppendTime(ts) => {
+                                            (now_ms - ts) > (ke_min_age as i64 * 1000)
+                                        }
+                                        Timestamp::NotAvailable => false,
+                                    };
+                                    if too_old {
+                                        debug!(
+                                            partition = partition,
+                                            offset = offset,
+                                            "Skipping old knowledge edit (older than {}s)",
+                                            ke_min_age
+                                        );
+                                        if let Err(e) = kec.commit_message(&topic, partition, offset) {
+                                            error!(error = %e, "Failed to commit knowledge edits offset");
+                                        }
+                                        continue;
+                                    }
+                                }
+
+                                let Some(payload) = msg.payload() else {
+                                    if let Err(e) = kec.commit_message(&topic, partition, offset) {
+                                        error!(error = %e, "Failed to commit knowledge edits offset");
+                                    }
+                                    continue;
+                                };
+
+                                // Parse HermesEdit protobuf
+                                let hermes_edit = match parse_hermes_edit(payload) {
+                                    Ok(edit) => edit,
+                                    Err(e) => {
+                                        // Parse error — commit to avoid poison pill
+                                        warn!(
+                                            error = %e,
+                                            partition = partition,
+                                            offset = offset,
+                                            "Failed to parse HermesEdit, committing to skip"
+                                        );
+                                        ke_errors += 1;
+                                        if let Err(e) = kec.commit_message(&topic, partition, offset) {
+                                            error!(error = %e, "Failed to commit knowledge edits offset");
+                                        }
+                                        continue;
+                                    }
+                                };
+
+                                // Extract bounty relations from GRC-20 payload
+                                let relations = match extract_bounty_relations(&hermes_edit, &ke_cfg) {
+                                    Ok(rels) => rels,
+                                    Err(e) => {
+                                        // Decode error — commit to avoid poison pill
+                                        warn!(
+                                            error = %e,
+                                            partition = partition,
+                                            offset = offset,
+                                            "Failed to extract bounty relations, committing to skip"
+                                        );
+                                        ke_errors += 1;
+                                        if let Err(e) = kec.commit_message(&topic, partition, offset) {
+                                            error!(error = %e, "Failed to commit knowledge edits offset");
+                                        }
+                                        continue;
+                                    }
+                                };
+
+                                if relations.is_empty() {
+                                    // No bounty relations in this edit — commit and continue
+                                    if let Err(e) = kec.commit_message(&topic, partition, offset) {
+                                        error!(error = %e, "Failed to commit knowledge edits offset");
+                                    }
+                                    continue;
+                                }
+
+                                let mut all_ok = true;
+                                for (mut info, event_type) in relations {
+                                    // Block delay: wait for kg-indexer catchup
+                                    if ke_bd > 0 {
+                                        wait_for_kg_catchup(
+                                            &ke_stor,
+                                            info.block_number,
+                                            ke_bd,
+                                            ke_bd_timeout,
+                                        )
+                                        .await;
+                                    }
+
+                                    match event_type {
+                                        NotificationEventType::BountyInterest => {
+                                            // Resolve bounty_space_id from DB
+                                            match ke_stor.lookup_bounty_space(info.bounty_entity_id).await {
+                                                Ok(Some(space_id)) => {
+                                                    info.bounty_space_id = space_id;
+                                                }
+                                                Ok(None) => {
+                                                    warn!(
+                                                        bounty_entity_id = %info.bounty_entity_id,
+                                                        "Could not resolve bounty space, skipping interest notification"
+                                                    );
+                                                    continue;
+                                                }
+                                                Err(e) => {
+                                                    error!(error = %e, "DB error looking up bounty space, will retry");
+                                                    ke_errors += 1;
+                                                    all_ok = false;
+                                                    break;
+                                                }
+                                            }
+
+                                            let mut event = handle_bounty_interest(&info);
+                                            enrich_payload(&ke_stor, &mut event, info.bounty_space_id).await;
+
+                                            let editors = match ke_stor.find_editors_for_space(info.bounty_space_id).await {
+                                                Ok(eds) => eds,
+                                                Err(e) => {
+                                                    error!(error = %e, "DB error looking up editors for bounty interest, will retry");
+                                                    ke_errors += 1;
+                                                    all_ok = false;
+                                                    break;
+                                                }
+                                            };
+
+                                            if editors.is_empty() {
+                                                ke_processed += 1;
+                                                continue;
+                                            }
+
+                                            match ke_stor.insert_notifications_for_editors(&event, &editors).await {
+                                                Ok(count) => {
+                                                    if count > 0 {
+                                                        info!(
+                                                            event_type = "bounty_interest",
+                                                            editors = editors.len(),
+                                                            inserted = count,
+                                                            "Inserted bounty interest notifications"
+                                                        );
+                                                    }
+                                                    ke_processed += 1;
+                                                }
+                                                Err(e) => {
+                                                    error!(error = %e, "DB error inserting bounty interest notifications, will retry");
+                                                    ke_errors += 1;
+                                                    all_ok = false;
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                        NotificationEventType::BountyAllocated
+                                        | NotificationEventType::BountyPayout => {
+                                            // Resolve curator_space_id if nil
+                                            if info.curator_space_id.is_nil() {
+                                                match ke_stor.lookup_entity_space(info.bounty_entity_id).await {
+                                                    Ok(Some(space_id)) => {
+                                                        info.curator_space_id = space_id;
+                                                    }
+                                                    Ok(None) => {
+                                                        warn!(
+                                                            bounty_entity_id = %info.bounty_entity_id,
+                                                            event_type = %event_type.as_str(),
+                                                            "Could not resolve curator space, skipping notification"
+                                                        );
+                                                        continue;
+                                                    }
+                                                    Err(e) => {
+                                                        error!(error = %e, "DB error looking up curator space, will retry");
+                                                        ke_errors += 1;
+                                                        all_ok = false;
+                                                        break;
+                                                    }
+                                                }
+                                            }
+
+                                            let mut event = if event_type == NotificationEventType::BountyAllocated {
+                                                handle_bounty_allocated(&info)
+                                            } else {
+                                                handle_bounty_payout(&info)
+                                            };
+                                            enrich_payload(&ke_stor, &mut event, info.bounty_space_id).await;
+
+                                            match ke_stor.insert_notification_for_user(&event, info.curator_space_id).await {
+                                                Ok(count) => {
+                                                    if count > 0 {
+                                                        info!(
+                                                            event_type = %event_type.as_str(),
+                                                            curator_space_id = %info.curator_space_id,
+                                                            inserted = count,
+                                                            "Inserted bounty notification for curator"
+                                                        );
+                                                    }
+                                                    ke_processed += 1;
+                                                }
+                                                Err(e) => {
+                                                    error!(
+                                                        error = %e,
+                                                        event_type = %event_type.as_str(),
+                                                        "DB error inserting bounty notification, will retry"
+                                                    );
+                                                    ke_errors += 1;
+                                                    all_ok = false;
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                        _ => {
+                                            continue;
+                                        }
+                                    }
+                                }
+
+                                // Only commit offset if all relations in the edit were processed successfully.
+                                // On DB error: don't commit — retry on restart.
+                                if all_ok {
+                                    if let Err(e) = kec.commit_message(&topic, partition, offset) {
+                                        error!(error = %e, "Failed to commit knowledge edits offset");
+                                    }
+                                }
+                            }
+                            Some(Err(e)) => {
+                                error!(error = %e, "Knowledge edits Kafka error");
+                            }
+                            None => {
+                                info!("Knowledge edits stream ended");
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
+            kec.flush_commits();
+            info!(
+                processed = ke_processed,
+                errors = ke_errors,
+                "Knowledge edits consumer stopped"
+            );
+        }))
+    } else {
+        None
+    };
 
     // Main Kafka consumer loop
     let mut stream = consumer.stream();
@@ -509,6 +818,17 @@ async fn async_main() -> Result<(), IndexerError> {
         Ok(Err(e)) => warn!(error = %e, "Rejection poller task failed"),
         Err(_) => {
             warn!("Rejection poller did not stop within 5s, aborting");
+        }
+    }
+
+    // Wait for knowledge edits consumer to finish (if enabled)
+    if let Some(handle) = ke_handle {
+        match tokio::time::timeout(tokio::time::Duration::from_secs(5), handle).await {
+            Ok(Ok(())) => info!("Knowledge edits consumer stopped"),
+            Ok(Err(e)) => warn!(error = %e, "Knowledge edits consumer task failed"),
+            Err(_) => {
+                warn!("Knowledge edits consumer did not stop within 5s, aborting");
+            }
         }
     }
 

--- a/notification-service/notification-indexer/src/models.rs
+++ b/notification-service/notification-indexer/src/models.rs
@@ -655,11 +655,15 @@ pub fn build_rejection_event(
 // ---------------------------------------------------------------------------
 
 /// Well-known relation type UUIDs for bounty events.
-/// Hardcoded from the GRC-20 protocol; env vars override if set.
-const DEFAULT_INTEREST_TYPE_ID: &str = "2c765cae-c1b6-4cc3-a65d-693d0a67eaeb";
-// Placeholder UUIDs — update when the protocol defines them
-const DEFAULT_ALLOCATED_TYPE_ID: &str = "00000000-0000-0000-0000-000000000000";
-const DEFAULT_PAYOUT_TYPE_ID: &str = "00000000-0000-0000-0000-000000000000";
+/// Sourced from the curator-app (packages/curator-utils/src/ids.ts); env vars override if set.
+///
+/// Interest:  INTERESTED_IN_PROPERTY_ID — curator (Person) -> bounty, in curator's personal space
+/// Allocated: ALLOCATED_PROPERTY_ID     — bounty -> person, in public space (optional DAO proposal)
+/// Payout:    PAYOUT_RECIPIENT_PROPERTY_ID — space -> recipient space, creates Payout entity
+///            (Payout is a multi-relation entity; we detect it by the recipient relation type)
+const DEFAULT_INTEREST_TYPE_ID: &str = "ff7e1b44-44a2-4191-8732-4e6c222afe07";
+const DEFAULT_ALLOCATED_TYPE_ID: &str = "cfeb6422-23c5-4df4-b3f9-375a489d9e22";
+const DEFAULT_PAYOUT_TYPE_ID: &str = "fddacaae-8513-8a43-ec1a-50ff71564d42";
 
 /// Configuration for bounty relation type detection.
 #[derive(Debug, Clone)]
@@ -820,6 +824,71 @@ pub fn handle_bounty_payout(info: &BountyRelationInfo) -> NotificationEvent {
             }),
         },
     }
+}
+
+/// Extract bounty-related CreateRelation operations from a HermesEdit.
+///
+/// Decodes the GRC-20 payload, iterates over ops, and returns a list of
+/// `(BountyRelationInfo, NotificationEventType)` pairs for each matching
+/// `CreateRelation` whose `relation_type` matches a bounty type.
+pub fn extract_bounty_relations(
+    edit: &hermes_schema::pb::knowledge::HermesEdit,
+    config: &BountyConfig,
+) -> Result<Vec<(BountyRelationInfo, NotificationEventType)>, crate::error::HandlerError> {
+    use crate::error::HandlerError;
+
+    let meta = edit.meta.as_ref().ok_or(HandlerError::MissingMetadata)?;
+    let block_number = meta.block_number;
+    let sequence = u64::from(meta.sequence);
+    let timestamp = meta.created_at;
+
+    let edit_space_id = Uuid::from_slice(&edit.space_id).map_err(HandlerError::Uuid)?;
+
+    let decoded = grc_20::decode_edit(&edit.payload)
+        .map_err(|e| HandlerError::Grc20Decode(format!("{}", e)))?;
+
+    let mut results = Vec::new();
+    for op in &decoded.ops {
+        if let grc_20::Op::CreateRelation(rel) = op {
+            let rel_type_uuid = Uuid::from_bytes(rel.relation_type);
+            if let Some(event_type) = config.match_type(&rel_type_uuid) {
+                let info = match event_type {
+                    NotificationEventType::BountyInterest => {
+                        // Interest: from=curator entity, to=bounty entity
+                        // curator_space_id = HermesEdit.space_id (curator's personal space)
+                        BountyRelationInfo {
+                            relation_id: Uuid::from_bytes(rel.id),
+                            bounty_entity_id: Uuid::from_bytes(rel.to),
+                            curator_space_id: edit_space_id,
+                            bounty_space_id: Uuid::nil(), // Needs DB lookup
+                            proposal_id: None,
+                            block_number,
+                            sequence,
+                            timestamp,
+                        }
+                    }
+                    NotificationEventType::BountyAllocated
+                    | NotificationEventType::BountyPayout => {
+                        // Allocated/Payout: from=bounty/space, to=person/recipient_space
+                        let curator_space = rel.to_space.map(Uuid::from_bytes);
+                        BountyRelationInfo {
+                            relation_id: Uuid::from_bytes(rel.id),
+                            bounty_entity_id: Uuid::from_bytes(rel.from),
+                            curator_space_id: curator_space.unwrap_or(Uuid::nil()),
+                            bounty_space_id: edit_space_id,
+                            proposal_id: None,
+                            block_number,
+                            sequence,
+                            timestamp,
+                        }
+                    }
+                    _ => continue,
+                };
+                results.push((info, event_type));
+            }
+        }
+    }
+    Ok(results)
 }
 
 #[cfg(test)]
@@ -1372,5 +1441,266 @@ mod tests {
         );
         // Unknown type returns None
         assert_eq!(config.match_type(&Uuid::from_bytes([0xFF; 16])), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // extract_bounty_relations()
+    // -----------------------------------------------------------------------
+
+    /// Build a minimal valid GRC-20 edit with a single CreateRelation op,
+    /// encode it, and wrap in a HermesEdit protobuf.
+    fn make_hermes_edit_with_relation(
+        relation_type: [u8; 16],
+        from: [u8; 16],
+        to: [u8; 16],
+        space_id: [u8; 16],
+        to_space: Option<[u8; 16]>,
+    ) -> hermes_schema::pb::knowledge::HermesEdit {
+        use std::borrow::Cow;
+
+        let edit = grc_20::Edit {
+            id: [0x99; 16],
+            name: Cow::Borrowed("test edit"),
+            authors: vec![[0xAA; 16]],
+            created_at: 1700000000,
+            ops: vec![grc_20::Op::CreateRelation(grc_20::CreateRelation {
+                id: [0x77; 16],
+                relation_type,
+                from,
+                from_is_value_ref: false,
+                to,
+                to_is_value_ref: false,
+                from_space: None,
+                from_version: None,
+                to_space,
+                to_version: None,
+                entity: None,
+                position: None,
+                context: None,
+            })],
+        };
+        let payload = grc_20::encode_edit(&edit).expect("encode should succeed");
+
+        hermes_schema::pb::knowledge::HermesEdit {
+            id: vec![0x88; 16],
+            name: "test".into(),
+            payload,
+            authors: vec![vec![0xAA; 16]],
+            language: None,
+            space_id: space_id.to_vec(),
+            is_canonical: true,
+            meta: Some(BlockchainMetadata {
+                block_number: 12345,
+                created_at: 1700000000,
+                created_by: vec![],
+                cursor: String::new(),
+                sequence: 3,
+                is_last: false,
+            }),
+        }
+    }
+
+    #[test]
+    fn test_extract_bounty_relations_interest() {
+        let config = BountyConfig::default();
+        let interest_bytes = config.interest_type_id.into_bytes();
+        let hermes_edit = make_hermes_edit_with_relation(
+            interest_bytes,
+            [0xCC; 16], // from = curator entity
+            [0xDD; 16], // to = bounty entity
+            [0xEE; 16], // space_id = curator's personal space
+            None,
+        );
+
+        let results = extract_bounty_relations(&hermes_edit, &config).expect("should extract");
+        assert_eq!(results.len(), 1);
+        let (info, event_type) = &results[0];
+        assert_eq!(*event_type, NotificationEventType::BountyInterest);
+        assert_eq!(info.bounty_entity_id, Uuid::from_bytes([0xDD; 16]));
+        assert_eq!(info.curator_space_id, Uuid::from_bytes([0xEE; 16]));
+        assert_eq!(info.bounty_space_id, Uuid::nil()); // needs DB lookup
+        assert_eq!(info.block_number, 12345);
+        assert_eq!(info.sequence, 3);
+    }
+
+    #[test]
+    fn test_extract_bounty_relations_allocated() {
+        let config = BountyConfig::default();
+        let allocated_bytes = config.allocated_type_id.into_bytes();
+        let hermes_edit = make_hermes_edit_with_relation(
+            allocated_bytes,
+            [0xDD; 16],       // from = bounty entity
+            [0xCC; 16],       // to = person entity
+            [0xEE; 16],       // space_id = bounty space
+            Some([0xFF; 16]), // to_space = curator personal space
+        );
+
+        let results = extract_bounty_relations(&hermes_edit, &config).expect("should extract");
+        assert_eq!(results.len(), 1);
+        let (info, event_type) = &results[0];
+        assert_eq!(*event_type, NotificationEventType::BountyAllocated);
+        assert_eq!(info.bounty_entity_id, Uuid::from_bytes([0xDD; 16]));
+        assert_eq!(info.curator_space_id, Uuid::from_bytes([0xFF; 16]));
+        assert_eq!(info.bounty_space_id, Uuid::from_bytes([0xEE; 16]));
+    }
+
+    #[test]
+    fn test_extract_bounty_relations_payout() {
+        let config = BountyConfig::default();
+        let payout_bytes = config.payout_type_id.into_bytes();
+        let hermes_edit = make_hermes_edit_with_relation(
+            payout_bytes,
+            [0xDD; 16], // from = space/bounty
+            [0xCC; 16], // to = recipient space
+            [0xEE; 16], // space_id = bounty space
+            Some([0xFF; 16]),
+        );
+
+        let results = extract_bounty_relations(&hermes_edit, &config).expect("should extract");
+        assert_eq!(results.len(), 1);
+        let (_info, event_type) = &results[0];
+        assert_eq!(*event_type, NotificationEventType::BountyPayout);
+    }
+
+    #[test]
+    fn test_extract_bounty_relations_non_bounty_returns_empty() {
+        let config = BountyConfig::default();
+        let random_type = [0x11; 16]; // not a bounty relation type
+        let hermes_edit =
+            make_hermes_edit_with_relation(random_type, [0xCC; 16], [0xDD; 16], [0xEE; 16], None);
+
+        let results = extract_bounty_relations(&hermes_edit, &config).expect("should extract");
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_extract_bounty_relations_mixed_ops() {
+        use std::borrow::Cow;
+
+        let config = BountyConfig::default();
+        let interest_bytes = config.interest_type_id.into_bytes();
+
+        // Build an edit with one bounty and one non-bounty CreateRelation
+        let edit = grc_20::Edit {
+            id: [0x99; 16],
+            name: Cow::Borrowed("mixed"),
+            authors: vec![[0xAA; 16]],
+            created_at: 1700000000,
+            ops: vec![
+                grc_20::Op::CreateRelation(grc_20::CreateRelation {
+                    id: [0x77; 16],
+                    relation_type: interest_bytes,
+                    from: [0xCC; 16],
+                    from_is_value_ref: false,
+                    to: [0xDD; 16],
+                    to_is_value_ref: false,
+                    from_space: None,
+                    from_version: None,
+                    to_space: None,
+                    to_version: None,
+                    entity: None,
+                    position: None,
+                    context: None,
+                }),
+                grc_20::Op::CreateRelation(grc_20::CreateRelation {
+                    id: [0x78; 16],
+                    relation_type: [0x11; 16], // non-bounty
+                    from: [0xCC; 16],
+                    from_is_value_ref: false,
+                    to: [0xDD; 16],
+                    to_is_value_ref: false,
+                    from_space: None,
+                    from_version: None,
+                    to_space: None,
+                    to_version: None,
+                    entity: None,
+                    position: None,
+                    context: None,
+                }),
+                grc_20::Op::CreateEntity(grc_20::CreateEntity {
+                    id: [0x79; 16],
+                    values: vec![],
+                    context: None,
+                }),
+            ],
+        };
+        let payload = grc_20::encode_edit(&edit).expect("encode should succeed");
+
+        let hermes_edit = hermes_schema::pb::knowledge::HermesEdit {
+            id: vec![0x88; 16],
+            name: "mixed".into(),
+            payload,
+            authors: vec![vec![0xAA; 16]],
+            language: None,
+            space_id: vec![0xEE; 16],
+            is_canonical: true,
+            meta: Some(BlockchainMetadata {
+                block_number: 100,
+                created_at: 1700000000,
+                created_by: vec![],
+                cursor: String::new(),
+                sequence: 0,
+                is_last: false,
+            }),
+        };
+
+        let results = extract_bounty_relations(&hermes_edit, &config).expect("should extract");
+        assert_eq!(
+            results.len(),
+            1,
+            "only the bounty relation should be extracted"
+        );
+        assert_eq!(results[0].1, NotificationEventType::BountyInterest);
+    }
+
+    #[test]
+    fn test_extract_bounty_relations_missing_metadata() {
+        let config = BountyConfig::default();
+        let hermes_edit = hermes_schema::pb::knowledge::HermesEdit {
+            id: vec![0x88; 16],
+            name: "test".into(),
+            payload: vec![],
+            authors: vec![],
+            language: None,
+            space_id: vec![0xEE; 16],
+            is_canonical: true,
+            meta: None,
+        };
+
+        let result = extract_bounty_relations(&hermes_edit, &config);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.expect_err("should fail"),
+            crate::error::HandlerError::MissingMetadata
+        ));
+    }
+
+    #[test]
+    fn test_extract_bounty_relations_invalid_payload() {
+        let config = BountyConfig::default();
+        let hermes_edit = hermes_schema::pb::knowledge::HermesEdit {
+            id: vec![0x88; 16],
+            name: "bad".into(),
+            payload: vec![0xFF, 0xFE, 0xFD], // garbage bytes
+            authors: vec![],
+            language: None,
+            space_id: vec![0xEE; 16],
+            is_canonical: true,
+            meta: Some(BlockchainMetadata {
+                block_number: 100,
+                created_at: 1700000000,
+                created_by: vec![],
+                cursor: String::new(),
+                sequence: 0,
+                is_last: false,
+            }),
+        };
+
+        let result = extract_bounty_relations(&hermes_edit, &config);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.expect_err("should fail"),
+            crate::error::HandlerError::Grc20Decode(_)
+        ));
     }
 }

--- a/notification-service/notification-indexer/src/storage.rs
+++ b/notification-service/notification-indexer/src/storage.rs
@@ -173,6 +173,73 @@ impl Storage {
         Ok(inserted_count)
     }
 
+    // -----------------------------------------------------------------------
+    // Bounty entity/space resolution
+    // -----------------------------------------------------------------------
+
+    /// Resolve a user entity_id to their personal space UUID.
+    ///
+    /// Uses the "front page entity" pattern: finds a personal space
+    /// that has a Types relation pointing from the entity to SPACE_TYPE.
+    #[instrument(name = "notification_indexer.storage.lookup_entity_space", skip(self))]
+    pub async fn lookup_entity_space(&self, entity_id: Uuid) -> Result<Option<Uuid>, StorageError> {
+        // TYPE_RELATION_TYPE_ID = 8f151ba4-de20-4e3c-9cb4-99ddf96f48f1
+        // SPACE_TYPE = 362c1dbd-dc64-44bb-a3c4-652f38a642d7
+        let result = sqlx::query_scalar::<_, Uuid>(
+            r#"
+            SELECT r.space_id
+            FROM relations r
+            JOIN spaces s ON s.id = r.space_id
+            WHERE r.from_entity_id = $1
+              AND r.type_id = '8f151ba4-de20-4e3c-9cb4-99ddf96f48f1'::uuid
+              AND r.to_entity_id = '362c1dbd-dc64-44bb-a3c4-652f38a642d7'::uuid
+            LIMIT 1
+            "#,
+        )
+        .bind(entity_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(result)
+    }
+
+    /// Look up which space owns a bounty entity (for interest notifications).
+    #[instrument(name = "notification_indexer.storage.lookup_bounty_space", skip(self))]
+    pub async fn lookup_bounty_space(
+        &self,
+        bounty_entity_id: Uuid,
+    ) -> Result<Option<Uuid>, StorageError> {
+        let result = sqlx::query_scalar::<_, Uuid>(
+            r#"
+            SELECT space_id
+            FROM relations
+            WHERE from_entity_id = $1
+              AND type_id = '8f151ba4-de20-4e3c-9cb4-99ddf96f48f1'::uuid
+            LIMIT 1
+            "#,
+        )
+        .bind(bounty_entity_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(result)
+    }
+
+    /// Insert a notification for a single user (curator) into the outbox.
+    ///
+    /// Used for bounty_allocated and bounty_payout where there's one recipient.
+    /// Delegates to `insert_notifications_for_editors` with a single-element slice.
+    #[instrument(
+        name = "notification_indexer.storage.insert_notification_for_user",
+        skip(self, event)
+    )]
+    pub async fn insert_notification_for_user(
+        &self,
+        event: &NotificationEvent,
+        user_space_id: Uuid,
+    ) -> Result<u64, StorageError> {
+        self.insert_notifications_for_editors(event, &[user_space_id])
+            .await
+    }
+
     /// Find proposals that have expired (end_time < now) without being executed,
     /// and for which we haven't yet sent a rejection notification.
     ///


### PR DESCRIPTION
## Summary
- Fix all three bounty relation type IDs in the notification-indexer to match the canonical IDs from the curator-app
- Update TECH_DESIGN.md and RFC with correct IDs, relation directions, and payout entity structure
- Update tests to verify all three IDs are non-nil and distinct

## Problem
The notification-indexer had incorrect bounty relation type IDs:
- **Interest** was hardcoded as `2c765cae-c1b6-4cc3-a65d-693d0a67eaeb` (unknown origin) — curator-app uses `ff7e1b44-44a2-4191-8732-4e6c222afe07` (`INTERESTED_IN_PROPERTY_ID`)
- **Allocated** was a nil placeholder `00000000-...` — should be `cfeb6422-23c5-4df4-b3f9-375a489d9e22` (`ALLOCATED_PROPERTY_ID`)
- **Payout** was a nil placeholder `00000000-...` — should be `fddacaae-8513-8a43-ec1a-50ff71564d42` (`PAYOUT_RECIPIENT_PROPERTY_ID`)

The docs also incorrectly claimed the IDs were "from the GRC-20 protocol" — they are application-level IDs defined in the curator-app.

## Changes

**`notification-service/notification-indexer/src/models.rs`**
- Updated `DEFAULT_INTEREST_TYPE_ID`, `DEFAULT_ALLOCATED_TYPE_ID`, `DEFAULT_PAYOUT_TYPE_ID` constants
- Updated comments with relation directions (from/to entity) and payout entity structure
- Updated `test_bounty_config_default` to verify all three IDs are non-nil and distinct
- Updated `test_bounty_config_match_type` to use default config directly (no more placeholder workaround)

**`notification-service/TECH_DESIGN.md`**
- Added concrete UUIDs and curator-app constant names for each bounty relation type
- Added relation directions and payout sub-relation details
- Corrected source attribution (curator-app, not GRC-20 protocol)

**`docs/rfcs/0004-notification-service.md`**
- Added bounty relation type UUIDs and directions to the Bounty Lifecycle section

## Test plan
- [x] All 25 notification-indexer unit tests pass
- [ ] Verify IDs match curator-app `packages/curator-utils/src/ids.ts`