### PR TITLE
fix(api): tune Valkey cache for memory + fast-fail under stress

### DIFF
--- a/api/src/kg/__tests__/valkeyCache.test.ts
+++ b/api/src/kg/__tests__/valkeyCache.test.ts
@@ -124,4 +124,27 @@ describe("shouldSkipCacheSet", () => {
 			shouldSkipCacheSet("y".repeat(MAX_CACHEABLE_BYTES + 100)),
 		)
 	})
+
+	it("measures UTF-8 bytes, not UTF-16 code units (CJK content)", () => {
+		// Regression guard: `.length` returns UTF-16 code units. Each CJK char
+		// is 1 code unit but 3 UTF-8 bytes, so a payload that looks "safe" by
+		// length alone can still exceed the byte budget. ceil(limit/3)+1 chars
+		// puts us just past the cap after UTF-8 encoding.
+		const cjkCharsOverLimit = Math.ceil(MAX_CACHEABLE_BYTES / 3) + 1
+		const cjk = "日".repeat(cjkCharsOverLimit)
+		// By UTF-16 code units it looks well under the cap...
+		expect(cjk.length).toBeLessThan(MAX_CACHEABLE_BYTES)
+		// ...but the actual UTF-8 byte length is over, so we skip.
+		expect(Buffer.byteLength(cjk, "utf8")).toBeGreaterThan(MAX_CACHEABLE_BYTES)
+		expect(shouldSkipCacheSet(cjk)).toBe(true)
+	})
+
+	it("treats ASCII content as byte-for-byte equal to its length", () => {
+		// Sanity check: for pure ASCII, UTF-16 code units == UTF-8 bytes,
+		// so the byte-accurate check still agrees with `.length` here.
+		const asciiJustUnder = "x".repeat(MAX_CACHEABLE_BYTES)
+		const asciiJustOver = "x".repeat(MAX_CACHEABLE_BYTES + 1)
+		expect(shouldSkipCacheSet(asciiJustUnder)).toBe(false)
+		expect(shouldSkipCacheSet(asciiJustOver)).toBe(true)
+	})
 })

--- a/api/src/kg/__tests__/valkeyCache.test.ts
+++ b/api/src/kg/__tests__/valkeyCache.test.ts
@@ -1,5 +1,6 @@
 import {describe, expect, it} from "bun:test"
 import type {ExecutionResult} from "graphql"
+import {MAX_CACHEABLE_BYTES, shouldSkipCacheSet} from "../valkeyCache"
 
 /**
  * Unit tests for the Valkey cache adapter contract.
@@ -92,5 +93,35 @@ describe("Valkey cache adapter contract", () => {
 	it("invalidate is a no-op", async () => {
 		const mock = createMockCache()
 		await mock.cache.invalidate([{typename: "Entity", id: "123"}])
+	})
+})
+
+describe("shouldSkipCacheSet", () => {
+	it("returns false for an empty payload", () => {
+		expect(shouldSkipCacheSet("")).toBe(false)
+	})
+
+	it("returns false for payloads at the exact limit", () => {
+		// boundary: a string of exactly MAX_CACHEABLE_BYTES chars is NOT skipped
+		const atLimit = "x".repeat(MAX_CACHEABLE_BYTES)
+		expect(shouldSkipCacheSet(atLimit)).toBe(false)
+	})
+
+	it("returns true for payloads just over the limit", () => {
+		const overLimit = "x".repeat(MAX_CACHEABLE_BYTES + 1)
+		expect(shouldSkipCacheSet(overLimit)).toBe(true)
+	})
+
+	it("returns true for significantly oversized payloads", () => {
+		// Simulates the 36 MB Claim-relations response we saw in prod logs
+		const huge = "x".repeat(36_000_000)
+		expect(shouldSkipCacheSet(huge)).toBe(true)
+	})
+
+	it("is a pure function over string length", () => {
+		// Deliberately schema-agnostic: we only inspect length, not content
+		expect(shouldSkipCacheSet("x".repeat(MAX_CACHEABLE_BYTES + 100))).toBe(
+			shouldSkipCacheSet("y".repeat(MAX_CACHEABLE_BYTES + 100)),
+		)
 	})
 })

--- a/api/src/kg/valkeyCache.ts
+++ b/api/src/kg/valkeyCache.ts
@@ -47,8 +47,17 @@ export type Cache = {
  */
 export const MAX_CACHEABLE_BYTES = 15_000_000
 
+/**
+ * Decide whether to skip caching a serialized response based on its
+ * UTF-8 byte length, not `serialized.length` (which is UTF-16 code units).
+ * ASCII chars are 1:1, but a single CJK char is 3 UTF-8 bytes and an
+ * emoji is 4 — a code-unit check would under-count and let oversized
+ * payloads through. ioredis ultimately encodes the string to UTF-8 for
+ * its send buffer and the Valkey wire, which is the property we want
+ * to bound.
+ */
 export function shouldSkipCacheSet(serialized: string): boolean {
-	return serialized.length > MAX_CACHEABLE_BYTES
+	return Buffer.byteLength(serialized, "utf8") > MAX_CACHEABLE_BYTES
 }
 
 /**
@@ -104,10 +113,11 @@ export function createValkeyCache(valkeyUrl: string): Cache {
 		async set(id, data, _entities, ttl) {
 			try {
 				const serialized = JSON.stringify(data)
-				if (shouldSkipCacheSet(serialized)) {
+				const bytes = Buffer.byteLength(serialized, "utf8")
+				if (bytes > MAX_CACHEABLE_BYTES) {
 					log.debug("Valkey cache skip: response exceeds MAX_CACHEABLE_BYTES", {
 						cacheKey: id.slice(0, 64),
-						bytes: serialized.length,
+						bytes,
 						limit: MAX_CACHEABLE_BYTES,
 					})
 					return

--- a/api/src/kg/valkeyCache.ts
+++ b/api/src/kg/valkeyCache.ts
@@ -16,6 +16,42 @@ export type Cache = {
 }
 
 /**
+ * Skip caching responses larger than this threshold. Serializing a large
+ * response already allocates a second full copy of the data (JSON.stringify),
+ * and handing that string to ioredis allocates a third in its send buffer.
+ * For 30+ MB responses, this is the exact allocation spike that OOM'd pods
+ * before the pagination cap landed. Skipping the SET entirely avoids the
+ * ioredis buffer and the network send — the stringify still happens, but
+ * the peak is bounded by one copy instead of three.
+ *
+ * 15 MB is chosen to cover the full range of expected cacheable responses:
+ *   - the 12 MB Query.spaces response (near-static, high-value to cache)
+ *   - 2–15 MB Query.entities* / entitiesOrderedByProperty responses
+ *   - common 2–5 MB entity-list shapes
+ *
+ * Per-request memory impact stays bounded:
+ *   - Single SET peak = JS string (15 MB) + ioredis send buffer (15 MB) ≈
+ *     30 MB per concurrent write — 0.7% of the 4 Gi pod limit
+ *   - 8-pod cache stampede peaks at ~240 MB aggregate; each pod stays
+ *     under 30 MB incremental during the stampede
+ *   - SET over in-cluster networking is typically <200 ms; the 3 s
+ *     commandTimeout gives ~1.5× headroom for bad network days
+ *
+ * GET path on a cache hit parses the full JSON to rebuild the JS object
+ * tree — ~100–250 ms CPU and up to ~90 MB transient memory per pod on
+ * the biggest entries. For expensive queries this is still a net win over
+ * hitting the DB; for cheap queries it can approach DB cost.
+ *
+ * Responses over 15 MB fall through to the DB on every request rather
+ * than cache, bounding the worst-case memory allocation path.
+ */
+export const MAX_CACHEABLE_BYTES = 15_000_000
+
+export function shouldSkipCacheSet(serialized: string): boolean {
+	return serialized.length > MAX_CACHEABLE_BYTES
+}
+
+/**
  * Valkey-backed response cache for GraphQL Yoga.
  * Uses ioredis client (Valkey is protocol-compatible with Redis).
  *
@@ -23,14 +59,29 @@ export type Cache = {
  * - TTL-based expiry (no entity-based invalidation)
  * - Valkey maxmemory + allkeys-lru eviction handles memory limits
  * - Graceful degradation: cache misses on Valkey errors or timeouts (no request failures)
- * - 500ms command timeout via ioredis commandTimeout: if Valkey is slow/hanging, requests fall through to DB
+ * - No per-request retries + 3s command timeout: if Valkey is slow or
+ *   unhealthy, a single in-flight command times out cleanly and the request
+ *   falls through to the DB. 3s gives enough headroom for the biggest
+ *   cacheable responses (up to MAX_CACHEABLE_BYTES) to complete a SET
+ *   even when Valkey is under moderate load, while still bounding the
+ *   per-request tail wait. Retries are disabled — they doubled tail
+ *   latency when Valkey was degraded without improving hit rate.
+ * - Skips cache SET for responses over MAX_CACHEABLE_BYTES to bound
+ *   per-request memory spikes.
  */
 export function createValkeyCache(valkeyUrl: string): Cache {
 	const valkey = new Redis(valkeyUrl, {
-		maxRetriesPerRequest: 1,
+		// No per-request retries. When Valkey is slow or down, a retry just
+		// adds to tail latency and doesn't improve hit rate — better to fail
+		// fast and fall through to the DB.
+		maxRetriesPerRequest: 0,
 		lazyConnect: true,
 		connectTimeout: 2000,
-		commandTimeout: 500,
+		// 3s per command covers the worst case of a ~15 MB SET under
+		// moderate load (~1-2s on a degraded network) while still
+		// bounding how long a single request will wait on an unhealthy
+		// cache before falling through to the DB.
+		commandTimeout: 3000,
 		retryStrategy(times) {
 			// Reconnect with exponential backoff, max 5s
 			return Math.min(times * 500, 5000)
@@ -53,6 +104,14 @@ export function createValkeyCache(valkeyUrl: string): Cache {
 		async set(id, data, _entities, ttl) {
 			try {
 				const serialized = JSON.stringify(data)
+				if (shouldSkipCacheSet(serialized)) {
+					log.debug("Valkey cache skip: response exceeds MAX_CACHEABLE_BYTES", {
+						cacheKey: id.slice(0, 64),
+						bytes: serialized.length,
+						limit: MAX_CACHEABLE_BYTES,
+					})
+					return
+				}
 				// TTL is in milliseconds from the plugin, EX expects seconds
 				const ttlSeconds = Math.ceil(ttl / 1000)
 				await valkey.set(id, serialized, "EX", ttlSeconds)


### PR DESCRIPTION
## Summary

Three targeted changes to the Valkey response-cache adapter so it uses less pod memory when the cache misbehaves, and so large responses stop amplifying allocations through the cache write path.

This is a follow-up to PR #587 (the pagination cap). With `first:` now bounded at 1,000 per level, most responses are <1 MB — but the 12 MB `Query.spaces` list and 2–15 MB `Query.entities*` responses (the exact things we *want* to cache for the 60s TTL) still exist and still go through the cache.

## Changes

| Setting | Before | After | Why |
|---|---|---|---|
| `maxRetriesPerRequest` | 1 | **0** | Retrying a broken cache doubles tail latency without improving hit rate. Fail fast and fall through to the DB. |
| `commandTimeout` | 500 ms | **3000 ms** | A real 15 MB SET in-cluster is typically <200 ms but can stretch to 1–2 s under load. 3 s gives ~1.5× headroom while still bounding request-side wait. |
| `MAX_CACHEABLE_BYTES` | none | **15 MB** | Serializing a huge response allocates a JS string + ioredis send buffer (2× the data). Skipping SET above 15 MB caps per-pod peak at ~30 MB per concurrent write — 0.7% of the 4 Gi pod limit. |

## Worst-case wait on an unhealthy cache

- Before: 2 × 500 ms = 1000 ms (one retry)
- After: 1 × 3000 ms = 3000 ms (single shot)

Higher single-shot ceiling, but no ioredis retry state held in memory across attempts, and no doubled serialization/buffering on retry. Net lower memory pressure under sustained degradation.

## Why 15 MB, not 5 MB

Earlier draft gated at 1 MB then 5 MB. The `postgraphile.ts` comment confirms what the cache is sized for:

- `Query.spaces` / `spacesConnection` — ~12 MB, near-static, 60s TTL
- `Query.entities*` — 2–15 MB, 60s TTL

At 5 MB we'd skip the biggest, highest-value shapes — cache misses them forever. 15 MB covers them all. Per-pod memory impact during an 8-pod cache stampede peaks at ~240 MB aggregate / ~30 MB per pod — comfortably within 4 Gi.

## Test plan

- [x] New unit tests for `shouldSkipCacheSet` — boundary at limit / just over / 36 MB outlier / purely length-based
- [x] Existing `valkeyCache` mock contract tests (12 total pass)
- [x] Existing `cache-integration` Yoga-plugin tests (7/7 pass)
- [x] `bun run format:check` clean
- [x] `bun run check` (tsc --noEmit) clean
- [x] Full unit suite (`bun run test --exclude "**/__tests__/**"`): 105/105 pass
- [x] KG integration suite (`bun run test src/kg/__tests__/`): 120/120 pass

## Follow-ups (not in scope)

- GET-path optimization via HTTP-layer bypass (skip the parse → JS object → re-stringify round-trip). ~200–500 ms savings on big cache hits but requires a custom Yoga plugin and proper invalidation handling.
- Gzip compression of stored values — halves network bytes and storage for typical JSON, but needs a wire-format migration.