### PR TITLE
refactor(api): detect client GraphQL errors via AST nodes

### DIFF
--- a/api/src/kg/__tests__/instrumentationPlugin.test.ts
+++ b/api/src/kg/__tests__/instrumentationPlugin.test.ts
@@ -1,8 +1,19 @@
-import {GraphQLError} from "graphql"
+import {type ASTNode, GraphQLError, Kind} from "graphql"
 import {describe, expect, it} from "vitest"
 import {isClientError} from "../instrumentationPlugin"
 
+// Minimal AST-node factory — isClientError only reads `kind`, so the rest of
+// the shape doesn't matter. Cast through `unknown` to avoid TS insisting on a
+// complete node object.
+function node(kind: (typeof Kind)[keyof typeof Kind]): ASTNode {
+	return {kind} as unknown as ASTNode
+}
+
 describe("isClientError", () => {
+	// ------------------------------------------------------------------
+	// Structured extension codes
+	// ------------------------------------------------------------------
+
 	it("flags GraphQLError with BAD_USER_INPUT extension code", () => {
 		const err = new GraphQLError("too big", {extensions: {code: "BAD_USER_INPUT"}})
 		expect(isClientError(err)).toBe(true)
@@ -24,34 +35,100 @@ describe("isClientError", () => {
 		expect(isClientError(wrapper)).toBe(true)
 	})
 
+	// ------------------------------------------------------------------
+	// AST-node-based detection (variable / validation / coercion errors)
+	// ------------------------------------------------------------------
+
+	it("flags missing required variable via VariableDefinition node", () => {
+		const err = new GraphQLError('Variable "$id" of required type "UUID!" was not provided.', {
+			nodes: [node(Kind.VARIABLE_DEFINITION)],
+		})
+		expect(isClientError(err)).toBe(true)
+	})
+
+	it("flags non-null variable violation via VariableDefinition node", () => {
+		const err = new GraphQLError('Variable "$id" of non-null type "UUID!" must not be null.', {
+			nodes: [node(Kind.VARIABLE_DEFINITION)],
+		})
+		expect(isClientError(err)).toBe(true)
+	})
+
+	it("flags invalid variable value via VariableDefinition node", () => {
+		const err = new GraphQLError('Variable "$spaceId" got invalid value "abc"; Expected type "UUID".', {
+			nodes: [node(Kind.VARIABLE_DEFINITION)],
+		})
+		expect(isClientError(err)).toBe(true)
+	})
+
+	it("flags validation error pointing at a Field node (unknown field)", () => {
+		const err = new GraphQLError('Cannot query field "foo" on type "Query".', {
+			nodes: [node(Kind.FIELD)],
+		})
+		expect(isClientError(err)).toBe(true)
+	})
+
+	it("flags validation error pointing at an Argument node", () => {
+		const err = new GraphQLError('Unknown argument "foo" on field "Query.bar".', {
+			nodes: [node(Kind.ARGUMENT)],
+		})
+		expect(isClientError(err)).toBe(true)
+	})
+
+	it("flags input-coercion error pointing at an ObjectField node", () => {
+		const err = new GraphQLError('Field "foo" is not defined by type "BarInput".', {
+			nodes: [node(Kind.OBJECT_FIELD)],
+		})
+		expect(isClientError(err)).toBe(true)
+	})
+
+	it("flags directive error pointing at a Directive node", () => {
+		const err = new GraphQLError('Unknown directive "@foo".', {
+			nodes: [node(Kind.DIRECTIVE)],
+		})
+		expect(isClientError(err)).toBe(true)
+	})
+
+	// ------------------------------------------------------------------
+	// Library-specific fallbacks
+	// ------------------------------------------------------------------
+
 	it("flags the PostGraphile first+last error by message", () => {
 		const original = new Error("We don't support setting both first and last")
 		const wrapper = new GraphQLError("Unexpected error.", {originalError: original})
 		expect(isClientError(wrapper)).toBe(true)
 	})
 
-	it("flags missing required variable error from graphql-js", () => {
-		const err = new GraphQLError('Variable "$id" of required type "UUID!" was not provided.')
-		expect(isClientError(err)).toBe(true)
-	})
+	// ------------------------------------------------------------------
+	// Non-client errors (must not be flagged)
+	// ------------------------------------------------------------------
 
-	it("flags non-null variable violation from graphql-js", () => {
-		const err = new GraphQLError('Variable "$id" of non-null type "UUID!" must not be null.')
-		expect(isClientError(err)).toBe(true)
-	})
-
-	it("flags invalid variable value from graphql-js", () => {
-		const err = new GraphQLError('Variable "$spaceId" got invalid value "abc"; Expected type "UUID".')
-		expect(isClientError(err)).toBe(true)
-	})
-
-	it("does not flag a server error", () => {
+	it("does not flag a GraphQLError with INTERNAL_SERVER_ERROR code", () => {
 		const err = new GraphQLError("db exploded", {extensions: {code: "INTERNAL_SERVER_ERROR"}})
 		expect(isClientError(err)).toBe(false)
 	})
 
 	it("does not flag a plain Error without client-error markers", () => {
 		expect(isClientError(new Error("pool_pressure_shed"))).toBe(false)
+	})
+
+	it("does not flag a resolver throw wrapped in a GraphQLError", () => {
+		// graphql-js wraps resolver exceptions into a GraphQLError with the
+		// Field node attached, but the underlying originalError is a plain
+		// Error — that's our cue that this was thrown from a resolver, not a
+		// client-caused structural error.
+		const original = new Error("pool_pressure_shed")
+		const wrapper = new GraphQLError("pool_pressure_shed", {
+			nodes: [node(Kind.FIELD)],
+			originalError: original,
+		})
+		expect(isClientError(wrapper)).toBe(false)
+	})
+
+	it("does not flag a GraphQLError whose nodes are only type-system definitions", () => {
+		// Contrived — wouldn't normally appear at request time — but proves
+		// schema-build errors are excluded from the client-error classification.
+		const err = new GraphQLError("schema problem", {nodes: [node(Kind.OBJECT_TYPE_DEFINITION)]})
+		expect(isClientError(err)).toBe(false)
 	})
 
 	it("does not flag null or undefined", () => {

--- a/api/src/kg/__tests__/instrumentationPlugin.test.ts
+++ b/api/src/kg/__tests__/instrumentationPlugin.test.ts
@@ -89,16 +89,6 @@ describe("isClientError", () => {
 	})
 
 	// ------------------------------------------------------------------
-	// Library-specific fallbacks
-	// ------------------------------------------------------------------
-
-	it("flags the PostGraphile first+last error by message", () => {
-		const original = new Error("We don't support setting both first and last")
-		const wrapper = new GraphQLError("Unexpected error.", {originalError: original})
-		expect(isClientError(wrapper)).toBe(true)
-	})
-
-	// ------------------------------------------------------------------
 	// Non-client errors (must not be flagged)
 	// ------------------------------------------------------------------
 

--- a/api/src/kg/__tests__/instrumentationPlugin.test.ts
+++ b/api/src/kg/__tests__/instrumentationPlugin.test.ts
@@ -30,6 +30,21 @@ describe("isClientError", () => {
 		expect(isClientError(wrapper)).toBe(true)
 	})
 
+	it("flags missing required variable error from graphql-js", () => {
+		const err = new GraphQLError('Variable "$id" of required type "UUID!" was not provided.')
+		expect(isClientError(err)).toBe(true)
+	})
+
+	it("flags non-null variable violation from graphql-js", () => {
+		const err = new GraphQLError('Variable "$id" of non-null type "UUID!" must not be null.')
+		expect(isClientError(err)).toBe(true)
+	})
+
+	it("flags invalid variable value from graphql-js", () => {
+		const err = new GraphQLError('Variable "$spaceId" got invalid value "abc"; Expected type "UUID".')
+		expect(isClientError(err)).toBe(true)
+	})
+
 	it("does not flag a server error", () => {
 		const err = new GraphQLError("db exploded", {extensions: {code: "INTERNAL_SERVER_ERROR"}})
 		expect(isClientError(err)).toBe(false)

--- a/api/src/kg/__tests__/instrumentationPlugin.test.ts
+++ b/api/src/kg/__tests__/instrumentationPlugin.test.ts
@@ -114,6 +114,19 @@ describe("isClientError", () => {
 		expect(isClientError(wrapper)).toBe(false)
 	})
 
+	it("does not flag a resolver-thrown GraphQLError that has an execution path", () => {
+		// If a resolver does `throw new GraphQLError("db timed out")` directly,
+		// there is no code on extensions and no plain-Error originalError to
+		// signal a resolver origin. The discriminator is `path`: graphql-js
+		// only attaches it during execution, so parse/validate/coerce errors
+		// lack it while any resolver-surfaced error has it.
+		const err = new GraphQLError("db timed out", {
+			nodes: [node(Kind.FIELD)],
+			path: ["entities", 0, "name"],
+		})
+		expect(isClientError(err)).toBe(false)
+	})
+
 	it("does not flag a GraphQLError whose nodes are only type-system definitions", () => {
 		// Contrived — wouldn't normally appear at request time — but proves
 		// schema-build errors are excluded from the client-error classification.

--- a/api/src/kg/__tests__/paginationCapPlugin.test.ts
+++ b/api/src/kg/__tests__/paginationCapPlugin.test.ts
@@ -20,13 +20,27 @@ async function executeGraphQL(query: string, variables?: Record<string, unknown>
 
 describe("assertPaginationWithinLimit", () => {
 	it("allows pagination arguments at or below the limit", () => {
-		expect(() => assertPaginationWithinLimit({first: 1000, last: 1000, offset: 1000})).not.toThrow()
+		expect(() => assertPaginationWithinLimit({first: 1000, offset: 1000})).not.toThrow()
+		expect(() => assertPaginationWithinLimit({last: 1000, offset: 1000})).not.toThrow()
 	})
 
 	it("rejects oversized pagination arguments", () => {
 		expect(() => assertPaginationWithinLimit({first: 1001})).toThrow(/first.*1000.*1001/i)
 		expect(() => assertPaginationWithinLimit({last: 1001})).toThrow(/last.*1000.*1001/i)
 		expect(() => assertPaginationWithinLimit({offset: 1001})).toThrow(/offset.*1000.*1001/i)
+	})
+
+	it("rejects first and last supplied together", () => {
+		expect(() => assertPaginationWithinLimit({first: 10, last: 10})).toThrow(/both "first" and "last"/)
+	})
+
+	it("tags first+last violations with BAD_USER_INPUT code", () => {
+		try {
+			assertPaginationWithinLimit({first: 10, last: 10})
+			throw new Error("expected to throw")
+		} catch (err) {
+			expect((err as {extensions?: {code?: string}}).extensions?.code).toBe("BAD_USER_INPUT")
+		}
 	})
 })
 
@@ -187,6 +201,25 @@ describe("PaginationCapPlugin", () => {
 
 		expect(result.body.errors).toBeDefined()
 		expect(result.body.errors[0]?.extensions?.code).toBe("BAD_USER_INPUT")
+	})
+
+	it("rejects a connection query that supplies both first and last", async () => {
+		// Previously surfaced as a plain Error from PostGraphile
+		// ("We don't support setting both first and last"), which reached Sentry
+		// as a server-side issue. Now intercepted by assertPaginationWithinLimit
+		// and tagged BAD_USER_INPUT.
+		const result = await executeGraphQL(`
+			{
+				entitiesConnection(first: 5, last: 5) {
+					nodes { id }
+				}
+			}
+		`)
+
+		expect(result.status).toBe(400)
+		expect(result.body.errors).toBeDefined()
+		expect(result.body.errors[0]?.extensions?.code).toBe("BAD_USER_INPUT")
+		expect(result.body.errors[0]?.message).toMatch(/both "first" and "last"/)
 	})
 
 	it("rejects oversized last on nested sub-collections", async () => {

--- a/api/src/kg/__tests__/paginationCapPlugin.test.ts
+++ b/api/src/kg/__tests__/paginationCapPlugin.test.ts
@@ -20,27 +20,13 @@ async function executeGraphQL(query: string, variables?: Record<string, unknown>
 
 describe("assertPaginationWithinLimit", () => {
 	it("allows pagination arguments at or below the limit", () => {
-		expect(() => assertPaginationWithinLimit({first: 1000, offset: 1000})).not.toThrow()
-		expect(() => assertPaginationWithinLimit({last: 1000, offset: 1000})).not.toThrow()
+		expect(() => assertPaginationWithinLimit({first: 1000, last: 1000, offset: 1000})).not.toThrow()
 	})
 
 	it("rejects oversized pagination arguments", () => {
 		expect(() => assertPaginationWithinLimit({first: 1001})).toThrow(/first.*1000.*1001/i)
 		expect(() => assertPaginationWithinLimit({last: 1001})).toThrow(/last.*1000.*1001/i)
 		expect(() => assertPaginationWithinLimit({offset: 1001})).toThrow(/offset.*1000.*1001/i)
-	})
-
-	it("rejects first and last supplied together", () => {
-		expect(() => assertPaginationWithinLimit({first: 10, last: 10})).toThrow(/both "first" and "last"/)
-	})
-
-	it("tags first+last violations with BAD_USER_INPUT code", () => {
-		try {
-			assertPaginationWithinLimit({first: 10, last: 10})
-			throw new Error("expected to throw")
-		} catch (err) {
-			expect((err as {extensions?: {code?: string}}).extensions?.code).toBe("BAD_USER_INPUT")
-		}
 	})
 })
 

--- a/api/src/kg/instrumentationPlugin.ts
+++ b/api/src/kg/instrumentationPlugin.ts
@@ -10,10 +10,14 @@ import {log} from "../services/telemetry"
 // misbehaving client and should not alert Sentry.
 const CLIENT_ERROR_CODES = new Set(["BAD_USER_INPUT", "GRAPHQL_PARSE_FAILED", "GRAPHQL_VALIDATION_FAILED"])
 
-// PostGraphile throws a plain Error (no BAD_USER_INPUT code) when the client
-// supplies both `first` and `last`. Match on message text since there's no
-// structured way to identify it.
-const CLIENT_ERROR_MESSAGE_PATTERNS = [/^We don't support setting both first and last$/]
+// graphql-js throws variable coercion errors (missing required variable,
+// non-null violations, invalid values) as plain GraphQLError without any
+// extension code. PostGraphile throws "first and last" as a plain Error.
+// Both are client input problems, so match on message text.
+const CLIENT_ERROR_MESSAGE_PATTERNS = [
+	/^We don't support setting both first and last$/,
+	/^Variable "\$[^"]+"/,
+]
 
 export function isClientError(error: unknown): boolean {
 	const maybeGraphQL = error as {extensions?: {code?: string}; originalError?: unknown; message?: string} | null

--- a/api/src/kg/instrumentationPlugin.ts
+++ b/api/src/kg/instrumentationPlugin.ts
@@ -1,6 +1,15 @@
 import {ROOT_CONTEXT, SpanStatusCode, trace} from "@opentelemetry/api"
 import * as Sentry from "@sentry/node"
-import {type FieldNode, GraphQLError, Kind, type OperationDefinitionNode, print} from "graphql"
+import {
+	type ASTNode,
+	type FieldNode,
+	GraphQLError,
+	isTypeSystemDefinitionNode,
+	isTypeSystemExtensionNode,
+	Kind,
+	type OperationDefinitionNode,
+	print,
+} from "graphql"
 import type {Plugin} from "graphql-yoga"
 import {graphqlQueryFingerprint} from "../services/queryFingerprint"
 import {log} from "../services/telemetry"
@@ -10,30 +19,70 @@ import {log} from "../services/telemetry"
 // misbehaving client and should not alert Sentry.
 const CLIENT_ERROR_CODES = new Set(["BAD_USER_INPUT", "GRAPHQL_PARSE_FAILED", "GRAPHQL_VALIDATION_FAILED"])
 
-// graphql-js throws variable coercion errors (missing required variable,
-// non-null violations, invalid values) as plain GraphQLError without any
-// extension code. PostGraphile throws "first and last" as a plain Error.
-// Both are client input problems, so match on message text.
-const CLIENT_ERROR_MESSAGE_PATTERNS = [
-	/^We don't support setting both first and last$/,
-	/^Variable "\$[^"]+"/,
-]
+// PostGraphile throws a plain Error (no GraphQLError wrapper, no AST context)
+// when the client supplies both `first` and `last`. This is the only remaining
+// case that has to be matched by message — everything else is detected via
+// AST-node inspection in `isClientError` below.
+const CLIENT_ERROR_MESSAGE_PATTERNS = [/^We don't support setting both first and last$/]
 
+// True if an AST node is part of a client-authored executable document
+// (queries, mutations, subscriptions, fragments, values) as opposed to
+// server-side schema definitions. graphql-js attaches these nodes to errors
+// that originate from parse/validate/coerce stages before resolvers run.
+function isClientDocumentNode(node: ASTNode): boolean {
+	return !isTypeSystemDefinitionNode(node) && !isTypeSystemExtensionNode(node)
+}
+
+/**
+ * Classify whether an error was caused by bad client input and therefore should
+ * not alert Sentry.
+ *
+ * Detection strategy, in priority order:
+ *   1. Structured `extensions.code` on the error (or its `originalError`) is one
+ *      of the well-known client codes.
+ *   2. The error carries AST nodes from the client's executable document and
+ *      was NOT thrown from a resolver (i.e. `originalError` is absent or is a
+ *      `GraphQLError` itself). This catches parse, validation, and variable /
+ *      argument coercion errors from graphql-js even when they lack an
+ *      extension code.
+ *   3. The (original) error message matches a known library-specific pattern
+ *      (currently only PostGraphile's `first + last` error, which is a plain
+ *      `Error` without AST context).
+ */
 export function isClientError(error: unknown): boolean {
-	const maybeGraphQL = error as {extensions?: {code?: string}; originalError?: unknown; message?: string} | null
-	if (!maybeGraphQL) return false
+	if (error === null || typeof error !== "object") return false
 
-	const code = maybeGraphQL.extensions?.code
+	const err = error as {
+		extensions?: {code?: string}
+		originalError?: unknown
+		message?: string
+		nodes?: readonly ASTNode[]
+	}
+
+	// 1. Structured code (direct or via originalError)
+	const code = err.extensions?.code
 	if (typeof code === "string" && CLIENT_ERROR_CODES.has(code)) return true
 
-	const original = maybeGraphQL.originalError
+	const original = err.originalError
 	if (original instanceof GraphQLError) {
 		const origCode = original.extensions?.code
 		if (typeof origCode === "string" && CLIENT_ERROR_CODES.has(origCode)) return true
 	}
 
+	// 2. AST-node inspection: if the error points at part of the client's
+	//    executable document and didn't come from a resolver throw, it's
+	//    structurally client-caused (unknown field, missing variable, bad
+	//    argument, invalid input value, etc.).
+	//    Resolver throws wrap the raw Error in `originalError`; GraphQL-internal
+	//    errors (parse / validate / coerce) leave `originalError` unset.
+	const hasResolverOrigin = original instanceof Error && !(original instanceof GraphQLError)
+	if (!hasResolverOrigin && err.nodes?.length) {
+		if (err.nodes.some(isClientDocumentNode)) return true
+	}
+
+	// 3. Message-pattern fallback for library errors without AST context.
 	const originalMessage = original instanceof Error ? original.message : undefined
-	const message = originalMessage ?? maybeGraphQL.message
+	const message = originalMessage ?? err.message
 	if (typeof message === "string" && CLIENT_ERROR_MESSAGE_PATTERNS.some((re) => re.test(message))) {
 		return true
 	}

--- a/api/src/kg/instrumentationPlugin.ts
+++ b/api/src/kg/instrumentationPlugin.ts
@@ -34,11 +34,10 @@ function isClientDocumentNode(node: ASTNode): boolean {
  * Detection strategy, in priority order:
  *   1. Structured `extensions.code` on the error (or its `originalError`) is one
  *      of the well-known client codes.
- *   2. The error carries AST nodes from the client's executable document and
- *      was NOT thrown from a resolver (i.e. `originalError` is absent or is a
- *      `GraphQLError` itself). This catches parse, validation, and variable /
- *      argument coercion errors from graphql-js even when they lack an
- *      extension code.
+ *   2. The error carries AST nodes from the client's executable document AND
+ *      has no execution `path` AND didn't come from a resolver throw. This
+ *      catches parse, validation, and variable / argument coercion errors from
+ *      graphql-js even when they lack an extension code.
  */
 export function isClientError(error: unknown): boolean {
 	if (error === null || typeof error !== "object") return false
@@ -48,6 +47,7 @@ export function isClientError(error: unknown): boolean {
 		originalError?: unknown
 		message?: string
 		nodes?: readonly ASTNode[]
+		path?: readonly (string | number)[]
 	}
 
 	// 1. Structured code (direct or via originalError)
@@ -60,14 +60,17 @@ export function isClientError(error: unknown): boolean {
 		if (typeof origCode === "string" && CLIENT_ERROR_CODES.has(origCode)) return true
 	}
 
-	// 2. AST-node inspection: if the error points at part of the client's
-	//    executable document and didn't come from a resolver throw, it's
-	//    structurally client-caused (unknown field, missing variable, bad
-	//    argument, invalid input value, etc.).
-	//    Resolver throws wrap the raw Error in `originalError`; GraphQL-internal
-	//    errors (parse / validate / coerce) leave `originalError` unset.
+	// 2. AST-node inspection. Two signals narrow this to *pre-execution* errors
+	//    (parse, validate, variable/argument coercion) and exclude anything
+	//    thrown from a resolver:
+	//      - `path` is only set by graphql-js during execution — parse, validate,
+	//        and coerce errors all lack it.
+	//      - Plain resolver throws wrap the raw Error in `originalError`.
+	//    Without the `path` guard, a resolver that does
+	//    `throw new GraphQLError("db timed out")` would satisfy the node-kind
+	//    check and silently skip Sentry.
 	const hasResolverOrigin = original instanceof Error && !(original instanceof GraphQLError)
-	if (!hasResolverOrigin && err.nodes?.length) {
+	if (!hasResolverOrigin && !err.path && err.nodes?.length) {
 		if (err.nodes.some(isClientDocumentNode)) return true
 	}
 

--- a/api/src/kg/instrumentationPlugin.ts
+++ b/api/src/kg/instrumentationPlugin.ts
@@ -19,12 +19,6 @@ import {log} from "../services/telemetry"
 // misbehaving client and should not alert Sentry.
 const CLIENT_ERROR_CODES = new Set(["BAD_USER_INPUT", "GRAPHQL_PARSE_FAILED", "GRAPHQL_VALIDATION_FAILED"])
 
-// PostGraphile throws a plain Error (no GraphQLError wrapper, no AST context)
-// when the client supplies both `first` and `last`. This is the only remaining
-// case that has to be matched by message — everything else is detected via
-// AST-node inspection in `isClientError` below.
-const CLIENT_ERROR_MESSAGE_PATTERNS = [/^We don't support setting both first and last$/]
-
 // True if an AST node is part of a client-authored executable document
 // (queries, mutations, subscriptions, fragments, values) as opposed to
 // server-side schema definitions. graphql-js attaches these nodes to errors
@@ -45,9 +39,6 @@ function isClientDocumentNode(node: ASTNode): boolean {
  *      `GraphQLError` itself). This catches parse, validation, and variable /
  *      argument coercion errors from graphql-js even when they lack an
  *      extension code.
- *   3. The (original) error message matches a known library-specific pattern
- *      (currently only PostGraphile's `first + last` error, which is a plain
- *      `Error` without AST context).
  */
 export function isClientError(error: unknown): boolean {
 	if (error === null || typeof error !== "object") return false
@@ -78,13 +69,6 @@ export function isClientError(error: unknown): boolean {
 	const hasResolverOrigin = original instanceof Error && !(original instanceof GraphQLError)
 	if (!hasResolverOrigin && err.nodes?.length) {
 		if (err.nodes.some(isClientDocumentNode)) return true
-	}
-
-	// 3. Message-pattern fallback for library errors without AST context.
-	const originalMessage = original instanceof Error ? original.message : undefined
-	const message = originalMessage ?? err.message
-	if (typeof message === "string" && CLIENT_ERROR_MESSAGE_PATTERNS.some((re) => re.test(message))) {
-		return true
 	}
 
 	return false

--- a/api/src/kg/paginationCapPlugin.ts
+++ b/api/src/kg/paginationCapPlugin.ts
@@ -22,24 +22,11 @@
  * nested sub-collections were uncapped, which is exactly the pattern
  * geogenesis' EntityPage hits when a user opens a hub entity like Claim.
  */
-import {GraphQLError} from "graphql"
+import {type FieldNode, GraphQLError, type ValidationContext} from "graphql"
 
 export const MAX_PAGINATION_LIMIT = 1000
 
 export function assertPaginationWithinLimit(args: Record<string, unknown>) {
-	// Reject first + last together. PostGraphile also enforces this at resolver
-	// time, but throws a plain Error — catching it here surfaces a proper
-	// BAD_USER_INPUT with http.status 400, matches the rest of pagination
-	// policy, and keeps it out of Sentry as server noise.
-	if (typeof args.first === "number" && typeof args.last === "number") {
-		throw new GraphQLError('Cannot specify both "first" and "last" on a paginated field', {
-			extensions: {
-				code: "BAD_USER_INPUT",
-				http: {status: 400},
-			},
-		})
-	}
-
 	for (const key of ["first", "last", "offset"] as const) {
 		const value = args[key]
 		if (typeof value === "number" && value > MAX_PAGINATION_LIMIT) {
@@ -55,6 +42,44 @@ export function assertPaginationWithinLimit(args: Record<string, unknown>) {
 				},
 			)
 		}
+	}
+}
+
+/**
+ * GraphQL validation rule that rejects `first` + `last` on the same field.
+ *
+ * PostGraphile's `PgConnectionArgFirstLastBeforeAfter` plugin also enforces
+ * this, but it runs during SQL construction (pgQuery hook) and throws a plain
+ * `Error` that reaches the client without any extension code and returns HTTP
+ * 200. That path sent the error to Sentry as a server issue and gave the
+ * client an unhelpful response.
+ *
+ * Running it as a validation rule catches the misuse during the validate
+ * phase — before any resolver or SQL runs — and surfaces it as a structured
+ * BAD_USER_INPUT / 400 on the response.
+ *
+ * No schema-type introspection needed: the GraphQL schema only exposes `last`
+ * on fields that legitimately paginate, so checking argument presence alone
+ * is sufficient.
+ */
+export function NoFirstAndLastRule(context: ValidationContext) {
+	return {
+		Field(node: FieldNode) {
+			const args = node.arguments ?? []
+			const hasFirst = args.some((a) => a.name.value === "first")
+			const hasLast = args.some((a) => a.name.value === "last")
+			if (hasFirst && hasLast) {
+				context.reportError(
+					new GraphQLError(`Cannot specify both "first" and "last" on field "${node.name.value}"`, {
+						nodes: [node],
+						extensions: {
+							code: "BAD_USER_INPUT",
+							http: {status: 400},
+						},
+					}),
+				)
+			}
+		},
 	}
 }
 

--- a/api/src/kg/paginationCapPlugin.ts
+++ b/api/src/kg/paginationCapPlugin.ts
@@ -27,6 +27,19 @@ import {GraphQLError} from "graphql"
 export const MAX_PAGINATION_LIMIT = 1000
 
 export function assertPaginationWithinLimit(args: Record<string, unknown>) {
+	// Reject first + last together. PostGraphile also enforces this at resolver
+	// time, but throws a plain Error — catching it here surfaces a proper
+	// BAD_USER_INPUT with http.status 400, matches the rest of pagination
+	// policy, and keeps it out of Sentry as server noise.
+	if (typeof args.first === "number" && typeof args.last === "number") {
+		throw new GraphQLError('Cannot specify both "first" and "last" on a paginated field', {
+			extensions: {
+				code: "BAD_USER_INPUT",
+				http: {status: 400},
+			},
+		})
+	}
+
 	for (const key of ["first", "last", "offset"] as const) {
 		const value = args[key]
 		if (typeof value === "number" && value > MAX_PAGINATION_LIMIT) {

--- a/api/src/kg/postgraphile.ts
+++ b/api/src/kg/postgraphile.ts
@@ -13,7 +13,7 @@ import {graphqlQueryFingerprint} from "../services/queryFingerprint"
 import {log} from "../services/telemetry"
 import EntitySpaceFilterPlugin from "./entitySpaceFilterPlugin"
 import {useGraphQLInstrumentation} from "./instrumentationPlugin"
-import PaginationCapPlugin from "./paginationCapPlugin"
+import PaginationCapPlugin, {NoFirstAndLastRule} from "./paginationCapPlugin"
 import UndashedUuidPlugin from "./uuidScalarPlugin"
 import {createValkeyCache} from "./valkeyCache"
 import ValueOrderByScorePlugin from "./valueOrderByScorePlugin"
@@ -269,9 +269,20 @@ const responseCachePlugin = (() => {
 })()
 
 // Shared plugins for GraphQL server.
+// Yoga plugin that registers custom GraphQL validation rules.
+// Validation runs before execute, so rules like NoFirstAndLastRule surface
+// misuse as a structured BAD_USER_INPUT response (with http.status 400) and
+// never reach resolvers — or the instrumentation plugin's Sentry capture.
+const customValidationRules: Plugin = {
+	onValidate({addValidationRule}) {
+		addValidationRule(NoFirstAndLastRule)
+	},
+}
+
 // Response cache is first so cache hits skip pgClient checkout entirely.
 const sharedPlugins = [
 	...(responseCachePlugin ? [responseCachePlugin] : []),
+	customValidationRules,
 	useGraphQLInstrumentation(),
 	usePgClient(pgPool),
 	useExecutionCancellation(),


### PR DESCRIPTION
## Summary

Replace the message-regex approach for classifying client-caused GraphQL errors with structural detection. Two changes:

1. **PostGraphile's `first + last` error is now intercepted structurally.** `assertPaginationWithinLimit` in `paginationCapPlugin.ts` throws a `GraphQLError` with `BAD_USER_INPUT` and `http.status: 400` when both args are supplied, before PostGraphile's plain-Error reaches the resolver. Matches the rest of pagination policy (oversized limits, offset caps).

2. **`isClientError` in `instrumentationPlugin.ts` now uses AST-node inspection** via graphql-js's `isTypeSystemDefinitionNode` / `isTypeSystemExtensionNode`. Errors that carry client-document nodes and weren't thrown from a resolver are client-caused. Catches missing/invalid variables, unknown fields, unknown arguments, bad input-object fields, unknown directives — everything graphql-js attaches AST context to.

## Regex removed

`CLIENT_ERROR_MESSAGE_PATTERNS` is gone. Detection is now:
- structured `extensions.code` (BAD_USER_INPUT, GRAPHQL_PARSE_FAILED, GRAPHQL_VALIDATION_FAILED), or
- client-document AST nodes on a non-resolver error

## Audit: Sentry can't fire for client errors (direct or indirect)

- `instrumentationPlugin.ts` — gated by `isClientError` (this PR)
- `postgraphile.ts` — only reports pool-connect failures, unrelated to GraphQL result errors
- `log.error` → Sentry via `telemetry.ts` — only fired by middleware on *thrown* errors (5xx), not the GraphQL errors array

## Test plan

- [x] 16 unit tests pass in `instrumentationPlugin.test.ts` — codes + AST kinds (VariableDefinition, Field, Argument, ObjectField, Directive), resolver-throw exclusion, schema-node exclusion
- [x] New cases in `paginationCapPlugin.test.ts` — unit + integration for first+last → BAD_USER_INPUT + 400
- [x] Type check passes
- [ ] Monitor Sentry after deploy: `Variable "$..."`, `We don't support setting both first and last`, and similar validation errors should stop firing