### PR TITLE
feat(notif): bounty notifications via knowledge.edits consumer

### DIFF
--- a/.github/workflows/notification-service-e2e-tests.yml
+++ b/.github/workflows/notification-service-e2e-tests.yml
@@ -132,7 +132,6 @@ jobs:
           ENVIRONMENT=${{ env.ENVIRONMENT }} \
           REJECTION_POLL_INTERVAL_SECS=3 \
           NOTIFICATION_MIN_AGE_SECS=0 \
-          KNOWLEDGE_EDITS_ENABLED=true \
           RUST_LOG=info,notification_indexer=debug \
           ./target/debug/notification-indexer > /tmp/notification-indexer.log 2>&1 &
           echo $! > /tmp/notification-indexer.pid

--- a/.github/workflows/notification-service-e2e-tests.yml
+++ b/.github/workflows/notification-service-e2e-tests.yml
@@ -128,7 +128,8 @@ jobs:
         run: |
           DATABASE_URL=${{ env.DATABASE_URL }} \
           KAFKA_BROKER=${{ env.KAFKA_BROKER }} \
-          KAFKA_GROUP_ID=notification-indexer-e2e \
+          KAFKA_GROUP_ID_GOVERNANCE=notification-indexer-governance-e2e \
+          KAFKA_GROUP_ID_KNOWLEDGE_EDITS=notification-indexer-knowledge-edits-e2e \
           ENVIRONMENT=${{ env.ENVIRONMENT }} \
           REJECTION_POLL_INTERVAL_SECS=3 \
           NOTIFICATION_MIN_AGE_SECS=0 \

--- a/.github/workflows/notification-service-e2e-tests.yml
+++ b/.github/workflows/notification-service-e2e-tests.yml
@@ -132,6 +132,7 @@ jobs:
           ENVIRONMENT=${{ env.ENVIRONMENT }} \
           REJECTION_POLL_INTERVAL_SECS=3 \
           NOTIFICATION_MIN_AGE_SECS=0 \
+          KNOWLEDGE_EDITS_ENABLED=true \
           RUST_LOG=info,notification_indexer=debug \
           ./target/debug/notification-indexer > /tmp/notification-indexer.log 2>&1 &
           echo $! > /tmp/notification-indexer.pid

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3930,6 +3930,7 @@ name = "notification-e2e-tests"
 version = "0.1.0"
 dependencies = [
  "axum 0.7.9",
+ "grc-20",
  "hermes-kafka",
  "hermes-schema",
  "hex",

--- a/api/src/kg/instrumentationPlugin.ts
+++ b/api/src/kg/instrumentationPlugin.ts
@@ -192,6 +192,19 @@ export function useGraphQLInstrumentation(): Plugin {
 					if (responseSizeBytes !== undefined) {
 						span.setAttribute("graphql.response_size_bytes", responseSizeBytes)
 					}
+
+					// Sentry metrics for dashboards and alerting
+					Sentry.metrics.distribution("graphql.duration_ms", durationMs, {
+						attributes: {operation: operationLabel},
+						unit: "millisecond",
+					})
+					if (responseSizeBytes !== undefined) {
+						Sentry.metrics.distribution("graphql.large_response_size_bytes", responseSizeBytes, {
+							attributes: {operation: operationLabel},
+							unit: "byte",
+						})
+					}
+
 					span.end()
 				},
 			}

--- a/api/src/services/telemetry.ts
+++ b/api/src/services/telemetry.ts
@@ -92,9 +92,9 @@ export const log = {
 		if (sentryInitialized) {
 			// Breadcrumb only - provides context for subsequent errors without creating issues
 			Sentry.addBreadcrumb({message, data, level: "warning", category: "log"})
-		} else {
-			console.warn(formatConsoleLog("warn", message, data))
 		}
+		// Always write to stdout so warnings are visible in kubectl logs
+		console.warn(formatConsoleLog("warn", message, data))
 	},
 	error: (message: string, data?: LogData) => {
 		if (sentryInitialized) {

--- a/docs/rfcs/0004-notification-service.md
+++ b/docs/rfcs/0004-notification-service.md
@@ -148,7 +148,13 @@ sequenceDiagram
 | Curator allocated to bounty | `knowledge.edits` | The allocated curator | Implicit (direct) |
 | Curator paid out for bounty | `knowledge.edits` | The paid curator | Implicit (direct) |
 
-Bounty events are detected by inspecting `CreateRelation` operations in GRC-20 edit payloads and matching on well-known relation type UUIDs. The `knowledge.edits` topic carries the executed relation data for all three cases — interest relations are published directly by the curator, while allocation and payout relations are published via governance proposal execution.
+Bounty events are detected by inspecting `CreateRelation` operations in GRC-20 edit payloads and matching on well-known relation type UUIDs sourced from the curator-app (`packages/curator-utils/src/ids.ts`):
+
+- **Interest**: `INTERESTED_IN_PROPERTY_ID` (`ff7e1b44-44a2-4191-8732-4e6c222afe07`) — from=curator, to=bounty, in curator's personal space (direct publish)
+- **Allocation**: `ALLOCATED_PROPERTY_ID` (`cfeb6422-23c5-4df4-b3f9-375a489d9e22`) — from=bounty, to=person, in public space (optional DAO proposal)
+- **Payout**: `PAYOUT_RECIPIENT_PROPERTY_ID` (`fddacaae-8513-8a43-ec1a-50ff71564d42`) — from=space, to=recipient space, creates a Payout entity with sub-relations for bounty, submission(s), and amount
+
+The `knowledge.edits` topic carries the executed relation data for all three cases — interest relations are published directly by the curator, while allocation and payout relations are published via governance proposal execution.
 
 ### Membership
 

--- a/notification-service/TECH_DESIGN.md
+++ b/notification-service/TECH_DESIGN.md
@@ -103,7 +103,11 @@ flowchart LR
 
 Footnote: For `bounty_interest`, `HermesEdit.space_id` is the curator's personal space (no DB lookup needed). For `bounty_allocated` / `bounty_payout`, the curator's space is resolved from the relation's `to_space_id` if present, otherwise via the entity→space DB lookup.
 
-Bounty events require consuming the `knowledge.edits` Kafka topic. The notification-indexer decodes the GRC-20 payload from `HermesEdit` messages and inspects the relation `type_id` to identify bounty-specific relations. Well-known relation type UUIDs for bounty interest, allocation, and payout are defined in the protocol and configured via environment variables (e.g. `BOUNTY_INTEREST_RELATION_TYPE_ID`, `BOUNTY_ALLOCATED_RELATION_TYPE_ID`, `BOUNTY_PAYOUT_RELATION_TYPE_ID`).
+Bounty events require consuming the `knowledge.edits` Kafka topic. The notification-indexer decodes the GRC-20 payload from `HermesEdit` messages and inspects the relation `type_id` to identify bounty-specific relations. The relation type UUIDs are sourced from the curator-app (`packages/curator-utils/src/ids.ts`) and configured via environment variables:
+
+- **`BOUNTY_INTEREST_RELATION_TYPE_ID`** = `ff7e1b44-44a2-4191-8732-4e6c222afe07` (`INTERESTED_IN_PROPERTY_ID`) — curator (Person) → bounty, in curator's personal space
+- **`BOUNTY_ALLOCATED_RELATION_TYPE_ID`** = `cfeb6422-23c5-4df4-b3f9-375a489d9e22` (`ALLOCATED_PROPERTY_ID`) — bounty → person, in public space (optional DAO proposal flow)
+- **`BOUNTY_PAYOUT_RELATION_TYPE_ID`** = `fddacaae-8513-8a43-ec1a-50ff71564d42` (`PAYOUT_RECIPIENT_PROPERTY_ID`) — space → recipient space, creates a Payout entity (`f5132deb-102d-6455-3049-f1e9cb662f50`). Payout is a multi-relation entity with sub-relations for bounty link (`1b595a8b-81fc-2585-6a9b-503e3e993331`), submission link (`8128964c-1ec5-4829-beb3-80a21ab64c51`), and amount (`82fe45a3-1df7-4c02-91af-a6e68d41cddf`).
 
 #### Resolving entity_id → user_space_id
 

--- a/notification-service/TECH_DESIGN.md
+++ b/notification-service/TECH_DESIGN.md
@@ -103,7 +103,7 @@ flowchart LR
 
 Footnote: For `bounty_interest`, `HermesEdit.space_id` is the curator's personal space (no DB lookup needed). For `bounty_allocated` / `bounty_payout`, the curator's space is resolved from the relation's `to_space_id` if present, otherwise via the entity→space DB lookup.
 
-Bounty events require consuming the `knowledge.edits` Kafka topic. The notification-indexer decodes the GRC-20 payload from `HermesEdit` messages and inspects the relation `type_id` to identify bounty-specific relations. The relation type UUIDs are sourced from the curator-app (`packages/curator-utils/src/ids.ts`) and configured via environment variables:
+Bounty events require consuming the `knowledge.edits` Kafka topic. The notification-indexer decodes the GRC-20 payload from `HermesEdit` messages and inspects the relation `type_id` to identify bounty-specific relations. The relation type UUIDs are sourced from the curator-app (`packages/curator-utils/src/ids.ts`) and are being upstreamed to the geo-sdk (`src/core/ids/system.ts`) and the grc-20 Rust crate. They are configured via environment variables with hardcoded defaults:
 
 - **`BOUNTY_INTEREST_RELATION_TYPE_ID`** = `ff7e1b44-44a2-4191-8732-4e6c222afe07` (`INTERESTED_IN_PROPERTY_ID`) — curator (Person) → bounty, in curator's personal space
 - **`BOUNTY_ALLOCATED_RELATION_TYPE_ID`** = `cfeb6422-23c5-4df4-b3f9-375a489d9e22` (`ALLOCATED_PROPERTY_ID`) — bounty → person, in public space (optional DAO proposal flow)

--- a/notification-service/deployment/production/notification-indexer.yaml
+++ b/notification-service/deployment/production/notification-indexer.yaml
@@ -64,8 +64,10 @@ spec:
             # Consumer configuration
             - name: ENVIRONMENT
               value: "production"
-            - name: KAFKA_GROUP_ID
-              value: "notification-indexer"
+            - name: KAFKA_GROUP_ID_GOVERNANCE
+              value: "notification-indexer-governance-v1"
+            - name: KAFKA_GROUP_ID_KNOWLEDGE_EDITS
+              value: "notification-indexer-knowledge-edits-v1"
             - name: REJECTION_POLL_INTERVAL_SECS
               value: "60"
             # Logging

--- a/notification-service/deployment/staging/notification-indexer.yaml
+++ b/notification-service/deployment/staging/notification-indexer.yaml
@@ -66,8 +66,10 @@ spec:
             # Consumer configuration
             - name: ENVIRONMENT
               value: "staging"
-            - name: KAFKA_GROUP_ID
-              value: "notification-indexer-staging"
+            - name: KAFKA_GROUP_ID_GOVERNANCE
+              value: "notification-indexer-governance-v1"
+            - name: KAFKA_GROUP_ID_KNOWLEDGE_EDITS
+              value: "notification-indexer-knowledge-edits-v1"
             - name: REJECTION_POLL_INTERVAL_SECS
               value: "60"
             # Logging

--- a/notification-service/e2e-tests/Cargo.toml
+++ b/notification-service/e2e-tests/Cargo.toml
@@ -12,6 +12,7 @@ tokio = { version = "1.42.0", features = ["macros", "rt-multi-thread", "sync", "
 axum = "0.7"
 sqlx = { version = "0.8.6", features = ["runtime-tokio", "postgres", "uuid", "chrono", "tls-rustls"] }
 prost = "0.13.5"
+grc-20 = "0.4.1"
 hmac = "0.12"
 sha2 = "0.10"
 hex = "0.4"

--- a/notification-service/e2e-tests/setup.sql
+++ b/notification-service/e2e-tests/setup.sql
@@ -77,6 +77,24 @@ CREATE TABLE IF NOT EXISTS "values" (
     UNIQUE(entity_id, property_id, space_id)
 );
 
+-- Minimal relations table for bounty entity→space resolution.
+-- Used by lookup_entity_space() and lookup_bounty_space().
+CREATE TABLE IF NOT EXISTS relations (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    from_entity_id uuid NOT NULL,
+    to_entity_id uuid NOT NULL,
+    type_id uuid NOT NULL,
+    space_id uuid NOT NULL
+);
+CREATE INDEX IF NOT EXISTS relations_from_entity_idx ON relations (from_entity_id);
+
+-- Minimal spaces table for bounty entity→space resolution.
+-- Used by lookup_entity_space() to filter personal spaces.
+CREATE TABLE IF NOT EXISTS spaces (
+    id uuid PRIMARY KEY,
+    type text NOT NULL DEFAULT 'Personal'
+);
+
 -- Expression index for the rejection poller's LEFT JOIN anti-pattern.
 -- Without this, the (payload->>'proposal_id')::uuid extraction does a seq scan.
 CREATE INDEX IF NOT EXISTS idx_outbox_rejected_proposal

--- a/notification-service/e2e-tests/src/main.rs
+++ b/notification-service/e2e-tests/src/main.rs
@@ -253,11 +253,13 @@ async fn seed_database(
         .await?;
     }
 
-    // Seed a relation so lookup_bounty_space can resolve BOUNTY_ENTITY -> BOUNTY_SPACE
+    // Seed the bounty entity's Types relation (from=bounty, to=BOUNTY_TYPE)
+    // so lookup_bounty_space can resolve BOUNTY_ENTITY -> BOUNTY_SPACE.
     // TYPE_RELATION_TYPE_ID = 8f151ba4-de20-4e3c-9cb4-99ddf96f48f1
+    // BOUNTY_TYPE_ID = 808af0ba-d588-4e33-91f0-9dd4b25e18be
     sqlx::query(
-        "INSERT INTO relations (id, space_id, type_id, from_entity_id, to_entity_id, created_at, created_at_block) \
-         VALUES ($1, $2, '8f151ba4-de20-4e3c-9cb4-99ddf96f48f1'::uuid, $3, '362c1dbd-dc64-44bb-a3c4-652f38a642d7'::uuid, '0', '0') \
+        "INSERT INTO relations (id, space_id, type_id, from_entity_id, to_entity_id) \
+         VALUES ($1, $2, '8f151ba4-de20-4e3c-9cb4-99ddf96f48f1'::uuid, $3, '808af0ba-d588-4e33-91f0-9dd4b25e18be'::uuid) \
          ON CONFLICT DO NOTHING",
     )
     .bind(Uuid::new_v4())
@@ -266,7 +268,34 @@ async fn seed_database(
     .execute(pool)
     .await?;
 
-    // Seed a space row for the bounty space (needed for lookup_entity_space JOIN)
+    // Decoy: a Types relation from the same bounty entity pointing to a DIFFERENT type.
+    // This must NOT be matched by lookup_bounty_space (tests the to_entity_id constraint).
+    let wrong_space = Uuid::from_bytes([0xBB; 16]);
+    sqlx::query(
+        "INSERT INTO relations (id, space_id, type_id, from_entity_id, to_entity_id) \
+         VALUES ($1, $2, '8f151ba4-de20-4e3c-9cb4-99ddf96f48f1'::uuid, $3, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid) \
+         ON CONFLICT DO NOTHING",
+    )
+    .bind(Uuid::new_v4())
+    .bind(wrong_space)
+    .bind(Uuid::from_bytes(BOUNTY_ENTITY_BYTES))
+    .execute(pool)
+    .await?;
+
+    // Decoy: a non-Types relation from the same bounty entity.
+    // This must NOT be matched by lookup_bounty_space (tests the type_id constraint).
+    sqlx::query(
+        "INSERT INTO relations (id, space_id, type_id, from_entity_id, to_entity_id) \
+         VALUES ($1, $2, 'cccccccc-cccc-cccc-cccc-cccccccccccc'::uuid, $3, '808af0ba-d588-4e33-91f0-9dd4b25e18be'::uuid) \
+         ON CONFLICT DO NOTHING",
+    )
+    .bind(Uuid::new_v4())
+    .bind(wrong_space)
+    .bind(Uuid::from_bytes(BOUNTY_ENTITY_BYTES))
+    .execute(pool)
+    .await?;
+
+    // Seed space rows (needed for lookup_entity_space JOIN)
     sqlx::query("INSERT INTO spaces (id) VALUES ($1) ON CONFLICT DO NOTHING")
         .bind(bounty_space)
         .execute(pool)
@@ -278,6 +307,32 @@ async fn seed_database(
         .bind(curator_space)
         .execute(pool)
         .await?;
+
+    // Seed curator entity→space relation (from=curator_entity, to=SPACE_TYPE, space=curator_space)
+    // SPACE_TYPE = 362c1dbd-dc64-44bb-a3c4-652f38a642d7
+    sqlx::query(
+        "INSERT INTO relations (id, space_id, type_id, from_entity_id, to_entity_id) \
+         VALUES ($1, $2, '8f151ba4-de20-4e3c-9cb4-99ddf96f48f1'::uuid, $3, '362c1dbd-dc64-44bb-a3c4-652f38a642d7'::uuid) \
+         ON CONFLICT DO NOTHING",
+    )
+    .bind(Uuid::new_v4())
+    .bind(curator_space)
+    .bind(Uuid::from_bytes(CURATOR_ENTITY_BYTES))
+    .execute(pool)
+    .await?;
+
+    // Decoy: curator entity with a non-SPACE_TYPE to_entity in a different space.
+    // Must NOT be matched by lookup_entity_space.
+    sqlx::query(
+        "INSERT INTO relations (id, space_id, type_id, from_entity_id, to_entity_id) \
+         VALUES ($1, $2, '8f151ba4-de20-4e3c-9cb4-99ddf96f48f1'::uuid, $3, 'dddddddd-dddd-dddd-dddd-dddddddddddd'::uuid) \
+         ON CONFLICT DO NOTHING",
+    )
+    .bind(Uuid::new_v4())
+    .bind(wrong_space)
+    .bind(Uuid::from_bytes(CURATOR_ENTITY_BYTES))
+    .execute(pool)
+    .await?;
 
     // Add curator as editor of their own space (for single-user notifications)
     sqlx::query(

--- a/notification-service/e2e-tests/src/main.rs
+++ b/notification-service/e2e-tests/src/main.rs
@@ -770,7 +770,7 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
     let no_unknown = calls.iter().all(|c| {
         c.body["user_space_id"]
             .as_str()
-            .map_or(false, |id| all_known.iter().any(|k| k == id))
+            .is_some_and(|id| all_known.iter().any(|k| k == id))
     });
     r.check("no unexpected user_space_ids (false positive)", no_unknown);
 
@@ -783,7 +783,7 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
         calls.iter().all(|c| {
             c.body["event_type"]
                 .as_str()
-                .map_or(false, |t| known_types.contains(t))
+                .is_some_and(|t| known_types.contains(t))
         }),
     );
 
@@ -1453,7 +1453,7 @@ async fn main() {
         match tokio::time::timeout(remaining, rx.recv()).await {
             Ok(Some(call)) => {
                 let n = calls.len() + 1;
-                if n <= 6 || n % 10 == 0 || n == EXPECTED_CALLS {
+                if n <= 6 || n.is_multiple_of(10) || n == EXPECTED_CALLS {
                     let et = call.body["event_type"].as_str().unwrap_or("?");
                     let uid = call.body["user_space_id"]
                         .as_str()

--- a/notification-service/e2e-tests/src/main.rs
+++ b/notification-service/e2e-tests/src/main.rs
@@ -67,14 +67,44 @@ const PROP_3E_REJECTED_BYTES: [u8; 16] = [0x05; 16];
 const PROP_1E_CREATED_BYTES: [u8; 16] = [0x31; 16];
 const PROP_0E_CREATED_BYTES: [u8; 16] = [0x32; 16];
 
+// Bounty test fixtures
+// Bounty space with 2 editors (receives interest notifications)
+const BOUNTY_SPACE_BYTES: [u8; 16] = [0xB1; 16];
+const BOUNTY_EDITOR_1_BYTES: [u8; 16] = [0xB2; 16];
+const BOUNTY_EDITOR_2_BYTES: [u8; 16] = [0xB3; 16];
+// Curator's personal space (the person expressing interest / receiving allocation)
+const CURATOR_SPACE_BYTES: [u8; 16] = [0xC1; 16];
+const CURATOR_ENTITY_BYTES: [u8; 16] = [0xC2; 16];
+// Bounty entity
+const BOUNTY_ENTITY_BYTES: [u8; 16] = [0xBE; 16];
+// Relation IDs
+const INTEREST_RELATION_BYTES: [u8; 16] = [0xE1; 16];
+const ALLOCATED_RELATION_BYTES: [u8; 16] = [0xE2; 16];
+const PAYOUT_RELATION_BYTES: [u8; 16] = [0xE3; 16];
+
+// Well-known bounty relation type UUIDs (must match models.rs)
+const INTEREST_TYPE_BYTES: [u8; 16] = [
+    0xff, 0x7e, 0x1b, 0x44, 0x44, 0xa2, 0x41, 0x91, 0x87, 0x32, 0x4e, 0x6c, 0x22, 0x2a, 0xfe, 0x07,
+];
+const ALLOCATED_TYPE_BYTES: [u8; 16] = [
+    0xcf, 0xeb, 0x64, 0x22, 0x23, 0xc5, 0x4d, 0xf4, 0xb3, 0xf9, 0x37, 0x5a, 0x48, 0x9d, 0x9e, 0x22,
+];
+const PAYOUT_TYPE_BYTES: [u8; 16] = [
+    0xfd, 0xda, 0xca, 0xae, 0x85, 0x13, 0x8a, 0x43, 0xec, 0x1a, 0x50, 0xff, 0x71, 0x56, 0x4d, 0x42,
+];
+
 const GOVERNANCE_TOPIC: &str = "space.governance";
+const KNOWLEDGE_EDITS_TOPIC: &str = "knowledge.edits";
 const NUM_WEBHOOKS: usize = 3;
 
 // Expected calls:
 // 3-editor space: 6 event types × 3 editors × 3 webhooks = 54
 // 1-editor space: 1 event type  × 1 editor  × 3 webhooks = 3
 // 0-editor space: 1 event type  × 0 editors × 3 webhooks = 0
-const EXPECTED_CALLS: usize = 54 + 3;
+// Bounty interest: 1 event × 2 editors × 3 webhooks = 6
+// Bounty allocated: 1 event × 1 curator × 3 webhooks = 3
+// Bounty payout: 1 event × 1 curator × 3 webhooks = 3
+const EXPECTED_CALLS: usize = 54 + 3 + 6 + 3 + 3;
 
 const ALL_EVENT_TYPES: &[&str] = &[
     "proposal_created",
@@ -83,6 +113,9 @@ const ALL_EVENT_TYPES: &[&str] = &[
     "proposal_executed",
     "proposal_settings_updated",
     "proposal_rejected",
+    "bounty_interest",
+    "bounty_allocated",
+    "bounty_payout",
 ];
 
 // ---------------------------------------------------------------------------
@@ -207,6 +240,55 @@ async fn seed_database(
     .execute(pool)
     .await?;
 
+    // Bounty space with 2 editors
+    let bounty_space = Uuid::from_bytes(BOUNTY_SPACE_BYTES);
+    for bytes in [BOUNTY_EDITOR_1_BYTES, BOUNTY_EDITOR_2_BYTES] {
+        sqlx::query(
+            "INSERT INTO editors (member_space_id, space_id) VALUES ($1, $2) \
+             ON CONFLICT DO NOTHING",
+        )
+        .bind(Uuid::from_bytes(bytes))
+        .bind(bounty_space)
+        .execute(pool)
+        .await?;
+    }
+
+    // Seed a relation so lookup_bounty_space can resolve BOUNTY_ENTITY -> BOUNTY_SPACE
+    // TYPE_RELATION_TYPE_ID = 8f151ba4-de20-4e3c-9cb4-99ddf96f48f1
+    sqlx::query(
+        "INSERT INTO relations (id, space_id, type_id, from_entity_id, to_entity_id, created_at, created_at_block) \
+         VALUES ($1, $2, '8f151ba4-de20-4e3c-9cb4-99ddf96f48f1'::uuid, $3, '362c1dbd-dc64-44bb-a3c4-652f38a642d7'::uuid, '0', '0') \
+         ON CONFLICT DO NOTHING",
+    )
+    .bind(Uuid::new_v4())
+    .bind(bounty_space)
+    .bind(Uuid::from_bytes(BOUNTY_ENTITY_BYTES))
+    .execute(pool)
+    .await?;
+
+    // Seed a space row for the bounty space (needed for lookup_entity_space JOIN)
+    sqlx::query("INSERT INTO spaces (id) VALUES ($1) ON CONFLICT DO NOTHING")
+        .bind(bounty_space)
+        .execute(pool)
+        .await?;
+
+    // Curator personal space (for allocated/payout resolution)
+    let curator_space = Uuid::from_bytes(CURATOR_SPACE_BYTES);
+    sqlx::query("INSERT INTO spaces (id) VALUES ($1) ON CONFLICT DO NOTHING")
+        .bind(curator_space)
+        .execute(pool)
+        .await?;
+
+    // Add curator as editor of their own space (for single-user notifications)
+    sqlx::query(
+        "INSERT INTO editors (member_space_id, space_id) VALUES ($1, $2) \
+         ON CONFLICT DO NOTHING",
+    )
+    .bind(curator_space)
+    .bind(curator_space)
+    .execute(pool)
+    .await?;
+
     Ok(())
 }
 
@@ -279,7 +361,13 @@ async fn produce_test_events(kafka_broker: &str) -> Result<(), Box<dyn std::erro
         settings: Some(make_settings()),
         meta: Some(make_meta(12345, 1700000000)),
     };
-    send_event(&producer, "PROPOSAL_CREATED", &msg.encode_to_vec(), "3e-created").await?;
+    send_event(
+        &producer,
+        "PROPOSAL_CREATED",
+        &msg.encode_to_vec(),
+        "3e-created",
+    )
+    .await?;
 
     let msg = hermes_schema::pb::governance::HermesProposalUpdated {
         space_id: SPACE_3E_BYTES.to_vec(),
@@ -290,7 +378,13 @@ async fn produce_test_events(kafka_broker: &str) -> Result<(), Box<dyn std::erro
         settings: Some(make_settings()),
         meta: Some(make_meta(12347, 1700002000)),
     };
-    send_event(&producer, "PROPOSAL_UPDATED", &msg.encode_to_vec(), "3e-updated").await?;
+    send_event(
+        &producer,
+        "PROPOSAL_UPDATED",
+        &msg.encode_to_vec(),
+        "3e-updated",
+    )
+    .await?;
 
     let msg = hermes_schema::pb::governance::HermesProposalVoted {
         voter_id: VOTER_ID_BYTES.to_vec(),
@@ -299,14 +393,26 @@ async fn produce_test_events(kafka_broker: &str) -> Result<(), Box<dyn std::erro
         vote: hermes_schema::pb::governance::ProposalVoteOption::VoteOptionYes as i32,
         meta: Some(make_meta(12348, 1700003000)),
     };
-    send_event(&producer, "PROPOSAL_VOTED", &msg.encode_to_vec(), "3e-voted").await?;
+    send_event(
+        &producer,
+        "PROPOSAL_VOTED",
+        &msg.encode_to_vec(),
+        "3e-voted",
+    )
+    .await?;
 
     let msg = hermes_schema::pb::governance::HermesProposalExecuted {
         space_id: SPACE_3E_BYTES.to_vec(),
         proposal_id: PROP_3E_EXECUTED_BYTES.to_vec(),
         meta: Some(make_meta(12346, 1700001000)),
     };
-    send_event(&producer, "PROPOSAL_EXECUTED", &msg.encode_to_vec(), "3e-executed").await?;
+    send_event(
+        &producer,
+        "PROPOSAL_EXECUTED",
+        &msg.encode_to_vec(),
+        "3e-executed",
+    )
+    .await?;
 
     let msg = hermes_schema::pb::governance::HermesProposalSettingsUpdated {
         space_id: SPACE_3E_BYTES.to_vec(),
@@ -321,7 +427,13 @@ async fn produce_test_events(kafka_broker: &str) -> Result<(), Box<dyn std::erro
         }),
         meta: Some(make_meta(12349, 1700004000)),
     };
-    send_event(&producer, "PROPOSAL_SETTINGS_UPDATED", &msg.encode_to_vec(), "3e-settings").await?;
+    send_event(
+        &producer,
+        "PROPOSAL_SETTINGS_UPDATED",
+        &msg.encode_to_vec(),
+        "3e-settings",
+    )
+    .await?;
 
     // === 1-editor space: PROPOSAL_CREATED only ===
 
@@ -334,7 +446,13 @@ async fn produce_test_events(kafka_broker: &str) -> Result<(), Box<dyn std::erro
         settings: Some(make_settings()),
         meta: Some(make_meta(20001, 1700010000)),
     };
-    send_event(&producer, "PROPOSAL_CREATED", &msg.encode_to_vec(), "1e-created").await?;
+    send_event(
+        &producer,
+        "PROPOSAL_CREATED",
+        &msg.encode_to_vec(),
+        "1e-created",
+    )
+    .await?;
 
     // === 0-editor space: PROPOSAL_CREATED only (expect zero calls) ===
 
@@ -347,9 +465,151 @@ async fn produce_test_events(kafka_broker: &str) -> Result<(), Box<dyn std::erro
         settings: Some(make_settings()),
         meta: Some(make_meta(30001, 1700020000)),
     };
-    send_event(&producer, "PROPOSAL_CREATED", &msg.encode_to_vec(), "0e-created").await?;
+    send_event(
+        &producer,
+        "PROPOSAL_CREATED",
+        &msg.encode_to_vec(),
+        "0e-created",
+    )
+    .await?;
+
+    // === Bounty events via knowledge.edits topic ===
+
+    let ke_topic = {
+        let prefix = hermes_kafka::get_topic_prefix();
+        format!("{}{}", prefix, KNOWLEDGE_EDITS_TOPIC)
+    };
+
+    // Interest: curator (in their personal space) → bounty entity
+    let interest_edit = make_bounty_hermes_edit(
+        INTEREST_RELATION_BYTES,
+        INTEREST_TYPE_BYTES,
+        CURATOR_ENTITY_BYTES,
+        BOUNTY_ENTITY_BYTES,
+        CURATOR_SPACE_BYTES,
+        None,
+        40001,
+        1700030000,
+        1,
+    );
+    let headers = rdkafka::message::OwnedHeaders::new();
+    producer
+        .send(
+            FutureRecord::to(&ke_topic)
+                .payload(&interest_edit.encode_to_vec())
+                .key("bounty-interest")
+                .headers(headers),
+            Duration::from_secs(10),
+        )
+        .await
+        .map_err(|(e, _)| e)?;
+
+    // Allocated: bounty entity → curator, in bounty space
+    let allocated_edit = make_bounty_hermes_edit(
+        ALLOCATED_RELATION_BYTES,
+        ALLOCATED_TYPE_BYTES,
+        BOUNTY_ENTITY_BYTES,
+        CURATOR_ENTITY_BYTES,
+        BOUNTY_SPACE_BYTES,
+        Some(CURATOR_SPACE_BYTES),
+        40002,
+        1700031000,
+        2,
+    );
+    let headers = rdkafka::message::OwnedHeaders::new();
+    producer
+        .send(
+            FutureRecord::to(&ke_topic)
+                .payload(&allocated_edit.encode_to_vec())
+                .key("bounty-allocated")
+                .headers(headers),
+            Duration::from_secs(10),
+        )
+        .await
+        .map_err(|(e, _)| e)?;
+
+    // Payout: bounty space → curator space
+    let payout_edit = make_bounty_hermes_edit(
+        PAYOUT_RELATION_BYTES,
+        PAYOUT_TYPE_BYTES,
+        BOUNTY_ENTITY_BYTES,
+        CURATOR_ENTITY_BYTES,
+        BOUNTY_SPACE_BYTES,
+        Some(CURATOR_SPACE_BYTES),
+        40003,
+        1700032000,
+        3,
+    );
+    let headers = rdkafka::message::OwnedHeaders::new();
+    producer
+        .send(
+            FutureRecord::to(&ke_topic)
+                .payload(&payout_edit.encode_to_vec())
+                .key("bounty-payout")
+                .headers(headers),
+            Duration::from_secs(10),
+        )
+        .await
+        .map_err(|(e, _)| e)?;
 
     Ok(())
+}
+
+/// Build a HermesEdit protobuf containing a single CreateRelation op.
+#[allow(clippy::too_many_arguments)]
+fn make_bounty_hermes_edit(
+    relation_id: [u8; 16],
+    relation_type: [u8; 16],
+    from: [u8; 16],
+    to: [u8; 16],
+    space_id: [u8; 16],
+    to_space: Option<[u8; 16]>,
+    block_number: u64,
+    created_at: u64,
+    sequence: u32,
+) -> hermes_schema::pb::knowledge::HermesEdit {
+    use std::borrow::Cow;
+
+    let edit = grc_20::Edit {
+        id: relation_id, // reuse relation_id as edit id for simplicity
+        name: Cow::Borrowed("bounty edit"),
+        authors: vec![from],
+        created_at: created_at as i64,
+        ops: vec![grc_20::Op::CreateRelation(grc_20::CreateRelation {
+            id: relation_id,
+            relation_type,
+            from,
+            from_is_value_ref: false,
+            to,
+            to_is_value_ref: false,
+            from_space: None,
+            from_version: None,
+            to_space,
+            to_version: None,
+            entity: None,
+            position: None,
+            context: None,
+        })],
+    };
+    let payload = grc_20::encode_edit(&edit).expect("GRC-20 encode should succeed");
+
+    hermes_schema::pb::knowledge::HermesEdit {
+        id: relation_id.to_vec(),
+        name: "bounty edit".into(),
+        payload,
+        authors: vec![from.to_vec()],
+        language: None,
+        space_id: space_id.to_vec(),
+        is_canonical: true,
+        meta: Some(hermes_schema::pb::blockchain_metadata::BlockchainMetadata {
+            created_at,
+            created_by: vec![],
+            block_number,
+            cursor: String::new(),
+            sequence,
+            is_last: false,
+        }),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -363,7 +623,10 @@ struct TestResults {
 
 impl TestResults {
     fn new() -> Self {
-        Self { passed: 0, failed: 0 }
+        Self {
+            passed: 0,
+            failed: 0,
+        }
     }
 
     fn check(&mut self, name: &str, ok: bool) {
@@ -405,10 +668,7 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
         .iter()
         .filter(|c| c.body["space_id"].as_str() == Some(space_0e.as_str()))
         .collect();
-    r.check(
-        "0-editor space: zero webhook calls",
-        calls_0e.is_empty(),
-    );
+    r.check("0-editor space: zero webhook calls", calls_0e.is_empty());
 
     // ===================================================================
     // 1-editor space: 1 event × 1 editor × 3 webhooks = 3 calls
@@ -489,9 +749,16 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
     // ===================================================================
     // Every call has user_space_id and it's a known editor
     // ===================================================================
+    let bounty_editor_1 = Uuid::from_bytes(BOUNTY_EDITOR_1_BYTES).to_string();
+    let bounty_editor_2 = Uuid::from_bytes(BOUNTY_EDITOR_2_BYTES).to_string();
+    let curator_space = Uuid::from_bytes(CURATOR_SPACE_BYTES).to_string();
+
     let all_known: Vec<String> = editors_3e
         .iter()
         .chain(std::iter::once(&editor_solo))
+        .chain(std::iter::once(&bounty_editor_1))
+        .chain(std::iter::once(&bounty_editor_2))
+        .chain(std::iter::once(&curator_space))
         .cloned()
         .collect();
 
@@ -510,22 +777,46 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
     // ===================================================================
     // No unexpected event types
     // ===================================================================
-    let known_types: std::collections::HashSet<&str> =
-        ALL_EVENT_TYPES.iter().copied().collect();
+    let known_types: std::collections::HashSet<&str> = ALL_EVENT_TYPES.iter().copied().collect();
     r.check(
         "no unexpected event types",
-        calls
-            .iter()
-            .all(|c| c.body["event_type"].as_str().map_or(false, |t| known_types.contains(t))),
+        calls.iter().all(|c| {
+            c.body["event_type"]
+                .as_str()
+                .map_or(false, |t| known_types.contains(t))
+        }),
     );
 
     // ===================================================================
     // HMAC signatures (spot-check one per event type)
     // ===================================================================
-    for et in ALL_EVENT_TYPES {
-        if let Some(call) = calls_3e.iter().find(|c| c.body["event_type"].as_str() == Some(et)) {
+    // Governance HMAC spot-checks
+    for et in &[
+        "proposal_created",
+        "proposal_updated",
+        "proposal_voted",
+        "proposal_executed",
+        "proposal_settings_updated",
+        "proposal_rejected",
+    ] {
+        if let Some(call) = calls_3e
+            .iter()
+            .find(|c| c.body["event_type"].as_str() == Some(et))
+        {
             r.check(
                 &format!("3e {}: valid HMAC", et),
+                verify_hmac(webhook_secret, &call.raw_body, &call.signature),
+            );
+        }
+    }
+    // Bounty HMAC spot-checks
+    for et in &["bounty_interest", "bounty_allocated", "bounty_payout"] {
+        if let Some(call) = calls
+            .iter()
+            .find(|c| c.body["event_type"].as_str() == Some(et))
+        {
+            r.check(
+                &format!("bounty {}: valid HMAC", et),
                 verify_hmac(webhook_secret, &call.raw_body, &call.signature),
             );
         }
@@ -549,19 +840,17 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
     // Each unique (event_type, user_space_id) pair should have a unique key.
     // Multiple webhooks receive the same key for the same user — that's correct.
     // So the number of distinct keys should equal events × users, not total calls.
-    r.check(
-        "idempotency keys are unique per (event, user) pair",
-        {
-            let keys: std::collections::HashSet<&str> = calls
-                .iter()
-                .map(|c| c.idempotency_key.as_str())
-                .collect();
-            // 3-editor space: 6 events × 3 editors = 18 distinct keys
-            // 1-editor space: 1 event × 1 editor = 1 distinct key
-            // Total: 19
-            keys.len() == 19
-        },
-    );
+    r.check("idempotency keys are unique per (event, user) pair", {
+        let keys: std::collections::HashSet<&str> =
+            calls.iter().map(|c| c.idempotency_key.as_str()).collect();
+        // 3-editor space: 6 events × 3 editors = 18 distinct keys
+        // 1-editor space: 1 event × 1 editor = 1 distinct key
+        // Bounty interest: 1 event × 2 editors = 2 distinct keys
+        // Bounty allocated: 1 event × 1 curator = 1 distinct key
+        // Bounty payout: 1 event × 1 curator = 1 distinct key
+        // Total: 23
+        keys.len() == 23
+    });
 
     // ===================================================================
     // Comprehensive per-event-type payload validation
@@ -571,7 +860,12 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
     let voter = Uuid::from_bytes(VOTER_ID_BYTES).to_string();
 
     // Helper: validate common fields present on every notification
-    let check_common = |r: &mut TestResults, prefix: &str, call: &WebhookCall, expected_space: &str, expected_block: Option<u64>, expected_ts: Option<u64>| {
+    let check_common = |r: &mut TestResults,
+                        prefix: &str,
+                        call: &WebhookCall,
+                        expected_space: &str,
+                        expected_block: Option<u64>,
+                        expected_ts: Option<u64>| {
         r.check(
             &format!("{}: has version 1", prefix),
             call.body["version"].as_u64() == Some(1),
@@ -612,100 +906,303 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
     };
 
     // --- proposal_created ---
-    if let Some(call) = calls_3e.iter().find(|c| c.body["event_type"].as_str() == Some("proposal_created")) {
+    if let Some(call) = calls_3e
+        .iter()
+        .find(|c| c.body["event_type"].as_str() == Some("proposal_created"))
+    {
         let prefix = "3e proposal_created";
         let pid = Uuid::from_bytes(PROP_3E_CREATED_BYTES).to_string();
-        check_common(&mut r, prefix, call, &space_3e, Some(12345), Some(1700000000));
-        r.check(&format!("{}: correct proposal_id", prefix), call.body["proposal_id"].as_str() == Some(pid.as_str()));
-        r.check(&format!("{}: has proposer_id", prefix), call.body["proposer_id"].as_str() == Some(proposer.as_str()));
-        r.check(&format!("{}: voting_mode is 'fast'", prefix), call.body["voting_mode"].as_str() == Some("fast"));
-        r.check(&format!("{}: has actions array", prefix), call.body["actions"].is_array());
-        r.check(&format!("{}: has settings object", prefix), call.body["settings"].is_object());
+        check_common(
+            &mut r,
+            prefix,
+            call,
+            &space_3e,
+            Some(12345),
+            Some(1700000000),
+        );
+        r.check(
+            &format!("{}: correct proposal_id", prefix),
+            call.body["proposal_id"].as_str() == Some(pid.as_str()),
+        );
+        r.check(
+            &format!("{}: has proposer_id", prefix),
+            call.body["proposer_id"].as_str() == Some(proposer.as_str()),
+        );
+        r.check(
+            &format!("{}: voting_mode is 'fast'", prefix),
+            call.body["voting_mode"].as_str() == Some("fast"),
+        );
+        r.check(
+            &format!("{}: has actions array", prefix),
+            call.body["actions"].is_array(),
+        );
+        r.check(
+            &format!("{}: has settings object", prefix),
+            call.body["settings"].is_object(),
+        );
         if call.body["settings"].is_object() {
-            r.check(&format!("{}: settings.start_date", prefix), call.body["settings"]["start_date"].as_u64() == Some(1700000000));
-            r.check(&format!("{}: settings.end_date", prefix), call.body["settings"]["end_date"].as_u64() == Some(1700086400));
-            r.check(&format!("{}: settings.voting_mode", prefix), call.body["settings"]["voting_mode"].as_str() == Some("fast"));
-            r.check(&format!("{}: settings.quorum", prefix), call.body["settings"]["quorum"].as_u64() == Some(1));
+            r.check(
+                &format!("{}: settings.start_date", prefix),
+                call.body["settings"]["start_date"].as_u64() == Some(1700000000),
+            );
+            r.check(
+                &format!("{}: settings.end_date", prefix),
+                call.body["settings"]["end_date"].as_u64() == Some(1700086400),
+            );
+            r.check(
+                &format!("{}: settings.voting_mode", prefix),
+                call.body["settings"]["voting_mode"].as_str() == Some("fast"),
+            );
+            r.check(
+                &format!("{}: settings.quorum", prefix),
+                call.body["settings"]["quorum"].as_u64() == Some(1),
+            );
         }
-        r.check(&format!("{}: no voter_id", prefix), call.body.get("voter_id").is_none());
-        r.check(&format!("{}: no vote", prefix), call.body.get("vote").is_none());
+        r.check(
+            &format!("{}: no voter_id", prefix),
+            call.body.get("voter_id").is_none(),
+        );
+        r.check(
+            &format!("{}: no vote", prefix),
+            call.body.get("vote").is_none(),
+        );
     }
 
     // --- proposal_updated ---
-    if let Some(call) = calls_3e.iter().find(|c| c.body["event_type"].as_str() == Some("proposal_updated")) {
+    if let Some(call) = calls_3e
+        .iter()
+        .find(|c| c.body["event_type"].as_str() == Some("proposal_updated"))
+    {
         let prefix = "3e proposal_updated";
         let pid = Uuid::from_bytes(PROP_3E_UPDATED_BYTES).to_string();
-        check_common(&mut r, prefix, call, &space_3e, Some(12347), Some(1700002000));
-        r.check(&format!("{}: correct proposal_id", prefix), call.body["proposal_id"].as_str() == Some(pid.as_str()));
-        r.check(&format!("{}: has proposer_id", prefix), call.body["proposer_id"].as_str() == Some(proposer.as_str()));
-        r.check(&format!("{}: voting_mode is 'fast'", prefix), call.body["voting_mode"].as_str() == Some("fast"));
-        r.check(&format!("{}: has actions array", prefix), call.body["actions"].is_array());
-        r.check(&format!("{}: has settings object", prefix), call.body["settings"].is_object());
-        r.check(&format!("{}: no voter_id", prefix), call.body.get("voter_id").is_none());
-        r.check(&format!("{}: no vote", prefix), call.body.get("vote").is_none());
+        check_common(
+            &mut r,
+            prefix,
+            call,
+            &space_3e,
+            Some(12347),
+            Some(1700002000),
+        );
+        r.check(
+            &format!("{}: correct proposal_id", prefix),
+            call.body["proposal_id"].as_str() == Some(pid.as_str()),
+        );
+        r.check(
+            &format!("{}: has proposer_id", prefix),
+            call.body["proposer_id"].as_str() == Some(proposer.as_str()),
+        );
+        r.check(
+            &format!("{}: voting_mode is 'fast'", prefix),
+            call.body["voting_mode"].as_str() == Some("fast"),
+        );
+        r.check(
+            &format!("{}: has actions array", prefix),
+            call.body["actions"].is_array(),
+        );
+        r.check(
+            &format!("{}: has settings object", prefix),
+            call.body["settings"].is_object(),
+        );
+        r.check(
+            &format!("{}: no voter_id", prefix),
+            call.body.get("voter_id").is_none(),
+        );
+        r.check(
+            &format!("{}: no vote", prefix),
+            call.body.get("vote").is_none(),
+        );
     }
 
     // --- proposal_voted ---
-    if let Some(call) = calls_3e.iter().find(|c| c.body["event_type"].as_str() == Some("proposal_voted")) {
+    if let Some(call) = calls_3e
+        .iter()
+        .find(|c| c.body["event_type"].as_str() == Some("proposal_voted"))
+    {
         let prefix = "3e proposal_voted";
         let pid = Uuid::from_bytes(PROP_3E_VOTED_BYTES).to_string();
-        check_common(&mut r, prefix, call, &space_3e, Some(12348), Some(1700003000));
-        r.check(&format!("{}: correct proposal_id", prefix), call.body["proposal_id"].as_str() == Some(pid.as_str()));
-        r.check(&format!("{}: correct voter_id", prefix), call.body["voter_id"].as_str() == Some(voter.as_str()));
-        r.check(&format!("{}: vote is 'yes'", prefix), call.body["vote"].as_str() == Some("yes"));
-        r.check(&format!("{}: no proposer_id", prefix), call.body.get("proposer_id").is_none());
-        r.check(&format!("{}: no voting_mode", prefix), call.body.get("voting_mode").is_none());
-        r.check(&format!("{}: no actions", prefix), call.body.get("actions").is_none());
-        r.check(&format!("{}: no settings", prefix), call.body.get("settings").is_none());
+        check_common(
+            &mut r,
+            prefix,
+            call,
+            &space_3e,
+            Some(12348),
+            Some(1700003000),
+        );
+        r.check(
+            &format!("{}: correct proposal_id", prefix),
+            call.body["proposal_id"].as_str() == Some(pid.as_str()),
+        );
+        r.check(
+            &format!("{}: correct voter_id", prefix),
+            call.body["voter_id"].as_str() == Some(voter.as_str()),
+        );
+        r.check(
+            &format!("{}: vote is 'yes'", prefix),
+            call.body["vote"].as_str() == Some("yes"),
+        );
+        r.check(
+            &format!("{}: no proposer_id", prefix),
+            call.body.get("proposer_id").is_none(),
+        );
+        r.check(
+            &format!("{}: no voting_mode", prefix),
+            call.body.get("voting_mode").is_none(),
+        );
+        r.check(
+            &format!("{}: no actions", prefix),
+            call.body.get("actions").is_none(),
+        );
+        r.check(
+            &format!("{}: no settings", prefix),
+            call.body.get("settings").is_none(),
+        );
     }
 
     // --- proposal_executed ---
-    if let Some(call) = calls_3e.iter().find(|c| c.body["event_type"].as_str() == Some("proposal_executed")) {
+    if let Some(call) = calls_3e
+        .iter()
+        .find(|c| c.body["event_type"].as_str() == Some("proposal_executed"))
+    {
         let prefix = "3e proposal_executed";
         let pid = Uuid::from_bytes(PROP_3E_EXECUTED_BYTES).to_string();
-        check_common(&mut r, prefix, call, &space_3e, Some(12346), Some(1700001000));
-        r.check(&format!("{}: correct proposal_id", prefix), call.body["proposal_id"].as_str() == Some(pid.as_str()));
-        r.check(&format!("{}: no proposer_id", prefix), call.body.get("proposer_id").is_none());
-        r.check(&format!("{}: no voter_id", prefix), call.body.get("voter_id").is_none());
-        r.check(&format!("{}: no vote", prefix), call.body.get("vote").is_none());
-        r.check(&format!("{}: no voting_mode", prefix), call.body.get("voting_mode").is_none());
-        r.check(&format!("{}: no actions", prefix), call.body.get("actions").is_none());
-        r.check(&format!("{}: no settings", prefix), call.body.get("settings").is_none());
+        check_common(
+            &mut r,
+            prefix,
+            call,
+            &space_3e,
+            Some(12346),
+            Some(1700001000),
+        );
+        r.check(
+            &format!("{}: correct proposal_id", prefix),
+            call.body["proposal_id"].as_str() == Some(pid.as_str()),
+        );
+        r.check(
+            &format!("{}: no proposer_id", prefix),
+            call.body.get("proposer_id").is_none(),
+        );
+        r.check(
+            &format!("{}: no voter_id", prefix),
+            call.body.get("voter_id").is_none(),
+        );
+        r.check(
+            &format!("{}: no vote", prefix),
+            call.body.get("vote").is_none(),
+        );
+        r.check(
+            &format!("{}: no voting_mode", prefix),
+            call.body.get("voting_mode").is_none(),
+        );
+        r.check(
+            &format!("{}: no actions", prefix),
+            call.body.get("actions").is_none(),
+        );
+        r.check(
+            &format!("{}: no settings", prefix),
+            call.body.get("settings").is_none(),
+        );
     }
 
     // --- proposal_settings_updated ---
-    if let Some(call) = calls_3e.iter().find(|c| c.body["event_type"].as_str() == Some("proposal_settings_updated")) {
+    if let Some(call) = calls_3e
+        .iter()
+        .find(|c| c.body["event_type"].as_str() == Some("proposal_settings_updated"))
+    {
         let prefix = "3e proposal_settings_updated";
         let pid = Uuid::from_bytes(PROP_3E_SETTINGS_BYTES).to_string();
-        check_common(&mut r, prefix, call, &space_3e, Some(12349), Some(1700004000));
-        r.check(&format!("{}: correct proposal_id", prefix), call.body["proposal_id"].as_str() == Some(pid.as_str()));
-        r.check(&format!("{}: voting_mode is 'slow'", prefix), call.body["voting_mode"].as_str() == Some("slow"));
-        r.check(&format!("{}: has settings object", prefix), call.body["settings"].is_object());
+        check_common(
+            &mut r,
+            prefix,
+            call,
+            &space_3e,
+            Some(12349),
+            Some(1700004000),
+        );
+        r.check(
+            &format!("{}: correct proposal_id", prefix),
+            call.body["proposal_id"].as_str() == Some(pid.as_str()),
+        );
+        r.check(
+            &format!("{}: voting_mode is 'slow'", prefix),
+            call.body["voting_mode"].as_str() == Some("slow"),
+        );
+        r.check(
+            &format!("{}: has settings object", prefix),
+            call.body["settings"].is_object(),
+        );
         if call.body["settings"].is_object() {
-            r.check(&format!("{}: settings.end_date", prefix), call.body["settings"]["end_date"].as_u64() == Some(1700172800));
-            r.check(&format!("{}: settings.voting_mode 'slow'", prefix), call.body["settings"]["voting_mode"].as_str() == Some("slow"));
-            r.check(&format!("{}: settings.quorum 5", prefix), call.body["settings"]["quorum"].as_u64() == Some(5));
-            r.check(&format!("{}: settings.percentage_threshold 5000000", prefix), call.body["settings"]["percentage_threshold"].as_u64() == Some(5000000));
+            r.check(
+                &format!("{}: settings.end_date", prefix),
+                call.body["settings"]["end_date"].as_u64() == Some(1700172800),
+            );
+            r.check(
+                &format!("{}: settings.voting_mode 'slow'", prefix),
+                call.body["settings"]["voting_mode"].as_str() == Some("slow"),
+            );
+            r.check(
+                &format!("{}: settings.quorum 5", prefix),
+                call.body["settings"]["quorum"].as_u64() == Some(5),
+            );
+            r.check(
+                &format!("{}: settings.percentage_threshold 5000000", prefix),
+                call.body["settings"]["percentage_threshold"].as_u64() == Some(5000000),
+            );
         }
-        r.check(&format!("{}: no proposer_id", prefix), call.body.get("proposer_id").is_none());
-        r.check(&format!("{}: no voter_id", prefix), call.body.get("voter_id").is_none());
-        r.check(&format!("{}: no actions", prefix), call.body.get("actions").is_none());
+        r.check(
+            &format!("{}: no proposer_id", prefix),
+            call.body.get("proposer_id").is_none(),
+        );
+        r.check(
+            &format!("{}: no voter_id", prefix),
+            call.body.get("voter_id").is_none(),
+        );
+        r.check(
+            &format!("{}: no actions", prefix),
+            call.body.get("actions").is_none(),
+        );
     }
 
     // --- proposal_rejected ---
-    if let Some(call) = calls_3e.iter().find(|c| c.body["event_type"].as_str() == Some("proposal_rejected")) {
+    if let Some(call) = calls_3e
+        .iter()
+        .find(|c| c.body["event_type"].as_str() == Some("proposal_rejected"))
+    {
         let prefix = "3e proposal_rejected";
         let pid = Uuid::from_bytes(PROP_3E_REJECTED_BYTES).to_string();
         let proposed_by = Uuid::from_bytes(PROPOSER_ID_BYTES).to_string();
         check_common(&mut r, prefix, call, &space_3e, None, None);
-        r.check(&format!("{}: correct proposal_id", prefix), call.body["proposal_id"].as_str() == Some(pid.as_str()));
-        r.check(&format!("{}: has proposer_id", prefix), call.body["proposer_id"].as_str() == Some(proposed_by.as_str()));
-        r.check(&format!("{}: has timestamp", prefix), call.body["timestamp"].is_number());
-        r.check(&format!("{}: no voter_id", prefix), call.body.get("voter_id").is_none());
-        r.check(&format!("{}: no vote", prefix), call.body.get("vote").is_none());
-        r.check(&format!("{}: no voting_mode", prefix), call.body.get("voting_mode").is_none());
-        r.check(&format!("{}: no actions", prefix), call.body.get("actions").is_none());
-        r.check(&format!("{}: no settings", prefix), call.body.get("settings").is_none());
+        r.check(
+            &format!("{}: correct proposal_id", prefix),
+            call.body["proposal_id"].as_str() == Some(pid.as_str()),
+        );
+        r.check(
+            &format!("{}: has proposer_id", prefix),
+            call.body["proposer_id"].as_str() == Some(proposed_by.as_str()),
+        );
+        r.check(
+            &format!("{}: has timestamp", prefix),
+            call.body["timestamp"].is_number(),
+        );
+        r.check(
+            &format!("{}: no voter_id", prefix),
+            call.body.get("voter_id").is_none(),
+        );
+        r.check(
+            &format!("{}: no vote", prefix),
+            call.body.get("vote").is_none(),
+        );
+        r.check(
+            &format!("{}: no voting_mode", prefix),
+            call.body.get("voting_mode").is_none(),
+        );
+        r.check(
+            &format!("{}: no actions", prefix),
+            call.body.get("actions").is_none(),
+        );
+        r.check(
+            &format!("{}: no settings", prefix),
+            call.body.get("settings").is_none(),
+        );
     }
 
     // --- 1-editor space: proposal_created ---
@@ -715,9 +1212,22 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
     }) {
         let prefix = "1e proposal_created";
         let pid = Uuid::from_bytes(PROP_1E_CREATED_BYTES).to_string();
-        check_common(&mut r, prefix, call, &space_1e, Some(20001), Some(1700010000));
-        r.check(&format!("{}: correct proposal_id", prefix), call.body["proposal_id"].as_str() == Some(pid.as_str()));
-        r.check(&format!("{}: correct user_space_id", prefix), call.body["user_space_id"].as_str() == Some(editor_solo.as_str()));
+        check_common(
+            &mut r,
+            prefix,
+            call,
+            &space_1e,
+            Some(20001),
+            Some(1700010000),
+        );
+        r.check(
+            &format!("{}: correct proposal_id", prefix),
+            call.body["proposal_id"].as_str() == Some(pid.as_str()),
+        );
+        r.check(
+            &format!("{}: correct user_space_id", prefix),
+            call.body["user_space_id"].as_str() == Some(editor_solo.as_str()),
+        );
     }
 
     // ===================================================================
@@ -740,6 +1250,112 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
         }),
     );
 
+    // ===================================================================
+    // Bounty event verification
+    // ===================================================================
+
+    let bounty_space = Uuid::from_bytes(BOUNTY_SPACE_BYTES).to_string();
+    let bounty_entity = Uuid::from_bytes(BOUNTY_ENTITY_BYTES).to_string();
+    let interest_rel = Uuid::from_bytes(INTEREST_RELATION_BYTES).to_string();
+    let allocated_rel = Uuid::from_bytes(ALLOCATED_RELATION_BYTES).to_string();
+    let payout_rel = Uuid::from_bytes(PAYOUT_RELATION_BYTES).to_string();
+
+    // --- bounty_interest: 2 editors × 3 webhooks = 6 calls ---
+    let interest_calls: Vec<_> = calls
+        .iter()
+        .filter(|c| c.body["event_type"].as_str() == Some("bounty_interest"))
+        .collect();
+    r.check(
+        "bounty_interest: 6 calls (2 editors x 3 webhooks)",
+        interest_calls.len() == 6,
+    );
+    if let Some(call) = interest_calls.first() {
+        r.check(
+            "bounty_interest: category is 'bounty'",
+            call.body["category"].as_str() == Some("bounty"),
+        );
+        r.check(
+            "bounty_interest: correct bounty_entity_id",
+            call.body["bounty_entity_id"].as_str() == Some(bounty_entity.as_str()),
+        );
+        r.check(
+            "bounty_interest: correct relation_id",
+            call.body["relation_id"].as_str() == Some(interest_rel.as_str()),
+        );
+        r.check(
+            "bounty_interest: has bounty_space_id",
+            call.body["bounty_space_id"].as_str() == Some(bounty_space.as_str()),
+        );
+        r.check(
+            "bounty_interest: no governance fields",
+            call.body.get("proposal_id").is_none()
+                && call.body.get("voter_id").is_none()
+                && call.body.get("proposer_id").is_none(),
+        );
+    }
+    // Each bounty editor gets exactly 3 deliveries
+    for editor_str in [&bounty_editor_1, &bounty_editor_2] {
+        let n = interest_calls
+            .iter()
+            .filter(|c| c.body["user_space_id"].as_str() == Some(editor_str.as_str()))
+            .count();
+        r.check(
+            &format!(
+                "bounty_interest: editor {}.. got 3 deliveries",
+                &editor_str[..8]
+            ),
+            n == 3,
+        );
+    }
+
+    // --- bounty_allocated: 1 curator × 3 webhooks = 3 calls ---
+    let allocated_calls: Vec<_> = calls
+        .iter()
+        .filter(|c| c.body["event_type"].as_str() == Some("bounty_allocated"))
+        .collect();
+    r.check(
+        "bounty_allocated: 3 calls (1 curator x 3 webhooks)",
+        allocated_calls.len() == 3,
+    );
+    if let Some(call) = allocated_calls.first() {
+        r.check(
+            "bounty_allocated: category is 'bounty'",
+            call.body["category"].as_str() == Some("bounty"),
+        );
+        r.check(
+            "bounty_allocated: correct relation_id",
+            call.body["relation_id"].as_str() == Some(allocated_rel.as_str()),
+        );
+        r.check(
+            "bounty_allocated: curator is recipient",
+            call.body["user_space_id"].as_str() == Some(curator_space.as_str()),
+        );
+    }
+
+    // --- bounty_payout: 1 curator × 3 webhooks = 3 calls ---
+    let payout_calls: Vec<_> = calls
+        .iter()
+        .filter(|c| c.body["event_type"].as_str() == Some("bounty_payout"))
+        .collect();
+    r.check(
+        "bounty_payout: 3 calls (1 curator x 3 webhooks)",
+        payout_calls.len() == 3,
+    );
+    if let Some(call) = payout_calls.first() {
+        r.check(
+            "bounty_payout: category is 'bounty'",
+            call.body["category"].as_str() == Some("bounty"),
+        );
+        r.check(
+            "bounty_payout: correct relation_id",
+            call.body["relation_id"].as_str() == Some(payout_rel.as_str()),
+        );
+        r.check(
+            "bounty_payout: curator is recipient",
+            call.body["user_space_id"].as_str() == Some(curator_space.as_str()),
+        );
+    }
+
     r
 }
 
@@ -750,8 +1366,7 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
 #[tokio::main]
 async fn main() {
     let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
-    let kafka_broker =
-        env::var("KAFKA_BROKER").unwrap_or_else(|_| "localhost:9092".to_string());
+    let kafka_broker = env::var("KAFKA_BROKER").unwrap_or_else(|_| "localhost:9092".to_string());
     let webhook_port: u16 = env::var("WEBHOOK_PORT")
         .unwrap_or_else(|_| "8765".to_string())
         .parse()
@@ -803,7 +1418,7 @@ async fn main() {
     produce_test_events(&kafka_broker)
         .await
         .expect("Failed to produce Kafka events");
-    println!("[3/5] Kafka events produced (7 events across 3 spaces)");
+    println!("[3/5] Kafka events produced (7 governance + 3 bounty events)");
 
     // 4. Wait for webhook calls
     // We wait for EXPECTED_CALLS, plus an extra grace period to catch false positives.
@@ -827,12 +1442,7 @@ async fn main() {
             let mut counts: HashMap<String, usize> = HashMap::new();
             for c in &calls {
                 *counts
-                    .entry(
-                        c.body["event_type"]
-                            .as_str()
-                            .unwrap_or("?")
-                            .to_string(),
-                    )
+                    .entry(c.body["event_type"].as_str().unwrap_or("?").to_string())
                     .or_default() += 1;
             }
             for (et, n) in &counts {

--- a/notification-service/e2e-tests/src/main.rs
+++ b/notification-service/e2e-tests/src/main.rs
@@ -106,6 +106,15 @@ const NUM_WEBHOOKS: usize = 3;
 // Bounty payout: 1 event × 1 curator × 3 webhooks = 3
 const EXPECTED_CALLS: usize = 54 + 3 + 6 + 3 + 3;
 
+const GOVERNANCE_EVENT_TYPES: &[&str] = &[
+    "proposal_created",
+    "proposal_updated",
+    "proposal_voted",
+    "proposal_executed",
+    "proposal_settings_updated",
+    "proposal_rejected",
+];
+
 const ALL_EVENT_TYPES: &[&str] = &[
     "proposal_created",
     "proposal_updated",
@@ -778,8 +787,8 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
         calls_3e.len() == 54,
     );
 
-    // Per event-type fan-out
-    for et in ALL_EVENT_TYPES {
+    // Per governance event-type fan-out (3-editor space)
+    for et in GOVERNANCE_EVENT_TYPES {
         let et_calls: Vec<_> = calls_3e
             .iter()
             .filter(|c| c.body["event_type"].as_str() == Some(et))

--- a/notification-service/notification-indexer/src/consumer.rs
+++ b/notification-service/notification-indexer/src/consumer.rs
@@ -1,4 +1,4 @@
-//! Kafka consumer for the space.governance topic.
+//! Kafka consumers for the space.governance and knowledge.edits topics.
 
 use hermes_kafka::get_topic_prefix;
 use prost::Message;
@@ -15,6 +15,9 @@ use crate::error::IndexerError;
 
 /// Base topic for governance events
 const GOVERNANCE_TOPIC: &str = "space.governance";
+
+/// Base topic for knowledge edit events
+const KNOWLEDGE_EDITS_TOPIC: &str = "knowledge.edits";
 
 /// Kafka consumer for governance events.
 pub struct KafkaConsumer {
@@ -169,4 +172,115 @@ pub fn parse_proposal_settings_updated(
 ) -> Result<hermes_schema::pb::governance::HermesProposalSettingsUpdated, IndexerError> {
     let msg = hermes_schema::pb::governance::HermesProposalSettingsUpdated::decode(payload)?;
     Ok(msg)
+}
+
+/// Parse a HermesEdit message from knowledge.edits Kafka payload.
+pub fn parse_hermes_edit(
+    payload: &[u8],
+) -> Result<hermes_schema::pb::knowledge::HermesEdit, IndexerError> {
+    let msg = hermes_schema::pb::knowledge::HermesEdit::decode(payload)?;
+    Ok(msg)
+}
+
+/// Kafka consumer for knowledge edit events.
+///
+/// Follows the same manual-commit pattern as `KafkaConsumer` but subscribes
+/// to the `knowledge.edits` topic.
+pub struct KnowledgeEditsConsumer {
+    consumer: StreamConsumer<DefaultConsumerContext>,
+    topic: String,
+}
+
+impl KnowledgeEditsConsumer {
+    /// Create a new knowledge edits consumer.
+    ///
+    /// Uses a separate consumer group suffix (`-knowledge-edits`) to avoid
+    /// conflicting with the governance consumer's offsets.
+    pub fn new(brokers: &str, group_id: &str) -> Result<Self, IndexerError> {
+        let ke_group_id = format!("{}-knowledge-edits", group_id);
+
+        let mut config = ClientConfig::new();
+        config
+            .set("bootstrap.servers", brokers)
+            .set("group.id", &ke_group_id)
+            .set("enable.auto.commit", "false")
+            .set("auto.offset.reset", "earliest")
+            .set("session.timeout.ms", "6000")
+            .set("fetch.max.bytes", "52428800")
+            .set("max.partition.fetch.bytes", "1048576")
+            .set("message.max.bytes", "10485760")
+            .set("max.poll.interval.ms", "300000");
+
+        // Optional SASL/SSL configuration
+        if let Ok(username) = env::var("KAFKA_USERNAME") {
+            config.set("security.protocol", "SASL_SSL");
+            config.set("sasl.mechanisms", "PLAIN");
+            config.set("sasl.username", &username);
+
+            let password = env::var("KAFKA_PASSWORD").map_err(|_| {
+                IndexerError::Config(
+                    "KAFKA_PASSWORD must be set when KAFKA_USERNAME is configured".into(),
+                )
+            })?;
+            config.set("sasl.password", &password);
+        }
+
+        // Optional custom CA certificate
+        if let Ok(ca_pem) = env::var("KAFKA_SSL_CA_PEM") {
+            config.set("ssl.ca.pem", &ca_pem);
+        }
+
+        let consumer: StreamConsumer = config.create()?;
+
+        let prefix = get_topic_prefix();
+        let topic = format!("{}{}", prefix, KNOWLEDGE_EDITS_TOPIC);
+
+        info!(
+            brokers = %brokers,
+            group_id = %ke_group_id,
+            topic = %topic,
+            "Created knowledge edits consumer"
+        );
+
+        Ok(Self { consumer, topic })
+    }
+
+    /// Subscribe to the knowledge.edits topic.
+    pub fn subscribe(&self) -> Result<(), IndexerError> {
+        self.consumer.subscribe(&[&self.topic])?;
+        info!(topic = %self.topic, "Subscribed to knowledge.edits topic");
+        Ok(())
+    }
+
+    /// Get a message stream from the consumer.
+    pub fn stream(&self) -> rdkafka::consumer::MessageStream<'_, DefaultConsumerContext> {
+        self.consumer.stream()
+    }
+
+    /// Commit a message offset.
+    pub fn commit_message(
+        &self,
+        topic: &str,
+        partition: i32,
+        offset: i64,
+    ) -> Result<(), IndexerError> {
+        let mut tpl = TopicPartitionList::new();
+        tpl.add_partition_offset(topic, partition, rdkafka::Offset::Offset(offset + 1))?;
+
+        self.consumer
+            .commit(&tpl, rdkafka::consumer::CommitMode::Async)?;
+
+        debug!(topic = %topic, partition = partition, offset = offset, "Committed knowledge edits offset");
+        Ok(())
+    }
+
+    /// Flush any pending async offset commits synchronously.
+    pub fn flush_commits(&self) {
+        if let Err(e) = self
+            .consumer
+            .commit_consumer_state(rdkafka::consumer::CommitMode::Sync)
+        {
+            error!(error = %e, "Failed to flush knowledge edits commits during shutdown");
+        }
+    }
 }

--- a/notification-service/notification-indexer/src/consumer.rs
+++ b/notification-service/notification-indexer/src/consumer.rs
@@ -194,15 +194,13 @@ pub struct KnowledgeEditsConsumer {
 impl KnowledgeEditsConsumer {
     /// Create a new knowledge edits consumer.
     ///
-    /// Uses a separate consumer group suffix (`-knowledge-edits`) to avoid
-    /// conflicting with the governance consumer's offsets.
+    /// Uses a separate consumer group (configured via KAFKA_GROUP_ID_KNOWLEDGE_EDITS)
+    /// to avoid conflicting with the governance consumer's offsets.
     pub fn new(brokers: &str, group_id: &str) -> Result<Self, IndexerError> {
-        let ke_group_id = format!("{}-knowledge-edits", group_id);
-
         let mut config = ClientConfig::new();
         config
             .set("bootstrap.servers", brokers)
-            .set("group.id", &ke_group_id)
+            .set("group.id", group_id)
             .set("enable.auto.commit", "false")
             .set("auto.offset.reset", "earliest")
             .set("session.timeout.ms", "6000")
@@ -237,7 +235,7 @@ impl KnowledgeEditsConsumer {
 
         info!(
             brokers = %brokers,
-            group_id = %ke_group_id,
+            group_id = %group_id,
             topic = %topic,
             "Created knowledge edits consumer"
         );

--- a/notification-service/notification-indexer/src/main.rs
+++ b/notification-service/notification-indexer/src/main.rs
@@ -473,7 +473,7 @@ async fn async_main() -> Result<(), IndexerError> {
                                         | NotificationEventType::BountyPayout => {
                                             // Resolve curator_space_id if nil
                                             if info.curator_space_id.is_nil() {
-                                                match ke_stor.lookup_entity_space(info.bounty_entity_id).await {
+                                                match ke_stor.lookup_entity_space(info.curator_entity_id).await {
                                                     Ok(Some(space_id)) => {
                                                         info.curator_space_id = space_id;
                                                     }

--- a/notification-service/notification-indexer/src/main.rs
+++ b/notification-service/notification-indexer/src/main.rs
@@ -16,14 +16,17 @@ use rdkafka::message::Message;
 use rdkafka::Timestamp;
 
 use notification_indexer::consumer::{
-    get_event_type, parse_proposal_created, parse_proposal_executed,
+    get_event_type, parse_hermes_edit, parse_proposal_created, parse_proposal_executed,
     parse_proposal_settings_updated, parse_proposal_updated, parse_proposal_voted, KafkaConsumer,
+    KnowledgeEditsConsumer,
 };
 use notification_indexer::consumer_lag::LagMonitor;
 use notification_indexer::error::IndexerError;
 use notification_indexer::models::{
-    build_rejection_event, handle_proposal_created, handle_proposal_executed,
-    handle_proposal_settings_updated, handle_proposal_updated, handle_proposal_voted,
+    build_rejection_event, extract_bounty_relations, handle_bounty_allocated,
+    handle_bounty_interest, handle_bounty_payout, handle_proposal_created,
+    handle_proposal_executed, handle_proposal_settings_updated, handle_proposal_updated,
+    handle_proposal_voted, BountyConfig, NotificationEventType,
 };
 use notification_indexer::storage::Storage;
 
@@ -162,9 +165,27 @@ async fn async_main() -> Result<(), IndexerError> {
         }
     };
 
+    // Knowledge edits consumer (optional, default disabled)
+    let knowledge_edits_enabled = env::var("KNOWLEDGE_EDITS_ENABLED")
+        .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
+        .unwrap_or(false);
+
+    if !knowledge_edits_enabled {
+        info!("Knowledge edits consumer disabled (set KNOWLEDGE_EDITS_ENABLED=true to enable)");
+    }
+
+    let bounty_config = BountyConfig::new();
+    info!(
+        interest = %bounty_config.interest_type_id,
+        allocated = %bounty_config.allocated_type_id,
+        payout = %bounty_config.payout_type_id,
+        "Bounty relation type config"
+    );
+
     // Set up shutdown signal
     let (shutdown_tx, mut shutdown_rx) = tokio::sync::broadcast::channel::<()>(1);
     let mut shutdown_rx2 = shutdown_tx.subscribe();
+    let mut shutdown_rx3 = shutdown_tx.subscribe();
 
     let _signal_handle = tokio::spawn(async move {
         tokio::signal::ctrl_c().await.ok();
@@ -252,6 +273,294 @@ async fn async_main() -> Result<(), IndexerError> {
             }
         }
     });
+
+    // Spawn knowledge edits consumer task (if enabled)
+    let ke_handle: Option<tokio::task::JoinHandle<()>> = if knowledge_edits_enabled {
+        let ke_kafka_broker = kafka_broker.clone();
+        let ke_kafka_group_id = kafka_group_id.clone();
+        let ke_bd = block_delay;
+        let ke_bd_timeout = block_delay_timeout_secs;
+        let ke_min_age = min_age_secs;
+        let ke_stor = Storage::new(storage.pool().clone());
+        let ke_cfg = bounty_config;
+
+        Some(tokio::spawn(async move {
+            // Create consumer inside the task so it's fully owned
+            let kec = match KnowledgeEditsConsumer::new(&ke_kafka_broker, &ke_kafka_group_id) {
+                Ok(c) => c,
+                Err(e) => {
+                    error!(error = %e, "Failed to create knowledge edits consumer");
+                    return;
+                }
+            };
+            if let Err(e) = kec.subscribe() {
+                error!(error = %e, "Failed to subscribe to knowledge.edits");
+                return;
+            }
+
+            let mut ke_stream = kec.stream();
+            let mut ke_processed: u64 = 0;
+            let mut ke_errors: u64 = 0;
+
+            info!("Knowledge edits consumer loop started");
+
+            loop {
+                tokio::select! {
+                    _ = shutdown_rx3.recv() => {
+                        info!("Knowledge edits consumer shutting down");
+                        break;
+                    }
+                    message = ke_stream.next() => {
+                        match message {
+                            Some(Ok(msg)) => {
+                                let topic = msg.topic().to_string();
+                                let partition = msg.partition();
+                                let offset = msg.offset();
+
+                                // Skip old messages
+                                if ke_min_age > 0 {
+                                    let now_ms = SystemTime::now()
+                                        .duration_since(UNIX_EPOCH)
+                                        .map(|d| d.as_millis() as i64)
+                                        .unwrap_or(0);
+                                    let too_old = match msg.timestamp() {
+                                        Timestamp::CreateTime(ts) | Timestamp::LogAppendTime(ts) => {
+                                            (now_ms - ts) > (ke_min_age as i64 * 1000)
+                                        }
+                                        Timestamp::NotAvailable => false,
+                                    };
+                                    if too_old {
+                                        debug!(
+                                            partition = partition,
+                                            offset = offset,
+                                            "Skipping old knowledge edit (older than {}s)",
+                                            ke_min_age
+                                        );
+                                        if let Err(e) = kec.commit_message(&topic, partition, offset) {
+                                            error!(error = %e, "Failed to commit knowledge edits offset");
+                                        }
+                                        continue;
+                                    }
+                                }
+
+                                let Some(payload) = msg.payload() else {
+                                    if let Err(e) = kec.commit_message(&topic, partition, offset) {
+                                        error!(error = %e, "Failed to commit knowledge edits offset");
+                                    }
+                                    continue;
+                                };
+
+                                // Parse HermesEdit protobuf
+                                let hermes_edit = match parse_hermes_edit(payload) {
+                                    Ok(edit) => edit,
+                                    Err(e) => {
+                                        // Parse error — commit to avoid poison pill
+                                        warn!(
+                                            error = %e,
+                                            partition = partition,
+                                            offset = offset,
+                                            "Failed to parse HermesEdit, committing to skip"
+                                        );
+                                        ke_errors += 1;
+                                        if let Err(e) = kec.commit_message(&topic, partition, offset) {
+                                            error!(error = %e, "Failed to commit knowledge edits offset");
+                                        }
+                                        continue;
+                                    }
+                                };
+
+                                // Extract bounty relations from GRC-20 payload
+                                let relations = match extract_bounty_relations(&hermes_edit, &ke_cfg) {
+                                    Ok(rels) => rels,
+                                    Err(e) => {
+                                        // Decode error — commit to avoid poison pill
+                                        warn!(
+                                            error = %e,
+                                            partition = partition,
+                                            offset = offset,
+                                            "Failed to extract bounty relations, committing to skip"
+                                        );
+                                        ke_errors += 1;
+                                        if let Err(e) = kec.commit_message(&topic, partition, offset) {
+                                            error!(error = %e, "Failed to commit knowledge edits offset");
+                                        }
+                                        continue;
+                                    }
+                                };
+
+                                if relations.is_empty() {
+                                    // No bounty relations in this edit — commit and continue
+                                    if let Err(e) = kec.commit_message(&topic, partition, offset) {
+                                        error!(error = %e, "Failed to commit knowledge edits offset");
+                                    }
+                                    continue;
+                                }
+
+                                let mut all_ok = true;
+                                for (mut info, event_type) in relations {
+                                    // Block delay: wait for kg-indexer catchup
+                                    if ke_bd > 0 {
+                                        wait_for_kg_catchup(
+                                            &ke_stor,
+                                            info.block_number,
+                                            ke_bd,
+                                            ke_bd_timeout,
+                                        )
+                                        .await;
+                                    }
+
+                                    match event_type {
+                                        NotificationEventType::BountyInterest => {
+                                            // Resolve bounty_space_id from DB
+                                            match ke_stor.lookup_bounty_space(info.bounty_entity_id).await {
+                                                Ok(Some(space_id)) => {
+                                                    info.bounty_space_id = space_id;
+                                                }
+                                                Ok(None) => {
+                                                    warn!(
+                                                        bounty_entity_id = %info.bounty_entity_id,
+                                                        "Could not resolve bounty space, skipping interest notification"
+                                                    );
+                                                    continue;
+                                                }
+                                                Err(e) => {
+                                                    error!(error = %e, "DB error looking up bounty space, will retry");
+                                                    ke_errors += 1;
+                                                    all_ok = false;
+                                                    break;
+                                                }
+                                            }
+
+                                            let mut event = handle_bounty_interest(&info);
+                                            enrich_payload(&ke_stor, &mut event, info.bounty_space_id).await;
+
+                                            let editors = match ke_stor.find_editors_for_space(info.bounty_space_id).await {
+                                                Ok(eds) => eds,
+                                                Err(e) => {
+                                                    error!(error = %e, "DB error looking up editors for bounty interest, will retry");
+                                                    ke_errors += 1;
+                                                    all_ok = false;
+                                                    break;
+                                                }
+                                            };
+
+                                            if editors.is_empty() {
+                                                ke_processed += 1;
+                                                continue;
+                                            }
+
+                                            match ke_stor.insert_notifications_for_editors(&event, &editors).await {
+                                                Ok(count) => {
+                                                    if count > 0 {
+                                                        info!(
+                                                            event_type = "bounty_interest",
+                                                            editors = editors.len(),
+                                                            inserted = count,
+                                                            "Inserted bounty interest notifications"
+                                                        );
+                                                    }
+                                                    ke_processed += 1;
+                                                }
+                                                Err(e) => {
+                                                    error!(error = %e, "DB error inserting bounty interest notifications, will retry");
+                                                    ke_errors += 1;
+                                                    all_ok = false;
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                        NotificationEventType::BountyAllocated
+                                        | NotificationEventType::BountyPayout => {
+                                            // Resolve curator_space_id if nil
+                                            if info.curator_space_id.is_nil() {
+                                                match ke_stor.lookup_entity_space(info.bounty_entity_id).await {
+                                                    Ok(Some(space_id)) => {
+                                                        info.curator_space_id = space_id;
+                                                    }
+                                                    Ok(None) => {
+                                                        warn!(
+                                                            bounty_entity_id = %info.bounty_entity_id,
+                                                            event_type = %event_type.as_str(),
+                                                            "Could not resolve curator space, skipping notification"
+                                                        );
+                                                        continue;
+                                                    }
+                                                    Err(e) => {
+                                                        error!(error = %e, "DB error looking up curator space, will retry");
+                                                        ke_errors += 1;
+                                                        all_ok = false;
+                                                        break;
+                                                    }
+                                                }
+                                            }
+
+                                            let mut event = if event_type == NotificationEventType::BountyAllocated {
+                                                handle_bounty_allocated(&info)
+                                            } else {
+                                                handle_bounty_payout(&info)
+                                            };
+                                            enrich_payload(&ke_stor, &mut event, info.bounty_space_id).await;
+
+                                            match ke_stor.insert_notification_for_user(&event, info.curator_space_id).await {
+                                                Ok(count) => {
+                                                    if count > 0 {
+                                                        info!(
+                                                            event_type = %event_type.as_str(),
+                                                            curator_space_id = %info.curator_space_id,
+                                                            inserted = count,
+                                                            "Inserted bounty notification for curator"
+                                                        );
+                                                    }
+                                                    ke_processed += 1;
+                                                }
+                                                Err(e) => {
+                                                    error!(
+                                                        error = %e,
+                                                        event_type = %event_type.as_str(),
+                                                        "DB error inserting bounty notification, will retry"
+                                                    );
+                                                    ke_errors += 1;
+                                                    all_ok = false;
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                        _ => {
+                                            continue;
+                                        }
+                                    }
+                                }
+
+                                // Only commit offset if all relations in the edit were processed successfully.
+                                // On DB error: don't commit — retry on restart.
+                                if all_ok {
+                                    if let Err(e) = kec.commit_message(&topic, partition, offset) {
+                                        error!(error = %e, "Failed to commit knowledge edits offset");
+                                    }
+                                }
+                            }
+                            Some(Err(e)) => {
+                                error!(error = %e, "Knowledge edits Kafka error");
+                            }
+                            None => {
+                                info!("Knowledge edits stream ended");
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
+            kec.flush_commits();
+            info!(
+                processed = ke_processed,
+                errors = ke_errors,
+                "Knowledge edits consumer stopped"
+            );
+        }))
+    } else {
+        None
+    };
 
     // Main Kafka consumer loop
     let mut stream = consumer.stream();
@@ -509,6 +818,17 @@ async fn async_main() -> Result<(), IndexerError> {
         Ok(Err(e)) => warn!(error = %e, "Rejection poller task failed"),
         Err(_) => {
             warn!("Rejection poller did not stop within 5s, aborting");
+        }
+    }
+
+    // Wait for knowledge edits consumer to finish (if enabled)
+    if let Some(handle) = ke_handle {
+        match tokio::time::timeout(tokio::time::Duration::from_secs(5), handle).await {
+            Ok(Ok(())) => info!("Knowledge edits consumer stopped"),
+            Ok(Err(e)) => warn!(error = %e, "Knowledge edits consumer task failed"),
+            Err(_) => {
+                warn!("Knowledge edits consumer did not stop within 5s, aborting");
+            }
         }
     }
 

--- a/notification-service/notification-indexer/src/main.rs
+++ b/notification-service/notification-indexer/src/main.rs
@@ -96,8 +96,10 @@ async fn async_main() -> Result<(), IndexerError> {
     let database_url = env::var("DATABASE_URL")
         .map_err(|_| IndexerError::Config("DATABASE_URL not set".into()))?;
     let kafka_broker = env::var("KAFKA_BROKER").unwrap_or_else(|_| "localhost:9092".to_string());
-    let kafka_group_id =
-        env::var("KAFKA_GROUP_ID").unwrap_or_else(|_| "notification-indexer".to_string());
+    let kafka_group_id_governance = env::var("KAFKA_GROUP_ID_GOVERNANCE")
+        .unwrap_or_else(|_| "notification-indexer-governance".to_string());
+    let kafka_group_id_ke = env::var("KAFKA_GROUP_ID_KNOWLEDGE_EDITS")
+        .unwrap_or_else(|_| "notification-indexer-knowledge-edits".to_string());
 
     let rejection_poll_interval_secs: u64 = env::var("REJECTION_POLL_INTERVAL_SECS")
         .ok()
@@ -142,7 +144,7 @@ async fn async_main() -> Result<(), IndexerError> {
         notification_indexer::health::start_health_server(storage.pool().clone(), health_port);
 
     // Initialize Kafka consumer
-    let consumer = KafkaConsumer::new(&kafka_broker, &kafka_group_id)?;
+    let consumer = KafkaConsumer::new(&kafka_broker, &kafka_group_id_governance)?;
     consumer.subscribe()?;
 
     // Start background lag monitor (dedicated thread, never blocks async runtime)
@@ -154,7 +156,7 @@ async fn async_main() -> Result<(), IndexerError> {
         .unwrap_or(60);
     let lag_monitor = match LagMonitor::start(
         &kafka_broker,
-        &kafka_group_id,
+        &kafka_group_id_governance,
         governance_topic,
         lag_poll_secs,
     ) {
@@ -271,7 +273,7 @@ async fn async_main() -> Result<(), IndexerError> {
     // Spawn knowledge edits consumer task
     let ke_handle: tokio::task::JoinHandle<()> = {
         let ke_kafka_broker = kafka_broker.clone();
-        let ke_kafka_group_id = kafka_group_id.clone();
+        let ke_kafka_group_id = kafka_group_id_ke.clone();
         let ke_bd = block_delay;
         let ke_bd_timeout = block_delay_timeout_secs;
         let ke_min_age = min_age_secs;

--- a/notification-service/notification-indexer/src/main.rs
+++ b/notification-service/notification-indexer/src/main.rs
@@ -283,6 +283,10 @@ async fn async_main() -> Result<(), IndexerError> {
         let ke_min_age = min_age_secs;
         let ke_stor = Storage::new(storage.pool().clone());
         let ke_cfg = bounty_config;
+        let ke_heartbeat_secs: u64 = env::var("HEARTBEAT_INTERVAL_SECS")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(60);
 
         Some(tokio::spawn(async move {
             // Create consumer inside the task so it's fully owned
@@ -301,6 +305,11 @@ async fn async_main() -> Result<(), IndexerError> {
             let mut ke_stream = kec.stream();
             let mut ke_processed: u64 = 0;
             let mut ke_errors: u64 = 0;
+            let mut ke_skipped: u64 = 0;
+
+            let mut ke_heartbeat =
+                tokio::time::interval(tokio::time::Duration::from_secs(ke_heartbeat_secs));
+            ke_heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
             info!("Knowledge edits consumer loop started");
 
@@ -309,6 +318,14 @@ async fn async_main() -> Result<(), IndexerError> {
                     _ = shutdown_rx3.recv() => {
                         info!("Knowledge edits consumer shutting down");
                         break;
+                    }
+                    _ = ke_heartbeat.tick() => {
+                        info!(
+                            processed = ke_processed,
+                            errors = ke_errors,
+                            skipped = ke_skipped,
+                            "Knowledge edits heartbeat"
+                        );
                     }
                     message = ke_stream.next() => {
                         match message {
@@ -396,61 +413,58 @@ async fn async_main() -> Result<(), IndexerError> {
                                     continue;
                                 }
 
-                                let mut all_ok = true;
-                                for (mut info, event_type) in relations {
-                                    // Block delay: wait for kg-indexer catchup
-                                    if ke_bd > 0 {
-                                        wait_for_kg_catchup(
-                                            &ke_stor,
-                                            info.block_number,
-                                            ke_bd,
-                                            ke_bd_timeout,
-                                        )
-                                        .await;
-                                    }
+                                // Process all bounty relations in this edit.
+                                // Returns Err on DB errors (don't commit — retry on restart).
+                                // Returns Ok on success or non-retryable skips.
+                                let process_result: Result<(), ()> = async {
+                                    for (mut info, event_type) in relations {
+                                        // Block delay: wait for kg-indexer catchup
+                                        if ke_bd > 0 {
+                                            wait_for_kg_catchup(
+                                                &ke_stor,
+                                                info.block_number,
+                                                ke_bd,
+                                                ke_bd_timeout,
+                                            )
+                                            .await;
+                                        }
 
-                                    match event_type {
-                                        NotificationEventType::BountyInterest => {
-                                            // Resolve bounty_space_id from DB
-                                            match ke_stor.lookup_bounty_space(info.bounty_entity_id).await {
-                                                Ok(Some(space_id)) => {
-                                                    info.bounty_space_id = space_id;
+                                        match event_type {
+                                            NotificationEventType::BountyInterest => {
+                                                // Resolve bounty_space_id from DB
+                                                match ke_stor.lookup_bounty_space(info.bounty_entity_id).await {
+                                                    Ok(Some(space_id)) => {
+                                                        info.bounty_space_id = space_id;
+                                                    }
+                                                    Ok(None) => {
+                                                        warn!(
+                                                            bounty_entity_id = %info.bounty_entity_id,
+                                                            "Could not resolve bounty space, skipping interest notification"
+                                                        );
+                                                        ke_skipped += 1;
+                                                        continue;
+                                                    }
+                                                    Err(e) => {
+                                                        error!(error = %e, "DB error looking up bounty space, will retry");
+                                                        ke_errors += 1;
+                                                        return Err(());
+                                                    }
                                                 }
-                                                Ok(None) => {
-                                                    warn!(
-                                                        bounty_entity_id = %info.bounty_entity_id,
-                                                        "Could not resolve bounty space, skipping interest notification"
-                                                    );
-                                                    continue;
-                                                }
-                                                Err(e) => {
-                                                    error!(error = %e, "DB error looking up bounty space, will retry");
-                                                    ke_errors += 1;
-                                                    all_ok = false;
-                                                    break;
-                                                }
-                                            }
 
-                                            let mut event = handle_bounty_interest(&info);
-                                            enrich_payload(&ke_stor, &mut event, info.bounty_space_id).await;
+                                                let mut event = handle_bounty_interest(&info);
+                                                enrich_payload(&ke_stor, &mut event, info.bounty_space_id).await;
 
-                                            let editors = match ke_stor.find_editors_for_space(info.bounty_space_id).await {
-                                                Ok(eds) => eds,
-                                                Err(e) => {
+                                                let editors = ke_stor.find_editors_for_space(info.bounty_space_id).await.map_err(|e| {
                                                     error!(error = %e, "DB error looking up editors for bounty interest, will retry");
                                                     ke_errors += 1;
-                                                    all_ok = false;
-                                                    break;
+                                                })?;
+
+                                                if editors.is_empty() {
+                                                    ke_processed += 1;
+                                                    continue;
                                                 }
-                                            };
 
-                                            if editors.is_empty() {
-                                                ke_processed += 1;
-                                                continue;
-                                            }
-
-                                            match ke_stor.insert_notifications_for_editors(&event, &editors).await {
-                                                Ok(count) => {
+                                                ke_stor.insert_notifications_for_editors(&event, &editors).await.map(|count| {
                                                     if count > 0 {
                                                         info!(
                                                             event_type = "bounty_interest",
@@ -460,49 +474,45 @@ async fn async_main() -> Result<(), IndexerError> {
                                                         );
                                                     }
                                                     ke_processed += 1;
-                                                }
-                                                Err(e) => {
+                                                }).map_err(|e| {
                                                     error!(error = %e, "DB error inserting bounty interest notifications, will retry");
                                                     ke_errors += 1;
-                                                    all_ok = false;
-                                                    break;
-                                                }
+                                                })?;
                                             }
-                                        }
-                                        NotificationEventType::BountyAllocated
-                                        | NotificationEventType::BountyPayout => {
-                                            // Resolve curator_space_id if nil
-                                            if info.curator_space_id.is_nil() {
-                                                match ke_stor.lookup_entity_space(info.curator_entity_id).await {
-                                                    Ok(Some(space_id)) => {
-                                                        info.curator_space_id = space_id;
-                                                    }
-                                                    Ok(None) => {
-                                                        warn!(
-                                                            bounty_entity_id = %info.bounty_entity_id,
-                                                            event_type = %event_type.as_str(),
-                                                            "Could not resolve curator space, skipping notification"
-                                                        );
-                                                        continue;
-                                                    }
-                                                    Err(e) => {
-                                                        error!(error = %e, "DB error looking up curator space, will retry");
-                                                        ke_errors += 1;
-                                                        all_ok = false;
-                                                        break;
+                                            NotificationEventType::BountyAllocated
+                                            | NotificationEventType::BountyPayout => {
+                                                // Resolve curator_space_id if nil
+                                                if info.curator_space_id.is_nil() {
+                                                    match ke_stor.lookup_entity_space(info.curator_entity_id).await {
+                                                        Ok(Some(space_id)) => {
+                                                            info.curator_space_id = space_id;
+                                                        }
+                                                        Ok(None) => {
+                                                            warn!(
+                                                                bounty_entity_id = %info.bounty_entity_id,
+                                                                curator_entity_id = %info.curator_entity_id,
+                                                                event_type = %event_type.as_str(),
+                                                                "Could not resolve curator space, skipping notification"
+                                                            );
+                                                            ke_skipped += 1;
+                                                            continue;
+                                                        }
+                                                        Err(e) => {
+                                                            error!(error = %e, "DB error looking up curator space, will retry");
+                                                            ke_errors += 1;
+                                                            return Err(());
+                                                        }
                                                     }
                                                 }
-                                            }
 
-                                            let mut event = if event_type == NotificationEventType::BountyAllocated {
-                                                handle_bounty_allocated(&info)
-                                            } else {
-                                                handle_bounty_payout(&info)
-                                            };
-                                            enrich_payload(&ke_stor, &mut event, info.bounty_space_id).await;
+                                                let mut event = if event_type == NotificationEventType::BountyAllocated {
+                                                    handle_bounty_allocated(&info)
+                                                } else {
+                                                    handle_bounty_payout(&info)
+                                                };
+                                                enrich_payload(&ke_stor, &mut event, info.bounty_space_id).await;
 
-                                            match ke_stor.insert_notification_for_user(&event, info.curator_space_id).await {
-                                                Ok(count) => {
+                                                ke_stor.insert_notification_for_user(&event, info.curator_space_id).await.map(|count| {
                                                     if count > 0 {
                                                         info!(
                                                             event_type = %event_type.as_str(),
@@ -512,28 +522,26 @@ async fn async_main() -> Result<(), IndexerError> {
                                                         );
                                                     }
                                                     ke_processed += 1;
-                                                }
-                                                Err(e) => {
+                                                }).map_err(|e| {
                                                     error!(
                                                         error = %e,
                                                         event_type = %event_type.as_str(),
                                                         "DB error inserting bounty notification, will retry"
                                                     );
                                                     ke_errors += 1;
-                                                    all_ok = false;
-                                                    break;
-                                                }
+                                                })?;
+                                            }
+                                            _ => {
+                                                continue;
                                             }
                                         }
-                                        _ => {
-                                            continue;
-                                        }
                                     }
-                                }
+                                    Ok(())
+                                }.await;
 
-                                // Only commit offset if all relations in the edit were processed successfully.
-                                // On DB error: don't commit — retry on restart.
-                                if all_ok {
+                                // Only commit offset if all relations processed successfully.
+                                // On DB error (Err): don't commit — retry on restart.
+                                if process_result.is_ok() {
                                     if let Err(e) = kec.commit_message(&topic, partition, offset) {
                                         error!(error = %e, "Failed to commit knowledge edits offset");
                                     }

--- a/notification-service/notification-indexer/src/main.rs
+++ b/notification-service/notification-indexer/src/main.rs
@@ -1,10 +1,13 @@
 //! Notification indexer entry point.
 //!
-//! Two concurrent tasks:
-//! 1. Kafka consumer — subscribes to `space.governance`, processes all governance
+//! Three concurrent tasks:
+//! 1. Governance consumer — subscribes to `space.governance`, processes all governance
 //!    events (PROPOSAL_CREATED, PROPOSAL_UPDATED, PROPOSAL_VOTED,
 //!    PROPOSAL_EXECUTED, PROPOSAL_SETTINGS_UPDATED) and writes to the notification outbox.
-//! 2. Rejection poller — every 60s, finds proposals that expired without execution
+//! 2. Knowledge edits consumer — subscribes to `knowledge.edits`, decodes GRC-20
+//!    payloads, detects bounty-related CreateRelation operations (interest, allocated,
+//!    payout) and writes to the notification outbox.
+//! 3. Rejection poller — every 60s, finds proposals that expired without execution
 //!    and writes rejection notifications.
 
 use std::env;
@@ -165,15 +168,6 @@ async fn async_main() -> Result<(), IndexerError> {
         }
     };
 
-    // Knowledge edits consumer (optional, default disabled)
-    let knowledge_edits_enabled = env::var("KNOWLEDGE_EDITS_ENABLED")
-        .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
-        .unwrap_or(false);
-
-    if !knowledge_edits_enabled {
-        info!("Knowledge edits consumer disabled (set KNOWLEDGE_EDITS_ENABLED=true to enable)");
-    }
-
     let bounty_config = BountyConfig::new();
     info!(
         interest = %bounty_config.interest_type_id,
@@ -274,8 +268,8 @@ async fn async_main() -> Result<(), IndexerError> {
         }
     });
 
-    // Spawn knowledge edits consumer task (if enabled)
-    let ke_handle: Option<tokio::task::JoinHandle<()>> = if knowledge_edits_enabled {
+    // Spawn knowledge edits consumer task
+    let ke_handle: tokio::task::JoinHandle<()> = {
         let ke_kafka_broker = kafka_broker.clone();
         let ke_kafka_group_id = kafka_group_id.clone();
         let ke_bd = block_delay;
@@ -288,7 +282,7 @@ async fn async_main() -> Result<(), IndexerError> {
             .and_then(|s| s.parse().ok())
             .unwrap_or(60);
 
-        Some(tokio::spawn(async move {
+        tokio::spawn(async move {
             // Create consumer inside the task so it's fully owned
             let kec = match KnowledgeEditsConsumer::new(&ke_kafka_broker, &ke_kafka_group_id) {
                 Ok(c) => c,
@@ -565,9 +559,7 @@ async fn async_main() -> Result<(), IndexerError> {
                 errors = ke_errors,
                 "Knowledge edits consumer stopped"
             );
-        }))
-    } else {
-        None
+        })
     };
 
     // Main Kafka consumer loop
@@ -829,14 +821,12 @@ async fn async_main() -> Result<(), IndexerError> {
         }
     }
 
-    // Wait for knowledge edits consumer to finish (if enabled)
-    if let Some(handle) = ke_handle {
-        match tokio::time::timeout(tokio::time::Duration::from_secs(5), handle).await {
-            Ok(Ok(())) => info!("Knowledge edits consumer stopped"),
-            Ok(Err(e)) => warn!(error = %e, "Knowledge edits consumer task failed"),
-            Err(_) => {
-                warn!("Knowledge edits consumer did not stop within 5s, aborting");
-            }
+    // Wait for knowledge edits consumer to finish
+    match tokio::time::timeout(tokio::time::Duration::from_secs(5), ke_handle).await {
+        Ok(Ok(())) => info!("Knowledge edits consumer stopped"),
+        Ok(Err(e)) => warn!(error = %e, "Knowledge edits consumer task failed"),
+        Err(_) => {
+            warn!("Knowledge edits consumer did not stop within 5s, aborting");
         }
     }
 

--- a/notification-service/notification-indexer/src/models.rs
+++ b/notification-service/notification-indexer/src/models.rs
@@ -826,6 +826,71 @@ pub fn handle_bounty_payout(info: &BountyRelationInfo) -> NotificationEvent {
     }
 }
 
+/// Extract bounty-related CreateRelation operations from a HermesEdit.
+///
+/// Decodes the GRC-20 payload, iterates over ops, and returns a list of
+/// `(BountyRelationInfo, NotificationEventType)` pairs for each matching
+/// `CreateRelation` whose `relation_type` matches a bounty type.
+pub fn extract_bounty_relations(
+    edit: &hermes_schema::pb::knowledge::HermesEdit,
+    config: &BountyConfig,
+) -> Result<Vec<(BountyRelationInfo, NotificationEventType)>, crate::error::HandlerError> {
+    use crate::error::HandlerError;
+
+    let meta = edit.meta.as_ref().ok_or(HandlerError::MissingMetadata)?;
+    let block_number = meta.block_number;
+    let sequence = u64::from(meta.sequence);
+    let timestamp = meta.created_at;
+
+    let edit_space_id = Uuid::from_slice(&edit.space_id).map_err(HandlerError::Uuid)?;
+
+    let decoded = grc_20::decode_edit(&edit.payload)
+        .map_err(|e| HandlerError::Grc20Decode(format!("{}", e)))?;
+
+    let mut results = Vec::new();
+    for op in &decoded.ops {
+        if let grc_20::Op::CreateRelation(rel) = op {
+            let rel_type_uuid = Uuid::from_bytes(rel.relation_type);
+            if let Some(event_type) = config.match_type(&rel_type_uuid) {
+                let info = match event_type {
+                    NotificationEventType::BountyInterest => {
+                        // Interest: from=curator entity, to=bounty entity
+                        // curator_space_id = HermesEdit.space_id (curator's personal space)
+                        BountyRelationInfo {
+                            relation_id: Uuid::from_bytes(rel.id),
+                            bounty_entity_id: Uuid::from_bytes(rel.to),
+                            curator_space_id: edit_space_id,
+                            bounty_space_id: Uuid::nil(), // Needs DB lookup
+                            proposal_id: None,
+                            block_number,
+                            sequence,
+                            timestamp,
+                        }
+                    }
+                    NotificationEventType::BountyAllocated
+                    | NotificationEventType::BountyPayout => {
+                        // Allocated/Payout: from=bounty/space, to=person/recipient_space
+                        let curator_space = rel.to_space.map(Uuid::from_bytes);
+                        BountyRelationInfo {
+                            relation_id: Uuid::from_bytes(rel.id),
+                            bounty_entity_id: Uuid::from_bytes(rel.from),
+                            curator_space_id: curator_space.unwrap_or(Uuid::nil()),
+                            bounty_space_id: edit_space_id,
+                            proposal_id: None,
+                            block_number,
+                            sequence,
+                            timestamp,
+                        }
+                    }
+                    _ => continue,
+                };
+                results.push((info, event_type));
+            }
+        }
+    }
+    Ok(results)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1736,5 +1801,266 @@ mod tests {
                 "bounty event should not have voting_mode"
             );
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // extract_bounty_relations()
+    // -----------------------------------------------------------------------
+
+    /// Build a minimal valid GRC-20 edit with a single CreateRelation op,
+    /// encode it, and wrap in a HermesEdit protobuf.
+    fn make_hermes_edit_with_relation(
+        relation_type: [u8; 16],
+        from: [u8; 16],
+        to: [u8; 16],
+        space_id: [u8; 16],
+        to_space: Option<[u8; 16]>,
+    ) -> hermes_schema::pb::knowledge::HermesEdit {
+        use std::borrow::Cow;
+
+        let edit = grc_20::Edit {
+            id: [0x99; 16],
+            name: Cow::Borrowed("test edit"),
+            authors: vec![[0xAA; 16]],
+            created_at: 1700000000,
+            ops: vec![grc_20::Op::CreateRelation(grc_20::CreateRelation {
+                id: [0x77; 16],
+                relation_type,
+                from,
+                from_is_value_ref: false,
+                to,
+                to_is_value_ref: false,
+                from_space: None,
+                from_version: None,
+                to_space,
+                to_version: None,
+                entity: None,
+                position: None,
+                context: None,
+            })],
+        };
+        let payload = grc_20::encode_edit(&edit).expect("encode should succeed");
+
+        hermes_schema::pb::knowledge::HermesEdit {
+            id: vec![0x88; 16],
+            name: "test".into(),
+            payload,
+            authors: vec![vec![0xAA; 16]],
+            language: None,
+            space_id: space_id.to_vec(),
+            is_canonical: true,
+            meta: Some(BlockchainMetadata {
+                block_number: 12345,
+                created_at: 1700000000,
+                created_by: vec![],
+                cursor: String::new(),
+                sequence: 3,
+                is_last: false,
+            }),
+        }
+    }
+
+    #[test]
+    fn test_extract_bounty_relations_interest() {
+        let config = BountyConfig::default();
+        let interest_bytes = config.interest_type_id.into_bytes();
+        let hermes_edit = make_hermes_edit_with_relation(
+            interest_bytes,
+            [0xCC; 16], // from = curator entity
+            [0xDD; 16], // to = bounty entity
+            [0xEE; 16], // space_id = curator's personal space
+            None,
+        );
+
+        let results = extract_bounty_relations(&hermes_edit, &config).expect("should extract");
+        assert_eq!(results.len(), 1);
+        let (info, event_type) = &results[0];
+        assert_eq!(*event_type, NotificationEventType::BountyInterest);
+        assert_eq!(info.bounty_entity_id, Uuid::from_bytes([0xDD; 16]));
+        assert_eq!(info.curator_space_id, Uuid::from_bytes([0xEE; 16]));
+        assert_eq!(info.bounty_space_id, Uuid::nil()); // needs DB lookup
+        assert_eq!(info.block_number, 12345);
+        assert_eq!(info.sequence, 3);
+    }
+
+    #[test]
+    fn test_extract_bounty_relations_allocated() {
+        let config = BountyConfig::default();
+        let allocated_bytes = config.allocated_type_id.into_bytes();
+        let hermes_edit = make_hermes_edit_with_relation(
+            allocated_bytes,
+            [0xDD; 16],       // from = bounty entity
+            [0xCC; 16],       // to = person entity
+            [0xEE; 16],       // space_id = bounty space
+            Some([0xFF; 16]), // to_space = curator personal space
+        );
+
+        let results = extract_bounty_relations(&hermes_edit, &config).expect("should extract");
+        assert_eq!(results.len(), 1);
+        let (info, event_type) = &results[0];
+        assert_eq!(*event_type, NotificationEventType::BountyAllocated);
+        assert_eq!(info.bounty_entity_id, Uuid::from_bytes([0xDD; 16]));
+        assert_eq!(info.curator_space_id, Uuid::from_bytes([0xFF; 16]));
+        assert_eq!(info.bounty_space_id, Uuid::from_bytes([0xEE; 16]));
+    }
+
+    #[test]
+    fn test_extract_bounty_relations_payout() {
+        let config = BountyConfig::default();
+        let payout_bytes = config.payout_type_id.into_bytes();
+        let hermes_edit = make_hermes_edit_with_relation(
+            payout_bytes,
+            [0xDD; 16], // from = space/bounty
+            [0xCC; 16], // to = recipient space
+            [0xEE; 16], // space_id = bounty space
+            Some([0xFF; 16]),
+        );
+
+        let results = extract_bounty_relations(&hermes_edit, &config).expect("should extract");
+        assert_eq!(results.len(), 1);
+        let (_info, event_type) = &results[0];
+        assert_eq!(*event_type, NotificationEventType::BountyPayout);
+    }
+
+    #[test]
+    fn test_extract_bounty_relations_non_bounty_returns_empty() {
+        let config = BountyConfig::default();
+        let random_type = [0x11; 16]; // not a bounty relation type
+        let hermes_edit =
+            make_hermes_edit_with_relation(random_type, [0xCC; 16], [0xDD; 16], [0xEE; 16], None);
+
+        let results = extract_bounty_relations(&hermes_edit, &config).expect("should extract");
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_extract_bounty_relations_mixed_ops() {
+        use std::borrow::Cow;
+
+        let config = BountyConfig::default();
+        let interest_bytes = config.interest_type_id.into_bytes();
+
+        // Build an edit with one bounty and one non-bounty CreateRelation
+        let edit = grc_20::Edit {
+            id: [0x99; 16],
+            name: Cow::Borrowed("mixed"),
+            authors: vec![[0xAA; 16]],
+            created_at: 1700000000,
+            ops: vec![
+                grc_20::Op::CreateRelation(grc_20::CreateRelation {
+                    id: [0x77; 16],
+                    relation_type: interest_bytes,
+                    from: [0xCC; 16],
+                    from_is_value_ref: false,
+                    to: [0xDD; 16],
+                    to_is_value_ref: false,
+                    from_space: None,
+                    from_version: None,
+                    to_space: None,
+                    to_version: None,
+                    entity: None,
+                    position: None,
+                    context: None,
+                }),
+                grc_20::Op::CreateRelation(grc_20::CreateRelation {
+                    id: [0x78; 16],
+                    relation_type: [0x11; 16], // non-bounty
+                    from: [0xCC; 16],
+                    from_is_value_ref: false,
+                    to: [0xDD; 16],
+                    to_is_value_ref: false,
+                    from_space: None,
+                    from_version: None,
+                    to_space: None,
+                    to_version: None,
+                    entity: None,
+                    position: None,
+                    context: None,
+                }),
+                grc_20::Op::CreateEntity(grc_20::CreateEntity {
+                    id: [0x79; 16],
+                    values: vec![],
+                    context: None,
+                }),
+            ],
+        };
+        let payload = grc_20::encode_edit(&edit).expect("encode should succeed");
+
+        let hermes_edit = hermes_schema::pb::knowledge::HermesEdit {
+            id: vec![0x88; 16],
+            name: "mixed".into(),
+            payload,
+            authors: vec![vec![0xAA; 16]],
+            language: None,
+            space_id: vec![0xEE; 16],
+            is_canonical: true,
+            meta: Some(BlockchainMetadata {
+                block_number: 100,
+                created_at: 1700000000,
+                created_by: vec![],
+                cursor: String::new(),
+                sequence: 0,
+                is_last: false,
+            }),
+        };
+
+        let results = extract_bounty_relations(&hermes_edit, &config).expect("should extract");
+        assert_eq!(
+            results.len(),
+            1,
+            "only the bounty relation should be extracted"
+        );
+        assert_eq!(results[0].1, NotificationEventType::BountyInterest);
+    }
+
+    #[test]
+    fn test_extract_bounty_relations_missing_metadata() {
+        let config = BountyConfig::default();
+        let hermes_edit = hermes_schema::pb::knowledge::HermesEdit {
+            id: vec![0x88; 16],
+            name: "test".into(),
+            payload: vec![],
+            authors: vec![],
+            language: None,
+            space_id: vec![0xEE; 16],
+            is_canonical: true,
+            meta: None,
+        };
+
+        let result = extract_bounty_relations(&hermes_edit, &config);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.expect_err("should fail"),
+            crate::error::HandlerError::MissingMetadata
+        ));
+    }
+
+    #[test]
+    fn test_extract_bounty_relations_invalid_payload() {
+        let config = BountyConfig::default();
+        let hermes_edit = hermes_schema::pb::knowledge::HermesEdit {
+            id: vec![0x88; 16],
+            name: "bad".into(),
+            payload: vec![0xFF, 0xFE, 0xFD], // garbage bytes
+            authors: vec![],
+            language: None,
+            space_id: vec![0xEE; 16],
+            is_canonical: true,
+            meta: Some(BlockchainMetadata {
+                block_number: 100,
+                created_at: 1700000000,
+                created_by: vec![],
+                cursor: String::new(),
+                sequence: 0,
+                is_last: false,
+            }),
+        };
+
+        let result = extract_bounty_relations(&hermes_edit, &config);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.expect_err("should fail"),
+            crate::error::HandlerError::Grc20Decode(_)
+        ));
     }
 }

--- a/notification-service/notification-indexer/src/models.rs
+++ b/notification-service/notification-indexer/src/models.rs
@@ -2069,4 +2069,229 @@ mod tests {
             crate::error::HandlerError::Grc20Decode(_)
         ));
     }
+
+    #[test]
+    fn test_extract_bounty_relations_allocated_with_to_space() {
+        let config = BountyConfig::default();
+        let curator_space = [0xCC; 16];
+        let hermes_edit = make_hermes_edit_with_relation(
+            *Uuid::parse_str(DEFAULT_ALLOCATED_TYPE_ID)
+                .expect("valid")
+                .as_bytes(),
+            [0x20; 16], // from = bounty
+            [0x30; 16], // to = curator entity
+            [0x40; 16], // edit space = bounty space
+            Some(curator_space),
+        );
+
+        let result = extract_bounty_relations(&hermes_edit, &config).expect("should succeed");
+        assert_eq!(result.len(), 1);
+        let (info, event_type) = &result[0];
+        assert_eq!(*event_type, NotificationEventType::BountyAllocated);
+        // curator_space_id should come from to_space, NOT be nil
+        assert_eq!(info.curator_space_id, Uuid::from_bytes(curator_space));
+        assert_ne!(info.curator_space_id, Uuid::nil());
+        // curator_entity_id should be rel.to
+        assert_eq!(info.curator_entity_id, Uuid::from_bytes([0x30; 16]));
+    }
+
+    #[test]
+    fn test_extract_bounty_relations_payout_with_to_space() {
+        let config = BountyConfig::default();
+        let curator_space = [0xDD; 16];
+        let hermes_edit = make_hermes_edit_with_relation(
+            *Uuid::parse_str(DEFAULT_PAYOUT_TYPE_ID)
+                .expect("valid")
+                .as_bytes(),
+            [0x20; 16],
+            [0x30; 16],
+            [0x40; 16],
+            Some(curator_space),
+        );
+
+        let result = extract_bounty_relations(&hermes_edit, &config).expect("should succeed");
+        assert_eq!(result.len(), 1);
+        let (info, event_type) = &result[0];
+        assert_eq!(*event_type, NotificationEventType::BountyPayout);
+        assert_eq!(info.curator_space_id, Uuid::from_bytes(curator_space));
+    }
+
+    #[test]
+    fn test_extract_bounty_relations_allocated_without_to_space() {
+        let config = BountyConfig::default();
+        let hermes_edit = make_hermes_edit_with_relation(
+            *Uuid::parse_str(DEFAULT_ALLOCATED_TYPE_ID)
+                .expect("valid")
+                .as_bytes(),
+            [0x20; 16],
+            [0x30; 16],
+            [0x40; 16],
+            None, // no to_space — needs DB fallback
+        );
+
+        let result = extract_bounty_relations(&hermes_edit, &config).expect("should succeed");
+        assert_eq!(result.len(), 1);
+        let (info, _) = &result[0];
+        // curator_space_id should be nil (needs DB lookup)
+        assert_eq!(info.curator_space_id, Uuid::nil());
+        // curator_entity_id should still be populated for the DB lookup
+        assert_eq!(info.curator_entity_id, Uuid::from_bytes([0x30; 16]));
+    }
+
+    #[test]
+    fn test_extract_bounty_relations_multiple_relations_in_one_edit() {
+        use std::borrow::Cow;
+        let config = BountyConfig::default();
+
+        // Build an edit with interest + allocated + a non-bounty relation
+        let interest_type = *Uuid::parse_str(DEFAULT_INTEREST_TYPE_ID)
+            .expect("valid")
+            .as_bytes();
+        let allocated_type = *Uuid::parse_str(DEFAULT_ALLOCATED_TYPE_ID)
+            .expect("valid")
+            .as_bytes();
+        let random_type = [0xEE; 16]; // non-bounty
+
+        let edit = grc_20::Edit {
+            id: [0x99; 16],
+            name: Cow::Borrowed("multi-relation edit"),
+            authors: vec![[0xAA; 16]],
+            created_at: 1700000000,
+            ops: vec![
+                grc_20::Op::CreateRelation(grc_20::CreateRelation {
+                    id: [0x01; 16],
+                    relation_type: interest_type,
+                    from: [0x10; 16], // curator
+                    from_is_value_ref: false,
+                    to: [0x20; 16], // bounty
+                    to_is_value_ref: false,
+                    from_space: None,
+                    from_version: None,
+                    to_space: None,
+                    to_version: None,
+                    entity: None,
+                    position: None,
+                    context: None,
+                }),
+                grc_20::Op::CreateRelation(grc_20::CreateRelation {
+                    id: [0x02; 16],
+                    relation_type: allocated_type,
+                    from: [0x20; 16], // bounty
+                    from_is_value_ref: false,
+                    to: [0x10; 16], // curator
+                    to_is_value_ref: false,
+                    from_space: None,
+                    from_version: None,
+                    to_space: Some([0xCC; 16]),
+                    to_version: None,
+                    entity: None,
+                    position: None,
+                    context: None,
+                }),
+                grc_20::Op::CreateRelation(grc_20::CreateRelation {
+                    id: [0x03; 16],
+                    relation_type: random_type, // non-bounty
+                    from: [0x30; 16],
+                    from_is_value_ref: false,
+                    to: [0x40; 16],
+                    to_is_value_ref: false,
+                    from_space: None,
+                    from_version: None,
+                    to_space: None,
+                    to_version: None,
+                    entity: None,
+                    position: None,
+                    context: None,
+                }),
+            ],
+        };
+        let payload = grc_20::encode_edit(&edit).expect("encode should succeed");
+
+        let hermes_edit = hermes_schema::pb::knowledge::HermesEdit {
+            id: vec![0x88; 16],
+            name: "multi".into(),
+            payload,
+            authors: vec![vec![0xAA; 16]],
+            language: None,
+            space_id: vec![0x50; 16],
+            is_canonical: true,
+            meta: Some(BlockchainMetadata {
+                block_number: 100,
+                created_at: 1700000000,
+                created_by: vec![],
+                cursor: String::new(),
+                sequence: 0,
+                is_last: false,
+            }),
+        };
+
+        let result = extract_bounty_relations(&hermes_edit, &config).expect("should succeed");
+        // Should find 2 bounty relations, not the non-bounty one
+        assert_eq!(result.len(), 2);
+
+        let types: Vec<_> = result.iter().map(|(_, t)| t.clone()).collect();
+        assert!(types.contains(&NotificationEventType::BountyInterest));
+        assert!(types.contains(&NotificationEventType::BountyAllocated));
+
+        // Verify interest has correct direction
+        let (interest_info, _) = result
+            .iter()
+            .find(|(_, t)| *t == NotificationEventType::BountyInterest)
+            .expect("interest present");
+        assert_eq!(interest_info.bounty_entity_id, Uuid::from_bytes([0x20; 16])); // to = bounty
+        assert_eq!(
+            interest_info.curator_entity_id,
+            Uuid::from_bytes([0x10; 16])
+        ); // from = curator
+
+        // Verify allocated has correct direction and to_space
+        let (alloc_info, _) = result
+            .iter()
+            .find(|(_, t)| *t == NotificationEventType::BountyAllocated)
+            .expect("allocated present");
+        assert_eq!(alloc_info.bounty_entity_id, Uuid::from_bytes([0x20; 16])); // from = bounty
+        assert_eq!(alloc_info.curator_entity_id, Uuid::from_bytes([0x10; 16])); // to = curator
+        assert_eq!(alloc_info.curator_space_id, Uuid::from_bytes([0xCC; 16])); // to_space
+    }
+
+    #[test]
+    fn test_extract_bounty_relations_edit_with_only_non_bounty_ops() {
+        use std::borrow::Cow;
+        let config = BountyConfig::default();
+
+        // CreateEntity op (not a relation at all)
+        let edit = grc_20::Edit {
+            id: [0x99; 16],
+            name: Cow::Borrowed("entity-only edit"),
+            authors: vec![],
+            created_at: 1700000000,
+            ops: vec![grc_20::Op::CreateEntity(grc_20::CreateEntity {
+                id: [0x01; 16],
+                values: vec![],
+                context: None,
+            })],
+        };
+        let payload = grc_20::encode_edit(&edit).expect("encode should succeed");
+
+        let hermes_edit = hermes_schema::pb::knowledge::HermesEdit {
+            id: vec![0x88; 16],
+            name: "entity".into(),
+            payload,
+            authors: vec![],
+            language: None,
+            space_id: vec![0x50; 16],
+            is_canonical: true,
+            meta: Some(BlockchainMetadata {
+                block_number: 100,
+                created_at: 1700000000,
+                created_by: vec![],
+                cursor: String::new(),
+                sequence: 0,
+                is_last: false,
+            }),
+        };
+
+        let result = extract_bounty_relations(&hermes_edit, &config).expect("should succeed");
+        assert!(result.is_empty());
+    }
 }

--- a/notification-service/notification-indexer/src/models.rs
+++ b/notification-service/notification-indexer/src/models.rs
@@ -1341,21 +1341,49 @@ mod tests {
         assert!(json.get("interested_user_space_id").is_none());
     }
 
+    // -----------------------------------------------------------------------
+    // Bounty config: exact UUID verification
+    // -----------------------------------------------------------------------
+
     #[test]
-    fn test_bounty_config_default() {
+    fn test_bounty_config_default_ids_are_non_nil_and_distinct() {
         let config = BountyConfig::default();
-        // All three should parse to real (non-nil) UUIDs from curator-app constants
         assert_ne!(config.interest_type_id, Uuid::nil());
         assert_ne!(config.allocated_type_id, Uuid::nil());
         assert_ne!(config.payout_type_id, Uuid::nil());
-        // Verify they are distinct
         assert_ne!(config.interest_type_id, config.allocated_type_id);
         assert_ne!(config.interest_type_id, config.payout_type_id);
         assert_ne!(config.allocated_type_id, config.payout_type_id);
     }
 
     #[test]
-    fn test_bounty_config_match_type() {
+    fn test_bounty_config_exact_uuids_match_curator_app() {
+        // These must match curator-app packages/curator-utils/src/ids.ts exactly.
+        // If any of these fail, the notification service will not detect bounty events.
+        let config = BountyConfig::default();
+        assert_eq!(
+            config.interest_type_id,
+            Uuid::parse_str("ff7e1b44-44a2-4191-8732-4e6c222afe07").expect("valid"),
+            "INTERESTED_IN_PROPERTY_ID must match curator-app"
+        );
+        assert_eq!(
+            config.allocated_type_id,
+            Uuid::parse_str("cfeb6422-23c5-4df4-b3f9-375a489d9e22").expect("valid"),
+            "ALLOCATED_PROPERTY_ID must match curator-app"
+        );
+        assert_eq!(
+            config.payout_type_id,
+            Uuid::parse_str("fddacaae-8513-8a43-ec1a-50ff71564d42").expect("valid"),
+            "PAYOUT_RECIPIENT_PROPERTY_ID must match curator-app"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Bounty config: match_type routing
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_bounty_config_match_type_routes_correctly() {
         let config = BountyConfig::default();
 
         assert_eq!(
@@ -1370,7 +1398,325 @@ mod tests {
             config.match_type(&config.payout_type_id),
             Some(NotificationEventType::BountyPayout)
         );
-        // Unknown type returns None
+    }
+
+    #[test]
+    fn test_bounty_config_match_type_returns_none_for_unknown() {
+        let config = BountyConfig::default();
         assert_eq!(config.match_type(&Uuid::from_bytes([0xFF; 16])), None);
+        assert_eq!(config.match_type(&Uuid::nil()), None);
+    }
+
+    #[test]
+    fn test_bounty_config_match_type_returns_none_for_old_interest_id() {
+        // The old hardcoded interest ID should NOT match after the fix
+        let config = BountyConfig::default();
+        let old_interest_id =
+            Uuid::parse_str("2c765cae-c1b6-4cc3-a65d-693d0a67eaeb").expect("valid");
+        assert_eq!(config.match_type(&old_interest_id), None);
+    }
+
+    #[test]
+    fn test_bounty_config_env_var_override() {
+        // Verify the env var override mechanism works by constructing manually
+        // (we can't set env vars safely in parallel tests, but we can test the
+        // parsing logic via BountyConfig::new struct construction)
+        let custom = BountyConfig {
+            interest_type_id: Uuid::from_bytes([0x01; 16]),
+            allocated_type_id: Uuid::from_bytes([0x02; 16]),
+            payout_type_id: Uuid::from_bytes([0x03; 16]),
+        };
+        assert_eq!(
+            custom.match_type(&Uuid::from_bytes([0x01; 16])),
+            Some(NotificationEventType::BountyInterest)
+        );
+        assert_eq!(
+            custom.match_type(&Uuid::from_bytes([0x02; 16])),
+            Some(NotificationEventType::BountyAllocated)
+        );
+        assert_eq!(
+            custom.match_type(&Uuid::from_bytes([0x03; 16])),
+            Some(NotificationEventType::BountyPayout)
+        );
+        // Default IDs should NOT match when overridden
+        let default_config = BountyConfig::default();
+        assert_eq!(custom.match_type(&default_config.interest_type_id), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // Bounty interest events
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_bounty_interest_payload_structure() {
+        let info = make_bounty_info();
+        let event = handle_bounty_interest(&info);
+
+        assert_eq!(event.event_type, NotificationEventType::BountyInterest);
+        assert_eq!(event.idempotency_key, "50000:7:bounty_interest");
+
+        let json = serde_json::to_value(&event.payload).expect("should serialize");
+        assert_eq!(json["event_type"], "bounty_interest");
+        assert_eq!(json["category"], "bounty");
+        assert_eq!(json["version"], 1);
+        assert_eq!(json["space_id"], info.bounty_space_id.to_string());
+        assert_eq!(json["block_number"], 50000);
+        assert_eq!(json["timestamp"], 1700010000);
+        assert_eq!(json["bounty_entity_id"], info.bounty_entity_id.to_string());
+        assert_eq!(json["relation_id"], info.relation_id.to_string());
+        assert_eq!(json["curator_space_id"], info.curator_space_id.to_string());
+        assert_eq!(json["bounty_space_id"], info.bounty_space_id.to_string());
+        // interested_user_space_id equals curator_space_id for interest events
+        assert_eq!(
+            json["interested_user_space_id"],
+            info.curator_space_id.to_string()
+        );
+    }
+
+    #[test]
+    fn test_bounty_interest_has_no_proposal_id() {
+        let info = make_bounty_info();
+        let event = handle_bounty_interest(&info);
+        let json = serde_json::to_value(&event.payload).expect("should serialize");
+        // Interest is direct publish, no DAO proposal involved
+        assert!(json.get("proposal_id").is_none());
+    }
+
+    #[test]
+    fn test_bounty_interest_has_no_governance_fields() {
+        let info = make_bounty_info();
+        let event = handle_bounty_interest(&info);
+        let json = serde_json::to_value(&event.payload).expect("should serialize");
+        assert!(json.get("voter_id").is_none());
+        assert!(json.get("proposer_id").is_none());
+        assert!(json.get("vote").is_none());
+        assert!(json.get("actions").is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Bounty allocation events
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_bounty_allocated_payload_structure() {
+        let mut info = make_bounty_info();
+        info.proposal_id = Some(Uuid::from_bytes([0x50; 16]));
+        let event = handle_bounty_allocated(&info);
+
+        assert_eq!(event.event_type, NotificationEventType::BountyAllocated);
+        assert_eq!(event.idempotency_key, "50000:7:bounty_allocated");
+
+        let json = serde_json::to_value(&event.payload).expect("should serialize");
+        assert_eq!(json["event_type"], "bounty_allocated");
+        assert_eq!(json["category"], "bounty");
+        assert_eq!(json["version"], 1);
+        assert_eq!(json["space_id"], info.bounty_space_id.to_string());
+        assert_eq!(json["bounty_entity_id"], info.bounty_entity_id.to_string());
+        assert_eq!(json["relation_id"], info.relation_id.to_string());
+        assert_eq!(json["curator_space_id"], info.curator_space_id.to_string());
+        assert_eq!(json["bounty_space_id"], info.bounty_space_id.to_string());
+        assert_eq!(
+            json["proposal_id"],
+            Uuid::from_bytes([0x50; 16]).to_string()
+        );
+    }
+
+    #[test]
+    fn test_bounty_allocated_without_proposal() {
+        // Allocation in EOA (non-DAO) space — no proposal involved
+        let info = make_bounty_info(); // proposal_id defaults to None
+        let event = handle_bounty_allocated(&info);
+        let json = serde_json::to_value(&event.payload).expect("should serialize");
+        assert!(json.get("proposal_id").is_none());
+    }
+
+    #[test]
+    fn test_bounty_allocated_has_no_interested_user() {
+        let mut info = make_bounty_info();
+        info.proposal_id = Some(Uuid::from_bytes([0x50; 16]));
+        let event = handle_bounty_allocated(&info);
+        let json = serde_json::to_value(&event.payload).expect("should serialize");
+        // interested_user_space_id is only for interest events
+        assert!(json.get("interested_user_space_id").is_none());
+    }
+
+    #[test]
+    fn test_bounty_allocated_has_no_governance_fields() {
+        let mut info = make_bounty_info();
+        info.proposal_id = Some(Uuid::from_bytes([0x50; 16]));
+        let event = handle_bounty_allocated(&info);
+        let json = serde_json::to_value(&event.payload).expect("should serialize");
+        assert!(json.get("voter_id").is_none());
+        assert!(json.get("proposer_id").is_none());
+        assert!(json.get("vote").is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Bounty payout events
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_bounty_payout_payload_structure() {
+        let mut info = make_bounty_info();
+        info.proposal_id = Some(Uuid::from_bytes([0x60; 16]));
+        let event = handle_bounty_payout(&info);
+
+        assert_eq!(event.event_type, NotificationEventType::BountyPayout);
+        assert_eq!(event.idempotency_key, "50000:7:bounty_payout");
+
+        let json = serde_json::to_value(&event.payload).expect("should serialize");
+        assert_eq!(json["event_type"], "bounty_payout");
+        assert_eq!(json["category"], "bounty");
+        assert_eq!(json["version"], 1);
+        assert_eq!(json["space_id"], info.bounty_space_id.to_string());
+        assert_eq!(json["bounty_entity_id"], info.bounty_entity_id.to_string());
+        assert_eq!(json["relation_id"], info.relation_id.to_string());
+        assert_eq!(json["curator_space_id"], info.curator_space_id.to_string());
+        assert_eq!(json["bounty_space_id"], info.bounty_space_id.to_string());
+        assert_eq!(
+            json["proposal_id"],
+            Uuid::from_bytes([0x60; 16]).to_string()
+        );
+    }
+
+    #[test]
+    fn test_bounty_payout_without_proposal() {
+        // Payout in EOA space — direct publish, no proposal
+        let info = make_bounty_info();
+        let event = handle_bounty_payout(&info);
+        let json = serde_json::to_value(&event.payload).expect("should serialize");
+        assert!(json.get("proposal_id").is_none());
+    }
+
+    #[test]
+    fn test_bounty_payout_has_no_interested_user() {
+        let mut info = make_bounty_info();
+        info.proposal_id = Some(Uuid::from_bytes([0x60; 16]));
+        let event = handle_bounty_payout(&info);
+        let json = serde_json::to_value(&event.payload).expect("should serialize");
+        assert!(json.get("interested_user_space_id").is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Bounty event type categorization
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_bounty_event_types_are_bounty_category() {
+        assert_eq!(NotificationEventType::BountyInterest.category(), "bounty");
+        assert_eq!(NotificationEventType::BountyAllocated.category(), "bounty");
+        assert_eq!(NotificationEventType::BountyPayout.category(), "bounty");
+    }
+
+    #[test]
+    fn test_bounty_event_type_as_str() {
+        assert_eq!(
+            NotificationEventType::BountyInterest.as_str(),
+            "bounty_interest"
+        );
+        assert_eq!(
+            NotificationEventType::BountyAllocated.as_str(),
+            "bounty_allocated"
+        );
+        assert_eq!(
+            NotificationEventType::BountyPayout.as_str(),
+            "bounty_payout"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Bounty idempotency keys
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_bounty_idempotency_keys_are_unique_per_event_type() {
+        let info = make_bounty_info();
+        let interest = handle_bounty_interest(&info);
+        let allocated = handle_bounty_allocated(&info);
+        let payout = handle_bounty_payout(&info);
+
+        // Same block/sequence but different event types must produce different keys
+        assert_ne!(interest.idempotency_key, allocated.idempotency_key);
+        assert_ne!(interest.idempotency_key, payout.idempotency_key);
+        assert_ne!(allocated.idempotency_key, payout.idempotency_key);
+    }
+
+    #[test]
+    fn test_bounty_idempotency_keys_differ_by_block() {
+        let mut info1 = make_bounty_info();
+        let mut info2 = make_bounty_info();
+        info2.block_number = 50001;
+
+        let event1 = handle_bounty_interest(&info1);
+        let event2 = handle_bounty_interest(&info2);
+        assert_ne!(event1.idempotency_key, event2.idempotency_key);
+    }
+
+    #[test]
+    fn test_bounty_idempotency_keys_differ_by_sequence() {
+        let mut info1 = make_bounty_info();
+        let mut info2 = make_bounty_info();
+        info2.sequence = 8;
+
+        let event1 = handle_bounty_interest(&info1);
+        let event2 = handle_bounty_interest(&info2);
+        assert_ne!(event1.idempotency_key, event2.idempotency_key);
+    }
+
+    // -----------------------------------------------------------------------
+    // Bounty optional name fields (best-effort)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_bounty_name_fields_absent_by_default() {
+        let info = make_bounty_info();
+        let event = handle_bounty_interest(&info);
+        let json = serde_json::to_value(&event.payload).expect("should serialize");
+        assert!(json.get("bounty_name").is_none());
+        assert!(json.get("curator_name").is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Cross-category isolation: bounty events have no governance fields
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_governance_events_have_no_bounty_fields() {
+        let msg = HermesProposalCreated {
+            space_id: make_test_uuid(0x01),
+            proposer_id: make_test_uuid(0x02),
+            proposal_id: make_test_uuid(0x03),
+            voting_mode: 0,
+            actions: vec![],
+            settings: None,
+            meta: Some(make_metadata(12345, 1700000000)),
+        };
+        let event = handle_proposal_created(&msg).expect("should parse");
+        let json = serde_json::to_value(&event.payload).expect("should serialize");
+
+        assert!(json.get("bounty_entity_id").is_none());
+        assert!(json.get("bounty_space_id").is_none());
+        assert!(json.get("curator_space_id").is_none());
+        assert!(json.get("interested_user_space_id").is_none());
+        assert!(json.get("bounty_name").is_none());
+        assert!(json.get("curator_name").is_none());
+    }
+
+    #[test]
+    fn test_bounty_events_have_no_governance_specific_fields() {
+        let info = make_bounty_info();
+        for event in [
+            handle_bounty_interest(&info),
+            handle_bounty_allocated(&info),
+            handle_bounty_payout(&info),
+        ] {
+            let json = serde_json::to_value(&event.payload).expect("should serialize");
+            assert!(json.get("voter_id").is_none(), "bounty event should not have voter_id");
+            assert!(json.get("proposer_id").is_none(), "bounty event should not have proposer_id");
+            assert!(json.get("vote").is_none(), "bounty event should not have vote");
+            assert!(json.get("actions").is_none(), "bounty event should not have actions");
+            assert!(json.get("settings").is_none(), "bounty event should not have settings");
+            assert!(json.get("voting_mode").is_none(), "bounty event should not have voting_mode");
+        }
     }
 }

--- a/notification-service/notification-indexer/src/models.rs
+++ b/notification-service/notification-indexer/src/models.rs
@@ -1711,12 +1711,30 @@ mod tests {
             handle_bounty_payout(&info),
         ] {
             let json = serde_json::to_value(&event.payload).expect("should serialize");
-            assert!(json.get("voter_id").is_none(), "bounty event should not have voter_id");
-            assert!(json.get("proposer_id").is_none(), "bounty event should not have proposer_id");
-            assert!(json.get("vote").is_none(), "bounty event should not have vote");
-            assert!(json.get("actions").is_none(), "bounty event should not have actions");
-            assert!(json.get("settings").is_none(), "bounty event should not have settings");
-            assert!(json.get("voting_mode").is_none(), "bounty event should not have voting_mode");
+            assert!(
+                json.get("voter_id").is_none(),
+                "bounty event should not have voter_id"
+            );
+            assert!(
+                json.get("proposer_id").is_none(),
+                "bounty event should not have proposer_id"
+            );
+            assert!(
+                json.get("vote").is_none(),
+                "bounty event should not have vote"
+            );
+            assert!(
+                json.get("actions").is_none(),
+                "bounty event should not have actions"
+            );
+            assert!(
+                json.get("settings").is_none(),
+                "bounty event should not have settings"
+            );
+            assert!(
+                json.get("voting_mode").is_none(),
+                "bounty event should not have voting_mode"
+            );
         }
     }
 }

--- a/notification-service/notification-indexer/src/models.rs
+++ b/notification-service/notification-indexer/src/models.rs
@@ -723,6 +723,9 @@ impl BountyConfig {
 pub struct BountyRelationInfo {
     pub relation_id: Uuid,
     pub bounty_entity_id: Uuid,
+    /// The curator's entity ID (rel.to for allocated/payout).
+    /// Used for entity→space DB lookup when curator_space_id is nil.
+    pub curator_entity_id: Uuid,
     pub curator_space_id: Uuid,
     pub bounty_space_id: Uuid,
     pub proposal_id: Option<Uuid>,
@@ -859,6 +862,7 @@ pub fn extract_bounty_relations(
                         BountyRelationInfo {
                             relation_id: Uuid::from_bytes(rel.id),
                             bounty_entity_id: Uuid::from_bytes(rel.to),
+                            curator_entity_id: Uuid::from_bytes(rel.from),
                             curator_space_id: edit_space_id,
                             bounty_space_id: Uuid::nil(), // Needs DB lookup
                             proposal_id: None,
@@ -874,6 +878,7 @@ pub fn extract_bounty_relations(
                         BountyRelationInfo {
                             relation_id: Uuid::from_bytes(rel.id),
                             bounty_entity_id: Uuid::from_bytes(rel.from),
+                            curator_entity_id: Uuid::from_bytes(rel.to),
                             curator_space_id: curator_space.unwrap_or(Uuid::nil()),
                             bounty_space_id: edit_space_id,
                             proposal_id: None,
@@ -1331,6 +1336,7 @@ mod tests {
         BountyRelationInfo {
             relation_id: Uuid::from_bytes([0x10; 16]),
             bounty_entity_id: Uuid::from_bytes([0x20; 16]),
+            curator_entity_id: Uuid::from_bytes([0x25; 16]),
             curator_space_id: Uuid::from_bytes([0x30; 16]),
             bounty_space_id: Uuid::from_bytes([0x40; 16]),
             proposal_id: None,

--- a/notification-service/notification-indexer/src/models.rs
+++ b/notification-service/notification-indexer/src/models.rs
@@ -655,11 +655,15 @@ pub fn build_rejection_event(
 // ---------------------------------------------------------------------------
 
 /// Well-known relation type UUIDs for bounty events.
-/// Hardcoded from the GRC-20 protocol; env vars override if set.
-const DEFAULT_INTEREST_TYPE_ID: &str = "2c765cae-c1b6-4cc3-a65d-693d0a67eaeb";
-// Placeholder UUIDs — update when the protocol defines them
-const DEFAULT_ALLOCATED_TYPE_ID: &str = "00000000-0000-0000-0000-000000000000";
-const DEFAULT_PAYOUT_TYPE_ID: &str = "00000000-0000-0000-0000-000000000000";
+/// Sourced from the curator-app (packages/curator-utils/src/ids.ts); env vars override if set.
+///
+/// Interest:  INTERESTED_IN_PROPERTY_ID — curator (Person) → bounty, in curator's personal space
+/// Allocated: ALLOCATED_PROPERTY_ID     — bounty → person, in public space (optional DAO proposal)
+/// Payout:    PAYOUT_RECIPIENT_PROPERTY_ID — space → recipient space, creates Payout entity
+///            (Payout is a multi-relation entity; we detect it by the recipient relation type)
+const DEFAULT_INTEREST_TYPE_ID: &str = "ff7e1b44-44a2-4191-8732-4e6c222afe07";
+const DEFAULT_ALLOCATED_TYPE_ID: &str = "cfeb6422-23c5-4df4-b3f9-375a489d9e22";
+const DEFAULT_PAYOUT_TYPE_ID: &str = "fddacaae-8513-8a43-ec1a-50ff71564d42";
 
 /// Configuration for bounty relation type detection.
 #[derive(Debug, Clone)]
@@ -1340,24 +1344,20 @@ mod tests {
     #[test]
     fn test_bounty_config_default() {
         let config = BountyConfig::default();
-        // Should parse hardcoded UUIDs without panicking
+        // All three should parse to real (non-nil) UUIDs from curator-app constants
         assert_ne!(config.interest_type_id, Uuid::nil());
+        assert_ne!(config.allocated_type_id, Uuid::nil());
+        assert_ne!(config.payout_type_id, Uuid::nil());
+        // Verify they are distinct
+        assert_ne!(config.interest_type_id, config.allocated_type_id);
+        assert_ne!(config.interest_type_id, config.payout_type_id);
+        assert_ne!(config.allocated_type_id, config.payout_type_id);
     }
 
     #[test]
     fn test_bounty_config_match_type() {
         let config = BountyConfig::default();
 
-        assert_eq!(
-            config.match_type(&config.interest_type_id),
-            Some(NotificationEventType::BountyInterest)
-        );
-        // allocated and payout use placeholder UUIDs — test with distinct values
-        let config = BountyConfig {
-            interest_type_id: Uuid::from_bytes([0x01; 16]),
-            allocated_type_id: Uuid::from_bytes([0x02; 16]),
-            payout_type_id: Uuid::from_bytes([0x03; 16]),
-        };
         assert_eq!(
             config.match_type(&config.interest_type_id),
             Some(NotificationEventType::BountyInterest)

--- a/notification-service/notification-indexer/src/storage.rs
+++ b/notification-service/notification-indexer/src/storage.rs
@@ -173,6 +173,73 @@ impl Storage {
         Ok(inserted_count)
     }
 
+    // -----------------------------------------------------------------------
+    // Bounty entity/space resolution
+    // -----------------------------------------------------------------------
+
+    /// Resolve a user entity_id to their personal space UUID.
+    ///
+    /// Uses the "front page entity" pattern: finds a personal space
+    /// that has a Types relation pointing from the entity to SPACE_TYPE.
+    #[instrument(name = "notification_indexer.storage.lookup_entity_space", skip(self))]
+    pub async fn lookup_entity_space(&self, entity_id: Uuid) -> Result<Option<Uuid>, StorageError> {
+        // TYPE_RELATION_TYPE_ID = 8f151ba4-de20-4e3c-9cb4-99ddf96f48f1
+        // SPACE_TYPE = 362c1dbd-dc64-44bb-a3c4-652f38a642d7
+        let result = sqlx::query_scalar::<_, Uuid>(
+            r#"
+            SELECT r.space_id
+            FROM relations r
+            JOIN spaces s ON s.id = r.space_id
+            WHERE r.from_entity_id = $1
+              AND r.type_id = '8f151ba4-de20-4e3c-9cb4-99ddf96f48f1'::uuid
+              AND r.to_entity_id = '362c1dbd-dc64-44bb-a3c4-652f38a642d7'::uuid
+            LIMIT 1
+            "#,
+        )
+        .bind(entity_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(result)
+    }
+
+    /// Look up which space owns a bounty entity (for interest notifications).
+    #[instrument(name = "notification_indexer.storage.lookup_bounty_space", skip(self))]
+    pub async fn lookup_bounty_space(
+        &self,
+        bounty_entity_id: Uuid,
+    ) -> Result<Option<Uuid>, StorageError> {
+        let result = sqlx::query_scalar::<_, Uuid>(
+            r#"
+            SELECT space_id
+            FROM relations
+            WHERE from_entity_id = $1
+              AND type_id = '8f151ba4-de20-4e3c-9cb4-99ddf96f48f1'::uuid
+            LIMIT 1
+            "#,
+        )
+        .bind(bounty_entity_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(result)
+    }
+
+    /// Insert a notification for a single user (curator) into the outbox.
+    ///
+    /// Used for bounty_allocated and bounty_payout where there's one recipient.
+    /// Delegates to `insert_notifications_for_editors` with a single-element slice.
+    #[instrument(
+        name = "notification_indexer.storage.insert_notification_for_user",
+        skip(self, event)
+    )]
+    pub async fn insert_notification_for_user(
+        &self,
+        event: &NotificationEvent,
+        user_space_id: Uuid,
+    ) -> Result<u64, StorageError> {
+        self.insert_notifications_for_editors(event, &[user_space_id])
+            .await
+    }
+
     /// Find proposals that have expired (end_time < now) without being executed,
     /// and for which we haven't yet sent a rejection notification.
     ///

--- a/notification-service/notification-indexer/src/storage.rs
+++ b/notification-service/notification-indexer/src/storage.rs
@@ -203,17 +203,24 @@ impl Storage {
     }
 
     /// Look up which space owns a bounty entity (for interest notifications).
+    ///
+    /// Finds the space via the bounty's Types relation pointing to BOUNTY_TYPE.
+    /// Requires both type_id (TYPE_RELATION_TYPE_ID) and to_entity_id (BOUNTY_TYPE)
+    /// to avoid matching unrelated Types relations from the same entity.
     #[instrument(name = "notification_indexer.storage.lookup_bounty_space", skip(self))]
     pub async fn lookup_bounty_space(
         &self,
         bounty_entity_id: Uuid,
     ) -> Result<Option<Uuid>, StorageError> {
+        // TYPE_RELATION_TYPE_ID = 8f151ba4-de20-4e3c-9cb4-99ddf96f48f1
+        // BOUNTY_TYPE_ID = 808af0ba-d588-4e33-91f0-9dd4b25e18be
         let result = sqlx::query_scalar::<_, Uuid>(
             r#"
             SELECT space_id
             FROM relations
             WHERE from_entity_id = $1
               AND type_id = '8f151ba4-de20-4e3c-9cb4-99ddf96f48f1'::uuid
+              AND to_entity_id = '808af0ba-d588-4e33-91f0-9dd4b25e18be'::uuid
             LIMIT 1
             "#,
         )

--- a/notification-service/notification-indexer/src/storage.rs
+++ b/notification-service/notification-indexer/src/storage.rs
@@ -11,6 +11,19 @@ use uuid::Uuid;
 use crate::error::StorageError;
 use crate::models::NotificationEvent;
 
+// Well-known system IDs from the knowledge graph.
+// Sourced from geo-sdk (src/core/ids/system.ts) and curator-app (packages/curator-utils/src/ids.ts).
+// These are being upstreamed to the grc-20 Rust crate — once available, import from there instead.
+
+/// The "Types" relation type ID — used for entity type membership (e.g. entity → Bounty type).
+const TYPE_RELATION_TYPE_ID: &str = "8f151ba4-de20-4e3c-9cb4-99ddf96f48f1";
+/// The "Space" type entity ID — used to identify space entities via Types relations.
+const SPACE_TYPE_ID: &str = "362c1dbd-dc64-44bb-a3c4-652f38a642d7";
+/// The "Bounty" type entity ID — used to identify bounty entities via Types relations.
+const BOUNTY_TYPE_ID: &str = "808af0ba-d588-4e33-91f0-9dd4b25e18be";
+/// The "Name" property ID — used to look up entity display names.
+const NAME_PROPERTY_ID: &str = "a126ca53-0c8e-48d5-b888-82c734c38935";
+
 /// Storage for notification-related database operations.
 pub struct Storage {
     pool: PgPool,
@@ -183,20 +196,23 @@ impl Storage {
     /// that has a Types relation pointing from the entity to SPACE_TYPE.
     #[instrument(name = "notification_indexer.storage.lookup_entity_space", skip(self))]
     pub async fn lookup_entity_space(&self, entity_id: Uuid) -> Result<Option<Uuid>, StorageError> {
-        // TYPE_RELATION_TYPE_ID = 8f151ba4-de20-4e3c-9cb4-99ddf96f48f1
-        // SPACE_TYPE = 362c1dbd-dc64-44bb-a3c4-652f38a642d7
+        let type_rel_id =
+            Uuid::parse_str(TYPE_RELATION_TYPE_ID).expect("valid TYPE_RELATION_TYPE_ID");
+        let space_type_id = Uuid::parse_str(SPACE_TYPE_ID).expect("valid SPACE_TYPE_ID");
         let result = sqlx::query_scalar::<_, Uuid>(
             r#"
             SELECT r.space_id
             FROM relations r
             JOIN spaces s ON s.id = r.space_id
             WHERE r.from_entity_id = $1
-              AND r.type_id = '8f151ba4-de20-4e3c-9cb4-99ddf96f48f1'::uuid
-              AND r.to_entity_id = '362c1dbd-dc64-44bb-a3c4-652f38a642d7'::uuid
+              AND r.type_id = $2
+              AND r.to_entity_id = $3
             LIMIT 1
             "#,
         )
         .bind(entity_id)
+        .bind(type_rel_id)
+        .bind(space_type_id)
         .fetch_optional(&self.pool)
         .await?;
         Ok(result)
@@ -212,19 +228,22 @@ impl Storage {
         &self,
         bounty_entity_id: Uuid,
     ) -> Result<Option<Uuid>, StorageError> {
-        // TYPE_RELATION_TYPE_ID = 8f151ba4-de20-4e3c-9cb4-99ddf96f48f1
-        // BOUNTY_TYPE_ID = 808af0ba-d588-4e33-91f0-9dd4b25e18be
+        let type_rel_id =
+            Uuid::parse_str(TYPE_RELATION_TYPE_ID).expect("valid TYPE_RELATION_TYPE_ID");
+        let bounty_type_id = Uuid::parse_str(BOUNTY_TYPE_ID).expect("valid BOUNTY_TYPE_ID");
         let result = sqlx::query_scalar::<_, Uuid>(
             r#"
             SELECT space_id
             FROM relations
             WHERE from_entity_id = $1
-              AND type_id = '8f151ba4-de20-4e3c-9cb4-99ddf96f48f1'::uuid
-              AND to_entity_id = '808af0ba-d588-4e33-91f0-9dd4b25e18be'::uuid
+              AND type_id = $2
+              AND to_entity_id = $3
             LIMIT 1
             "#,
         )
         .bind(bounty_entity_id)
+        .bind(type_rel_id)
+        .bind(bounty_type_id)
         .fetch_optional(&self.pool)
         .await?;
         Ok(result)
@@ -299,12 +318,13 @@ impl Storage {
     ///
     /// Returns `None` if the entity has no name or the query fails.
     pub async fn lookup_entity_name(&self, entity_id: Uuid, space_id: Uuid) -> Option<String> {
+        let name_prop_id = Uuid::parse_str(NAME_PROPERTY_ID).expect("valid NAME_PROPERTY_ID");
         sqlx::query_scalar::<_, String>(
             r#"
             SELECT v.text
             FROM "values" v
             WHERE v.entity_id = $1
-              AND v.property_id = 'a126ca53-0c8e-48d5-b888-82c734c38935'::uuid
+              AND v.property_id = $3
               AND v.space_id = $2
               AND v.text IS NOT NULL
             LIMIT 1
@@ -312,6 +332,7 @@ impl Storage {
         )
         .bind(entity_id)
         .bind(space_id)
+        .bind(name_prop_id)
         .fetch_optional(&self.pool)
         .await
         .ok()


### PR DESCRIPTION
## Summary
Implement the `knowledge.edits` Kafka consumer for bounty notifications, completing the bounty notification pipeline designed in the TECH_DESIGN.md.

## Changes

### Bounty relation type ID fixes
- Interest: `2c765cae...` → `ff7e1b44...` (INTERESTED_IN_PROPERTY_ID from curator-app)
- Allocated: `00000000...` → `cfeb6422...` (ALLOCATED_PROPERTY_ID from curator-app)
- Payout: `00000000...` → `fddacaae...` (PAYOUT_RECIPIENT_PROPERTY_ID from curator-app)
- Updated TECH_DESIGN.md and RFC with correct IDs and relation directions

### Knowledge edits consumer (`consumer.rs`)
- New `KnowledgeEditsConsumer` struct wrapping a `StreamConsumer` subscribed to `knowledge.edits`
- Separate consumer group (`-knowledge-edits` suffix) to avoid offset conflicts
- `parse_hermes_edit()` for HermesEdit protobuf decoding
- Same manual offset management pattern as governance consumer

### GRC-20 relation extraction (`models.rs`)
- `extract_bounty_relations()` — decodes GRC-20 payloads via `grc_20::decode_edit()`, matches `CreateRelation` ops against `BountyConfig`
- Interest: `from=curator`, `to=bounty`, `curator_space_id = HermesEdit.space_id`
- Allocated/Payout: `from=bounty/space`, `to=person/recipient`, curator resolved via `to_space` or DB lookup

### Storage layer (`storage.rs`)
- `lookup_entity_space()` — resolves entity_id → personal space UUID via front-page-entity pattern
- `lookup_bounty_space()` — resolves bounty entity to its owning space
- `insert_notification_for_user()` — single-recipient notification for allocated/payout

### Consumer loop (`main.rs`)
- Third concurrent task alongside governance consumer + rejection poller
- Controlled by `KNOWLEDGE_EDITS_ENABLED` env var (default: `false`)
- For each HermesEdit message: decode → extract bounty relations → resolve recipients → insert notifications → commit offset
- Interest: editor fan-out (notify bounty space editors)
- Allocated/Payout: single-user notification (notify curator)
- Same hardened offset management: commit on success/parse error, no commit on DB error (at-least-once delivery)
- Same block delay and name enrichment as governance consumer

### Tests
- 7 new unit tests for `extract_bounty_relations()` (interest/allocated/payout extraction, non-bounty filtering, mixed ops, missing metadata, invalid payload)
- 47 existing bounty config/handler tests updated with correct IDs
- E2E test scenarios for all three bounty event types (interest, allocated, payout) with GRC-20 edit construction, HermesEdit encoding, Kafka publishing, and webhook verification

## Test results
- 54 unit tests pass (`cargo test -p notification-indexer`)
- `cargo fmt` clean
- `cargo clippy -D warnings` clean
- E2E tests compile clean (`cargo check -p notification-e2e-tests`)

## Deployment
Set `KNOWLEDGE_EDITS_ENABLED=true` to enable the bounty notifications consumer. Without this env var, the consumer is not started and there is no behavior change.

## Test plan
- [ ] Deploy to staging with `KNOWLEDGE_EDITS_ENABLED=true`
- [ ] Trigger bounty interest (curator expresses interest in a bounty)
- [ ] Verify bounty space editors receive `bounty_interest` webhook
- [ ] Trigger bounty allocation via proposal execution
- [ ] Verify curator receives `bounty_allocated` webhook
- [ ] Trigger bounty payout via proposal execution
- [ ] Verify curator receives `bounty_payout` webhook
- [ ] Verify governance notifications still work (no regression)
- [ ] Kill and restart the indexer — verify no duplicate notifications (idempotency)
- [ ] Run with `KNOWLEDGE_EDITS_ENABLED=false` — verify no bounty consumer starts