### PR TITLE
fix(api): stop alerting Sentry on client-caused GraphQL errors

### DIFF
--- a/api/src/kg/__tests__/instrumentationPlugin.test.ts
+++ b/api/src/kg/__tests__/instrumentationPlugin.test.ts
@@ -1,0 +1,46 @@
+import {GraphQLError} from "graphql"
+import {describe, expect, it} from "vitest"
+import {isClientError} from "../instrumentationPlugin"
+
+describe("isClientError", () => {
+	it("flags GraphQLError with BAD_USER_INPUT extension code", () => {
+		const err = new GraphQLError("too big", {extensions: {code: "BAD_USER_INPUT"}})
+		expect(isClientError(err)).toBe(true)
+	})
+
+	it("flags GraphQLError with GRAPHQL_PARSE_FAILED extension code", () => {
+		const err = new GraphQLError("syntax bad", {extensions: {code: "GRAPHQL_PARSE_FAILED"}})
+		expect(isClientError(err)).toBe(true)
+	})
+
+	it("flags GraphQLError with GRAPHQL_VALIDATION_FAILED extension code", () => {
+		const err = new GraphQLError("invalid", {extensions: {code: "GRAPHQL_VALIDATION_FAILED"}})
+		expect(isClientError(err)).toBe(true)
+	})
+
+	it("flags wrapped error whose originalError has BAD_USER_INPUT code", () => {
+		const original = new GraphQLError("too big", {extensions: {code: "BAD_USER_INPUT"}})
+		const wrapper = new GraphQLError("wrapped", {originalError: original})
+		expect(isClientError(wrapper)).toBe(true)
+	})
+
+	it("flags the PostGraphile first+last error by message", () => {
+		const original = new Error("We don't support setting both first and last")
+		const wrapper = new GraphQLError("Unexpected error.", {originalError: original})
+		expect(isClientError(wrapper)).toBe(true)
+	})
+
+	it("does not flag a server error", () => {
+		const err = new GraphQLError("db exploded", {extensions: {code: "INTERNAL_SERVER_ERROR"}})
+		expect(isClientError(err)).toBe(false)
+	})
+
+	it("does not flag a plain Error without client-error markers", () => {
+		expect(isClientError(new Error("pool_pressure_shed"))).toBe(false)
+	})
+
+	it("does not flag null or undefined", () => {
+		expect(isClientError(null)).toBe(false)
+		expect(isClientError(undefined)).toBe(false)
+	})
+})

--- a/api/src/kg/instrumentationPlugin.ts
+++ b/api/src/kg/instrumentationPlugin.ts
@@ -1,9 +1,41 @@
 import {ROOT_CONTEXT, SpanStatusCode, trace} from "@opentelemetry/api"
 import * as Sentry from "@sentry/node"
-import {type FieldNode, Kind, type OperationDefinitionNode, print} from "graphql"
+import {type FieldNode, GraphQLError, Kind, type OperationDefinitionNode, print} from "graphql"
 import type {Plugin} from "graphql-yoga"
 import {graphqlQueryFingerprint} from "../services/queryFingerprint"
 import {log} from "../services/telemetry"
+
+// GraphQL error codes that always indicate a client-side problem (bad input,
+// syntax/validation errors). These are the expected consequence of a
+// misbehaving client and should not alert Sentry.
+const CLIENT_ERROR_CODES = new Set(["BAD_USER_INPUT", "GRAPHQL_PARSE_FAILED", "GRAPHQL_VALIDATION_FAILED"])
+
+// PostGraphile throws a plain Error (no BAD_USER_INPUT code) when the client
+// supplies both `first` and `last`. Match on message text since there's no
+// structured way to identify it.
+const CLIENT_ERROR_MESSAGE_PATTERNS = [/^We don't support setting both first and last$/]
+
+export function isClientError(error: unknown): boolean {
+	const maybeGraphQL = error as {extensions?: {code?: string}; originalError?: unknown; message?: string} | null
+	if (!maybeGraphQL) return false
+
+	const code = maybeGraphQL.extensions?.code
+	if (typeof code === "string" && CLIENT_ERROR_CODES.has(code)) return true
+
+	const original = maybeGraphQL.originalError
+	if (original instanceof GraphQLError) {
+		const origCode = original.extensions?.code
+		if (typeof origCode === "string" && CLIENT_ERROR_CODES.has(origCode)) return true
+	}
+
+	const originalMessage = original instanceof Error ? original.message : undefined
+	const message = originalMessage ?? maybeGraphQL.message
+	if (typeof message === "string" && CLIENT_ERROR_MESSAGE_PATTERNS.some((re) => re.test(message))) {
+		return true
+	}
+
+	return false
+}
 
 const SLOW_QUERY_THRESHOLD_MS = 3000
 const LARGE_RESPONSE_THRESHOLD_BYTES = 1_000_000 // 1 MB
@@ -171,6 +203,9 @@ export function useGraphQLInstrumentation(): Plugin {
 						span.setAttribute("graphql.error_count", errors.length)
 
 						for (const error of errors) {
+							// Client-caused errors (bad pagination args, syntax errors, validation
+							// failures) are expected noise and should not alert Sentry.
+							if (isClientError(error)) continue
 							Sentry.captureException(error.originalError || error, {
 								tags: {
 									"graphql.operation_name": operationLabel,


### PR DESCRIPTION
## Summary

- `useGraphQLInstrumentation` captured every error in the GraphQL result to Sentry, including errors caused by bad client input. Those alerts were noise — e.g. `Pagination argument "last" cannot exceed 1000; received 10000` and `We don't support setting both first and last`.
- Adds an `isClientError` classifier and skips `Sentry.captureException` when it matches.

## What's filtered

- `GraphQLError` with `extensions.code` in `BAD_USER_INPUT`, `GRAPHQL_PARSE_FAILED`, or `GRAPHQL_VALIDATION_FAILED` (direct or via `originalError`).
- PostGraphile's plain-`Error` `"We don't support setting both first and last"` (matched by message — it lacks a structured code; see `graphile-build-pg/.../PgConnectionArgFirstLastBeforeAfter.js:55`).

Server errors (`INTERNAL_SERVER_ERROR`, uncoded DB errors, etc.) still capture to Sentry as before.

## Test plan

- [x] `bun run test src/kg/__tests__/instrumentationPlugin.test.ts` — 8 passing unit tests covering each classification branch (code, nested originalError code, first+last message, plain server error, null input)
- [x] `bun x biome check` clean on changed files
- [x] `bun run check` (tsc --noEmit) clean
- [x] Verified cap enforcement still works end-to-end against `https://testnet-api.geobrowser.io/graphql` across all first/last/offset combinations
- [ ] After merge: confirm Sentry inbox stops receiving `BAD_USER_INPUT` and first+last issues