### PR TITLE
feat(api): add RAW_SCORE on order by score plugin

### DIFF
--- a/api/src/kg/__tests__/valueOrderByScorePlugin.test.ts
+++ b/api/src/kg/__tests__/valueOrderByScorePlugin.test.ts
@@ -116,6 +116,34 @@ describe("ValueOrderByScorePlugin", () => {
 		expect(filterSchemaErrors(nextPage.errors)).toHaveLength(0)
 	})
 
+	it("adds RAW_SCORE_ASC and RAW_SCORE_DESC to ValuesOrderBy enum", async () => {
+		const result = await executeGraphQL(`
+			{
+				__type(name: "ValuesOrderBy") {
+					enumValues { name }
+				}
+			}
+		`)
+
+		expect(result.errors).toBeUndefined()
+		const enumNames = result.data.__type.enumValues.map((v: {name: string}) => v.name)
+		expect(enumNames).toContain("RAW_SCORE_ASC")
+		expect(enumNames).toContain("RAW_SCORE_DESC")
+	})
+
+	it("accepts RAW_SCORE_DESC as an orderBy argument", async () => {
+		const result = await executeGraphQL(`
+			{
+				valuesConnection(orderBy: RAW_SCORE_DESC, first: 5) {
+					nodes { id entityId spaceId }
+					pageInfo { hasNextPage endCursor }
+				}
+			}
+		`)
+
+		expect(filterSchemaErrors(result.errors)).toHaveLength(0)
+	})
+
 	it("composes orderBy with spaceId filter", async () => {
 		const result = await executeGraphQL(`
 			{
@@ -125,6 +153,23 @@ describe("ValueOrderByScorePlugin", () => {
 					first: 5
 				) {
 					nodes { id entityId spaceId }
+				}
+			}
+		`)
+
+		expect(filterSchemaErrors(result.errors)).toHaveLength(0)
+	})
+
+	it("composes RAW_SCORE orderBy with spaceId filter", async () => {
+		const result = await executeGraphQL(`
+			{
+				valuesConnection(
+					filter: { spaceId: { is: "00000000000000000000000000000000" } }
+					orderBy: RAW_SCORE_DESC
+					first: 50
+				) {
+					nodes { id entityId spaceId }
+					pageInfo { hasNextPage endCursor }
 				}
 			}
 		`)

--- a/api/src/kg/valueOrderByScorePlugin.ts
+++ b/api/src/kg/valueOrderByScorePlugin.ts
@@ -42,7 +42,7 @@ export const ValueOrderByScorePlugin = makeAddPgTableOrderByPlugin(
 						AND vc.object_type = 0
 				)`
 			},
-			{unique: false, nulls: "last-iff-ascending"},
+			{unique: false, nulls: "last"},
 		)
 
 		return {...localScore, ...globalScore, ...rawScore}

--- a/api/src/kg/valueOrderByScorePlugin.ts
+++ b/api/src/kg/valueOrderByScorePlugin.ts
@@ -31,9 +31,23 @@ export const ValueOrderByScorePlugin = makeAddPgTableOrderByPlugin(
 			{unique: false, nulls: "last"},
 		)
 
-		return {...localScore, ...globalScore}
+		const rawScore = orderByAscDesc(
+			"RAW_SCORE",
+			({queryBuilder}) => {
+				const t = queryBuilder.getTableAlias()
+				return sql.fragment`(
+					SELECT (vc.upvotes - vc.downvotes) FROM public.votes_count vc
+					WHERE vc.object_id = ${t}.entity_id
+						AND vc.space_id = ${t}.space_id
+						AND vc.object_type = 0
+				)`
+			},
+			{unique: false, nulls: "last-iff-ascending"},
+		)
+
+		return {...localScore, ...globalScore, ...rawScore}
 	},
-	"Adding orderBy local_scores.score and global_scores.score to values connection",
+	"Adding orderBy local_scores.score, global_scores.score, and raw vote score to values connection",
 )
 
 export default ValueOrderByScorePlugin

--- a/api/src/kg/valueOrderByScorePlugin.ts
+++ b/api/src/kg/valueOrderByScorePlugin.ts
@@ -36,10 +36,15 @@ export const ValueOrderByScorePlugin = makeAddPgTableOrderByPlugin(
 			({queryBuilder}) => {
 				const t = queryBuilder.getTableAlias()
 				return sql.fragment`(
-					SELECT (vc.upvotes - vc.downvotes) FROM public.votes_count vc
-					WHERE vc.object_id = ${t}.entity_id
-						AND vc.space_id = ${t}.space_id
-						AND vc.object_type = 0
+					COALESCE(
+						(
+							SELECT (vc.upvotes - vc.downvotes) FROM public.votes_count vc
+							WHERE vc.object_id = ${t}.entity_id
+								AND vc.space_id = ${t}.space_id
+								AND vc.object_type = 0
+						),
+						0
+					)
 				)`
 			},
 			{unique: false, nulls: "last"},


### PR DESCRIPTION
## Summary

  - Adds RAW_SCORE_ASC / RAW_SCORE_DESC to the ValuesOrderBy GraphQL enum, enabling realtime vote-based sorting for space homepages 
  - Uses a correlated subquery against votes_count (upvotes - downvotes, filtered to object_type = 0) — same pattern as existing LOCAL_SCORE and GLOBAL_SCORE
  - No new tables, migrations, Kafka topics, or infrastructure changes — purely a plugin extension

## How it works

  The votes_count table is already maintained in near-realtime by the vote-indexer. This adds a query-time computed raw score (upvotes - downvotes) as an orderBy option, scoped per entity per space.

```graphql
query SpaceHomepage($spaceId: UUID!) {
  valuesConnection(
    filter: { spaceId: { is: $spaceId } }
    orderBy: RAW_SCORE_DESC
    first: 50
  ) {
    nodes { id entityId spaceId }
    pageInfo { hasNextPage endCursor }
  }
}
  ```

  The subquery hits the existing unique constraint on votes_count(object_id, object_type, space_id) — no new index needed.

  Closes GEO-495