### PR TITLE
feat(api): log.warn on every GraphQL search/searchConnection invocation

### DIFF
--- a/api/src/kg/__tests__/searchInvocationLogger.test.ts
+++ b/api/src/kg/__tests__/searchInvocationLogger.test.ts
@@ -1,0 +1,234 @@
+import {parse} from "graphql"
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest"
+import {log} from "../../services/telemetry"
+import {graphqlServer} from "../postgraphile"
+import {extractClientIp, findSearchInvocations} from "../searchInvocationLogger"
+
+async function executeGraphQL(query: string, variables?: Record<string, unknown>, headers?: Record<string, string>) {
+	const response = await graphqlServer.fetch(
+		new Request("http://localhost/graphql", {
+			method: "POST",
+			headers: {"Content-Type": "application/json", ...(headers ?? {})},
+			body: JSON.stringify({query, variables}),
+		}),
+		{},
+	)
+	return {
+		status: response.status,
+		body: await response.json(),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests — pure AST walk + header parsing, no DB needed.
+// ---------------------------------------------------------------------------
+
+describe("extractClientIp", () => {
+	function h(entries: Record<string, string>): Headers {
+		return new Headers(entries)
+	}
+
+	it("prefers X-Real-IP", () => {
+		expect(extractClientIp(h({"x-real-ip": "203.0.113.5"}))).toBe("203.0.113.5")
+	})
+
+	it("returns rightmost X-Forwarded-For entry when X-Real-IP is absent", () => {
+		// nginx appends its observation to the right of any client-supplied XFF,
+		// so the rightmost entry is trusted and the leftmost is spoofable.
+		expect(extractClientIp(h({"x-forwarded-for": "1.2.3.4, 5.6.7.8, 203.0.113.5"}))).toBe("203.0.113.5")
+	})
+
+	it("ignores spoofed leftmost X-Forwarded-For entries when X-Real-IP is present", () => {
+		const headers = h({
+			"x-real-ip": "203.0.113.5",
+			"x-forwarded-for": "1.2.3.4, 203.0.113.5",
+		})
+		expect(extractClientIp(headers)).toBe("203.0.113.5")
+	})
+
+	it("returns null when neither header is present", () => {
+		expect(extractClientIp(h({}))).toBeNull()
+	})
+
+	it("returns null when X-Forwarded-For is empty / whitespace-only", () => {
+		expect(extractClientIp(h({"x-forwarded-for": ""}))).toBeNull()
+		expect(extractClientIp(h({"x-forwarded-for": ",  ,"}))).toBeNull()
+	})
+
+	it("trims whitespace around X-Real-IP", () => {
+		expect(extractClientIp(h({"x-real-ip": "  203.0.113.5  "}))).toBe("203.0.113.5")
+	})
+
+	it("handles single-entry X-Forwarded-For", () => {
+		expect(extractClientIp(h({"x-forwarded-for": "203.0.113.5"}))).toBe("203.0.113.5")
+	})
+})
+
+describe("findSearchInvocations", () => {
+	it("returns empty when no search field is present", () => {
+		const doc = parse(`{ entities(first: 5) { id name } }`)
+		expect(findSearchInvocations(doc)).toEqual([])
+	})
+
+	it("detects a top-level `search` call with inline args", () => {
+		const doc = parse(`{ search(query: "geo", first: 10) { id } }`)
+		expect(findSearchInvocations(doc)).toEqual([
+			{field: "search", query: "geo", first: 10, spaceId: undefined, similarityThreshold: undefined},
+		])
+	})
+
+	it("detects `searchConnection` and resolves numeric/string args via variables", () => {
+		const doc = parse(`
+			query S($q: String!, $n: Int!, $space: UUID) {
+				searchConnection(query: $q, first: $n, spaceId: $space) { nodes { id } }
+			}
+		`)
+		expect(findSearchInvocations(doc, {q: "eth", n: 25, space: "ab-cd"})).toEqual([
+			{field: "searchConnection", query: "eth", first: 25, spaceId: "ab-cd", similarityThreshold: undefined},
+		])
+	})
+
+	it("captures multiple invocations in one document", () => {
+		const doc = parse(`
+			{
+				a: search(query: "foo") { id }
+				b: searchConnection(query: "bar", first: 5) { nodes { id } }
+			}
+		`)
+		const result = findSearchInvocations(doc)
+		expect(result).toHaveLength(2)
+		expect(result.map((i) => i.field)).toEqual(["search", "searchConnection"])
+		expect(result.map((i) => i.query)).toEqual(["foo", "bar"])
+	})
+
+	it("follows inline fragments and fragment spreads", () => {
+		const doc = parse(`
+			fragment SearchFrag on Query { search(query: "via-fragment") { id } }
+			query Outer {
+				... { searchConnection(query: "inline-frag") { nodes { id } } }
+				...SearchFrag
+			}
+		`)
+		const queries = findSearchInvocations(doc).map((i) => i.query)
+		expect(queries.sort()).toEqual(["inline-frag", "via-fragment"])
+	})
+
+	it("does not confuse an unrelated field named 'search' elsewhere in the selection set", () => {
+		// e.g. some nested type might have its own `search` field. We only walk
+		// operation selection sets and their descendants, so nested matches are
+		// still logged. This test documents that behavior — any field *named*
+		// search/searchConnection is logged; we don't distinguish by type.
+		const doc = parse(`{ entity(id: "x") { search(query: "nested") { id } } }`)
+		const result = findSearchInvocations(doc)
+		expect(result).toHaveLength(1)
+		expect(result[0]).toMatchObject({field: "search", query: "nested"})
+	})
+
+	it("returns undefined for args when the variable isn't supplied", () => {
+		const doc = parse(`query S($q: String!) { search(query: $q) { id } }`)
+		const [inv] = findSearchInvocations(doc, {})
+		expect(inv).toBeDefined()
+		expect(inv?.query).toBeUndefined()
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Integration tests — real Yoga server, spies on log.warn.
+// ---------------------------------------------------------------------------
+
+describe("useSearchInvocationLogger (integration)", () => {
+	let warnSpy: ReturnType<typeof vi.spyOn>
+
+	beforeEach(() => {
+		warnSpy = vi.spyOn(log, "warn").mockImplementation(() => {})
+	})
+
+	afterEach(() => {
+		warnSpy.mockRestore()
+	})
+
+	function warningsMatching(substring: string): unknown[][] {
+		return warnSpy.mock.calls.filter(([msg]) => typeof msg === "string" && msg.includes(substring))
+	}
+
+	it("does not warn on a non-search query", async () => {
+		await executeGraphQL(`{ entities(first: 5) { id } }`)
+		expect(warningsMatching("search field invoked")).toHaveLength(0)
+	})
+
+	it("warns once on a `search` invocation and captures args", async () => {
+		await executeGraphQL(`{ search(query: "test-probe-1", first: 3) { id } }`)
+		const warnings = warningsMatching("search field invoked")
+		expect(warnings).toHaveLength(1)
+		const [, payload] = warnings[0] as [string, Record<string, unknown>]
+		expect(payload).toMatchObject({
+			field: "search",
+			query: "test-probe-1",
+			first: 3,
+		})
+	})
+
+	it("warns on `searchConnection` with variable-supplied args", async () => {
+		await executeGraphQL(`query Probe($q: String!) { searchConnection(query: $q, first: 7) { nodes { id } } }`, {
+			q: "test-probe-2",
+		})
+		const warnings = warningsMatching("search field invoked")
+		expect(warnings).toHaveLength(1)
+		const [, payload] = warnings[0] as [string, Record<string, unknown>]
+		expect(payload).toMatchObject({
+			field: "searchConnection",
+			query: "test-probe-2",
+			first: 7,
+			operationName: "Probe",
+		})
+	})
+
+	it("records X-Real-IP as clientIp", async () => {
+		await executeGraphQL(`{ search(query: "ip-probe") { id } }`, undefined, {"X-Real-IP": "203.0.113.5"})
+		const warnings = warningsMatching("search field invoked")
+		expect(warnings).toHaveLength(1)
+		const [, payload] = warnings[0] as [string, Record<string, unknown>]
+		expect(payload.clientIp).toBe("203.0.113.5")
+	})
+
+	it("ignores spoofed leftmost X-Forwarded-For entries when X-Real-IP is present", async () => {
+		await executeGraphQL(`{ search(query: "spoof-probe") { id } }`, undefined, {
+			"X-Real-IP": "203.0.113.5",
+			"X-Forwarded-For": "1.2.3.4, 203.0.113.5",
+		})
+		const warnings = warningsMatching("search field invoked")
+		const [, payload] = warnings[0] as [string, Record<string, unknown>]
+		expect(payload.clientIp).toBe("203.0.113.5")
+	})
+
+	it("falls back to rightmost X-Forwarded-For entry when X-Real-IP is absent", async () => {
+		await executeGraphQL(`{ search(query: "xff-probe") { id } }`, undefined, {
+			"X-Forwarded-For": "1.2.3.4, 203.0.113.5",
+		})
+		const warnings = warningsMatching("search field invoked")
+		const [, payload] = warnings[0] as [string, Record<string, unknown>]
+		expect(payload.clientIp).toBe("203.0.113.5")
+	})
+
+	it("captures origin and user-agent when present", async () => {
+		await executeGraphQL(`{ search(query: "ua-probe") { id } }`, undefined, {
+			"X-Real-IP": "203.0.113.5",
+			Origin: "https://app.geobrowser.io",
+			"User-Agent": "Mozilla/5.0 test-runner",
+		})
+		const warnings = warningsMatching("search field invoked")
+		const [, payload] = warnings[0] as [string, Record<string, unknown>]
+		expect(payload.origin).toBe("https://app.geobrowser.io")
+		expect(payload.userAgent).toBe("Mozilla/5.0 test-runner")
+	})
+
+	it("emits one warning per search invocation in a document with multiple", async () => {
+		await executeGraphQL(
+			`{
+				a: search(query: "q1") { id }
+				b: searchConnection(query: "q2", first: 5) { nodes { id } }
+			}`,
+		)
+		expect(warningsMatching("search field invoked")).toHaveLength(2)
+	})
+})

--- a/api/src/kg/postgraphile.ts
+++ b/api/src/kg/postgraphile.ts
@@ -14,6 +14,7 @@ import {log} from "../services/telemetry"
 import EntitySpaceFilterPlugin from "./entitySpaceFilterPlugin"
 import {useGraphQLInstrumentation} from "./instrumentationPlugin"
 import PaginationCapPlugin from "./paginationCapPlugin"
+import {useSearchInvocationLogger} from "./searchInvocationLogger"
 import UndashedUuidPlugin from "./uuidScalarPlugin"
 import {createValkeyCache} from "./valkeyCache"
 import ValueOrderByScorePlugin from "./valueOrderByScorePlugin"
@@ -270,9 +271,13 @@ const responseCachePlugin = (() => {
 
 // Shared plugins for GraphQL server.
 // Response cache is first so cache hits skip pgClient checkout entirely.
+// Search-invocation logger runs per request (AST walk only, no DB) and
+// warns on every `search` / `searchConnection` invocation so we can
+// observe usage + caller IP without adding a separate metrics pipeline.
 const sharedPlugins = [
 	...(responseCachePlugin ? [responseCachePlugin] : []),
 	useGraphQLInstrumentation(),
+	useSearchInvocationLogger(),
 	usePgClient(pgPool),
 	useExecutionCancellation(),
 ]

--- a/api/src/kg/searchInvocationLogger.ts
+++ b/api/src/kg/searchInvocationLogger.ts
@@ -1,0 +1,211 @@
+/**
+ * Yoga plugin that emits `log.warn` whenever a GraphQL operation invokes
+ * the `search` or `searchConnection` root fields.
+ *
+ * Motivation: we want per-invocation visibility on the text-search path so
+ * we can (a) measure how heavily the GraphQL search is used vs. the REST
+ * `/search` endpoint, (b) spot clients that still route through
+ * `entities(filter: {name: ...})` (the slow path) vs. the purpose-built
+ * `search()` pg function, and (c) have a caller IP captured for abuse
+ * investigations without standing up a full rate-limit system.
+ *
+ * AST-only detection — no schema introspection, no realm-crossing issues.
+ * Walks each operation's selection set, follows inline fragments and
+ * fragment spreads, and emits one `log.warn` per search-field selection.
+ * Multiple `search` calls in a single document all get logged.
+ *
+ * Client IP extraction (see `extractClientIp`) prefers `X-Real-IP`
+ * because it's the unspoofable value in this cluster's topology:
+ * DO LoadBalancer → ingress-nginx with `externalTrafficPolicy: Local`
+ * and L4 TCP passthrough preserves the real client source IP to nginx,
+ * and nginx sets `X-Real-IP = $remote_addr` (single-valued, overwrites
+ * any client-supplied header). `X-Forwarded-For` is a fallback: nginx
+ * appends its observed `$remote_addr` to the right of any client-supplied
+ * value, so the *rightmost* entry is trustworthy and leftmost entries are
+ * client-controlled / spoofable. Never reading leftmost XFF here.
+ */
+import {
+	type DocumentNode,
+	type FieldNode,
+	type FragmentDefinitionNode,
+	Kind,
+	type OperationDefinitionNode,
+	type SelectionSetNode,
+	type ValueNode,
+} from "graphql"
+import type {Plugin} from "graphql-yoga"
+import {log} from "../services/telemetry"
+
+const SEARCH_FIELD_NAMES: ReadonlySet<string> = new Set(["search", "searchConnection"])
+
+export type SearchInvocation = {
+	field: string
+	query?: string
+	spaceId?: string
+	first?: number
+	similarityThreshold?: number
+}
+
+/**
+ * Extract the real client IP from request headers.
+ *
+ * Priority:
+ *   1. `X-Real-IP` — set by nginx to `$remote_addr`, single-valued,
+ *      overwrites any client-supplied value. Unspoofable via HTTP in
+ *      our cluster config.
+ *   2. Rightmost entry of `X-Forwarded-For` — nginx appends its own
+ *      `$remote_addr` to the end of the XFF chain via
+ *      `$proxy_add_x_forwarded_for`. Leftmost entries are client-
+ *      controlled and NOT trusted; we only read the rightmost.
+ *
+ * Returns `null` if neither header is present.
+ */
+export function extractClientIp(headers: Headers): string | null {
+	const xRealIp = headers.get("x-real-ip")?.trim()
+	if (xRealIp) return xRealIp
+
+	const xff = headers.get("x-forwarded-for")
+	if (xff) {
+		const parts = xff
+			.split(",")
+			.map((s) => s.trim())
+			.filter(Boolean)
+		const rightmost = parts[parts.length - 1]
+		if (rightmost) return rightmost
+	}
+	return null
+}
+
+/**
+ * Walk a GraphQL document and return every invocation of `search` or
+ * `searchConnection` on an operation, resolved against the variables map.
+ */
+export function findSearchInvocations(
+	document: DocumentNode,
+	variables: Record<string, unknown> = {},
+): SearchInvocation[] {
+	const fragments: Record<string, FragmentDefinitionNode> = {}
+	for (const def of document.definitions) {
+		if (def.kind === Kind.FRAGMENT_DEFINITION) {
+			fragments[def.name.value] = def
+		}
+	}
+
+	const invocations: SearchInvocation[] = []
+
+	const walk = (selectionSet: SelectionSetNode): void => {
+		for (const sel of selectionSet.selections) {
+			if (sel.kind === Kind.FIELD) {
+				if (SEARCH_FIELD_NAMES.has(sel.name.value)) {
+					invocations.push({
+						field: sel.name.value,
+						query: readStringArg(sel, "query", variables),
+						spaceId: readStringArg(sel, "spaceId", variables),
+						first: readNumericArg(sel, "first", variables),
+						similarityThreshold: readNumericArg(sel, "similarityThreshold", variables),
+					})
+				}
+				if (sel.selectionSet) walk(sel.selectionSet)
+			} else if (sel.kind === Kind.INLINE_FRAGMENT) {
+				if (sel.selectionSet) walk(sel.selectionSet)
+			} else if (sel.kind === Kind.FRAGMENT_SPREAD) {
+				const frag = fragments[sel.name.value]
+				if (frag) walk(frag.selectionSet)
+			}
+		}
+	}
+
+	for (const def of document.definitions) {
+		if (def.kind === Kind.OPERATION_DEFINITION) {
+			walk(def.selectionSet)
+		}
+	}
+	return invocations
+}
+
+function readStringArg(field: FieldNode, argName: string, variables: Record<string, unknown>): string | undefined {
+	const arg = field.arguments?.find((a) => a.name.value === argName)
+	if (!arg) return undefined
+	return readStringValue(arg.value, variables)
+}
+
+function readNumericArg(field: FieldNode, argName: string, variables: Record<string, unknown>): number | undefined {
+	const arg = field.arguments?.find((a) => a.name.value === argName)
+	if (!arg) return undefined
+	return readNumericValue(arg.value, variables)
+}
+
+function readStringValue(value: ValueNode, variables: Record<string, unknown>): string | undefined {
+	if (value.kind === Kind.STRING || value.kind === Kind.ENUM) return value.value
+	if (value.kind === Kind.VARIABLE) {
+		const v = variables[value.name.value]
+		return typeof v === "string" ? v : undefined
+	}
+	return undefined
+}
+
+function readNumericValue(value: ValueNode, variables: Record<string, unknown>): number | undefined {
+	if (value.kind === Kind.INT || value.kind === Kind.FLOAT) {
+		const n = Number(value.value)
+		return Number.isFinite(n) ? n : undefined
+	}
+	if (value.kind === Kind.VARIABLE) {
+		const v = variables[value.name.value]
+		return typeof v === "number" ? v : undefined
+	}
+	return undefined
+}
+
+function getOperationName(document: DocumentNode, fallback?: string | null): string {
+	if (fallback) return fallback
+	const op = document.definitions.find(
+		(def): def is OperationDefinitionNode => def.kind === Kind.OPERATION_DEFINITION,
+	)
+	return op?.name?.value ?? "anonymous"
+}
+
+/**
+ * Cap logged field values so a malicious/large argument can't blow up
+ * our log line or Sentry breadcrumb.
+ */
+function truncate(value: string | undefined, max = 256): string | undefined {
+	if (value === undefined) return undefined
+	return value.length > max ? `${value.slice(0, max)}…` : value
+}
+
+/**
+ * Registered in postgraphile.ts's sharedPlugins. Returns early on
+ * documents that don't invoke a search field.
+ */
+export function useSearchInvocationLogger(): Plugin {
+	return {
+		onExecute({args}) {
+			const invocations = findSearchInvocations(args.document, args.variableValues ?? {})
+			if (invocations.length === 0) return
+
+			const ctx = args.contextValue as {request?: Request; requestId?: string}
+			const headers = ctx.request?.headers
+			const clientIp = headers ? extractClientIp(headers) : null
+			const userAgent = headers?.get("user-agent") ?? null
+			const origin = headers?.get("origin") ?? null
+			const operationName = getOperationName(args.document, args.operationName)
+
+			for (const inv of invocations) {
+				log.warn("GraphQL search field invoked", {
+					field: inv.field,
+					query: truncate(inv.query),
+					spaceId: inv.spaceId,
+					first: inv.first,
+					similarityThreshold: inv.similarityThreshold,
+					clientIp,
+					origin,
+					userAgent: truncate(userAgent ?? undefined),
+					requestId: ctx.requestId,
+					operationName,
+				})
+			}
+		},
+	}
+}
+
+export default useSearchInvocationLogger


### PR DESCRIPTION
## Summary

Adds a Yoga plugin that emits `log.warn` on every invocation of the `search` or `searchConnection` root fields, with the caller's real IP attached. AST-only detection — no schema introspection, no DB round-trip, no overhead on non-search traffic.

## Why

Three things we can't see today:

1. **Who's using GraphQL search at all.** Both `search` / `searchConnection` (pg-function-backed) and the REST `/search` endpoint (OpenSearch-backed) exist. Log pile says ~1.5 REST requests/min but nothing about the GraphQL side.
2. **Which callers are on the slow path.** The pg `search()` function uses `values_text_gin_trgm_idx` and is fast. But clients that hit `entities(filter: { name: { isInsensitive: … } })` instead end up seq-scanning `entities` via the `STABLE entities_name()` function (the P0 finding from the prod index analysis). We need per-caller visibility to diagnose which clients to nudge.
3. **Caller attribution for abuse investigations.** If the GraphQL search grows 100×, we want to know from where before reaching for a rate limiter.

## What it logs

One `log.warn("GraphQL search field invoked", { … })` per invocation, with:

- `field` — `"search"` or `"searchConnection"`
- `query` — the search string (truncated at 256 chars)
- `spaceId`, `first`, `similarityThreshold`
- `clientIp` — real caller IP (see below)
- `origin`, `userAgent` (truncated)
- `requestId`, `operationName`

## Client IP — unspoofable via HTTP in this cluster

Priority: **`X-Real-IP` first, rightmost `X-Forwarded-For` entry as fallback.**

Cluster topology check (done live against prod):
- DO LoadBalancer → ingress-nginx-controller service (`type: LoadBalancer`, `externalTrafficPolicy: Local`, TCP protocol on 443 — L4 passthrough)
- ingress-nginx configmap: `use-proxy-protocol: "false"`, `use-forwarded-headers` unset (default `false`)

Effect: nginx's `$remote_addr` IS the real client IP (Local policy preserves source IP through the NodePort DNAT). nginx then sets:

- `X-Real-IP = $remote_addr` — single-valued header, overwrites any client-supplied value. **Unspoofable via HTTP.**
- `X-Forwarded-For = $proxy_add_x_forwarded_for` — appends `$remote_addr` to any client-supplied XFF. **Rightmost entry is trusted; leftmost entries are client-controlled and we never read them.**

Verified the preservation with a live spoof test: `curl -H 'X-Forwarded-For: 1.2.3.4' https://testnet-api.geobrowser.io/graphql` — nginx access log shows `$remote_addr = <real client IP>`, not `1.2.3.4`.

## Implementation notes

- **AST-only.** Walks each operation's selection set, follows inline fragments and fragment spreads, resolves variable-carried args. Never touches the schema (which means no `graphql@15`-vs-`graphql@16` realm issues like we hit in the query-limits plugin earlier). Zero DB round-trips.
- **Early return on non-search documents.** The hot path is one array iteration per request; nothing runs on the 99%+ of traffic that doesn't invoke a search field.
- **Value capping.** `query` and `userAgent` are truncated to 256 chars before logging so a hostile actor can't balloon log lines or Sentry breadcrumbs.
- **Registered in `sharedPlugins`** next to `useGraphQLInstrumentation` so it runs inside the existing per-request span / trace.

## Test plan

- [x] 22 new tests, all passing (`bun run test src/kg/__tests__/searchInvocationLogger.test.ts`)
  - 7 `extractClientIp` unit: priority, spoof-rejection, trim, empty fallback, single-entry XFF
  - 7 `findSearchInvocations` unit: inline args, variables, multiples, inline fragments, fragment spreads, unresolved variables
  - 8 integration vs. live Yoga server: non-search silent, single `search`, `searchConnection` with variables, X-Real-IP priority, spoofed XFF rejection, XFF-only fallback, origin/UA capture, multi-invocation
- [x] Full CI-equivalent matrix passes locally:
  - `bun run format:check` clean
  - `bun run check` (tsc) clean
  - KG integration: 150/150 pass (128 prior + 22 new)
  - Unit suite: 108/108 pass
  - Cache tests: 21/21 pass
- [ ] After deploy: tail `kubectl -n api logs -l app=api -f | grep 'search field invoked'` during a browse of curator-app / geogenesis to confirm invocations appear and `clientIp` is populated.

## Follow-ups (not in scope)

- Rewrite curator-backend `searchWorksAtEntities` (handlers.ts:1212) to use GraphQL `search()` instead of the slow `entities(filter: {name: isInsensitive})` three-step loop. Separate PR.
- Sampling — if this turns out to log too much, add a config knob (e.g., `SEARCH_LOG_SAMPLE_RATE`). Don't think it will: typical GraphQL search volume is far under what `log.warn` can handle.