### PR TITLE
fix(api): log full diagnostics on IPFS gateway errors

### DIFF
--- a/api/src/services/ipfs.ts
+++ b/api/src/services/ipfs.ts
@@ -156,7 +156,7 @@ export function upload(formData: FormData, url: string) {
 
 		const responseText = yield* Effect.tryPromise({
 			try: () => response.text(),
-			catch: (error) => new IpfsParseResponseError(`Could not read IPFS response body: ${error}`),
+			catch: (error) => new IpfsParseResponseError(`Could not parse IPFS JSON response: ${error}`),
 		})
 
 		const diagnostics = {

--- a/api/src/services/ipfs.ts
+++ b/api/src/services/ipfs.ts
@@ -156,7 +156,7 @@ export function upload(formData: FormData, url: string) {
 
 		const responseText = yield* Effect.tryPromise({
 			try: () => response.text(),
-			catch: (error) => new IpfsParseResponseError(`Could not parse IPFS JSON response: ${error}`),
+			catch: (error) => new IpfsParseResponseError(`Could not read IPFS response body: ${error}`),
 		})
 
 		const diagnostics = {

--- a/api/src/services/ipfs.ts
+++ b/api/src/services/ipfs.ts
@@ -179,19 +179,12 @@ export function upload(formData: FormData, url: string) {
 
 		if (!response.ok) {
 			yield* Effect.logWarning("[IPFS] gateway returned non-2xx status", diagnostics)
-			yield* Effect.fail(
-				new IpfsUploadError(
-					`IPFS gateway HTTP ${response.status} ${response.statusText}: ${diagnostics.bodyPreview}`,
-				),
-			)
+			yield* Effect.fail(new IpfsUploadError(`IPFS gateway HTTP ${response.status} ${response.statusText}`))
 		}
 
 		const responseJson = yield* Effect.try({
 			try: () => JSON.parse(responseText) as {error?: unknown; data?: {cid?: string}},
-			catch: () =>
-				new IpfsParseResponseError(
-					`IPFS response not JSON (status=${response.status}): ${diagnostics.bodyPreview}`,
-				),
+			catch: () => new IpfsParseResponseError(`Could not parse IPFS JSON response (status=${response.status})`),
 		}).pipe(Effect.tapError(() => Effect.logWarning("[IPFS] gateway returned non-JSON response", diagnostics)))
 
 		// Handle error responses from gateway

--- a/api/src/services/ipfs.ts
+++ b/api/src/services/ipfs.ts
@@ -140,6 +140,7 @@ class IpfsParseResponseError extends Error {
 export function upload(formData: FormData, url: string) {
 	return Effect.gen(function* () {
 		const config = yield* Environment
+		const requestStart = Date.now()
 
 		const response = yield* Effect.tryPromise({
 			try: () =>
@@ -153,24 +154,65 @@ export function upload(formData: FormData, url: string) {
 			catch: (error) => new IpfsUploadError(`IPFS fetch failed: ${error}`),
 		})
 
-		const responseJson = yield* Effect.tryPromise({
-			try: () => response.json(),
-			catch: (error) => new IpfsParseResponseError(`Could not parse IPFS JSON response: ${error}`),
+		const responseText = yield* Effect.tryPromise({
+			try: () => response.text(),
+			catch: (error) => new IpfsParseResponseError(`Could not read IPFS response body: ${error}`),
 		})
+
+		const diagnostics = {
+			url,
+			httpStatus: response.status,
+			httpStatusText: response.statusText,
+			responseTimeMs: Date.now() - requestStart,
+			contentType: response.headers.get("content-type"),
+			contentLength: response.headers.get("content-length"),
+			pinataRequestId: response.headers.get("x-pinata-request-id") ?? response.headers.get("x-request-id"),
+			cfRay: response.headers.get("cf-ray"),
+			server: response.headers.get("server"),
+			retryAfter: response.headers.get("retry-after"),
+			rateLimitLimit: response.headers.get("x-ratelimit-limit"),
+			rateLimitRemaining: response.headers.get("x-ratelimit-remaining"),
+			rateLimitReset: response.headers.get("x-ratelimit-reset"),
+			bodyLength: responseText.length,
+			bodyPreview: responseText.slice(0, 1000),
+		}
+
+		if (!response.ok) {
+			yield* Effect.logWarning("[IPFS] gateway returned non-2xx status", diagnostics)
+			yield* Effect.fail(
+				new IpfsUploadError(
+					`IPFS gateway HTTP ${response.status} ${response.statusText}: ${diagnostics.bodyPreview}`,
+				),
+			)
+		}
+
+		const responseJson = yield* Effect.try({
+			try: () => JSON.parse(responseText) as {error?: unknown; data?: {cid?: string}},
+			catch: () =>
+				new IpfsParseResponseError(
+					`IPFS response not JSON (status=${response.status}): ${diagnostics.bodyPreview}`,
+				),
+		}).pipe(Effect.tapError(() => Effect.logWarning("[IPFS] gateway returned non-JSON response", diagnostics)))
 
 		// Handle error responses from gateway
 		if (responseJson.error) {
 			const errorMsg =
-				typeof responseJson.error === "object"
-					? responseJson.error.message || JSON.stringify(responseJson.error)
+				typeof responseJson.error === "object" && responseJson.error !== null
+					? ((responseJson.error as {message?: string}).message ?? JSON.stringify(responseJson.error))
 					: String(responseJson.error)
+			yield* Effect.logWarning("[IPFS] gateway returned error in body", {
+				...diagnostics,
+				gatewayErrorMessage: errorMsg,
+			})
 			yield* Effect.fail(new IpfsUploadError(`IPFS gateway error: ${errorMsg}`))
 		}
 
-		if (!responseJson.data?.cid) {
-			yield* Effect.fail(new IpfsUploadError("IPFS gateway returned no CID"))
+		const cid = responseJson.data?.cid
+		if (!cid) {
+			yield* Effect.logWarning("[IPFS] gateway returned no CID", diagnostics)
+			return yield* Effect.fail(new IpfsUploadError("IPFS gateway returned no CID"))
 		}
 
-		return `ipfs://${responseJson.data.cid}` as const
+		return `ipfs://${cid}` as const
 	}).pipe(Effect.withSpan("ipfs.upload"))
 }

--- a/api/src/services/ipfs.ts
+++ b/api/src/services/ipfs.ts
@@ -198,7 +198,7 @@ export function upload(formData: FormData, url: string) {
 		if (responseJson.error) {
 			const errorMsg =
 				typeof responseJson.error === "object" && responseJson.error !== null
-					? ((responseJson.error as {message?: string}).message ?? JSON.stringify(responseJson.error))
+					? (responseJson.error as {message?: string}).message || JSON.stringify(responseJson.error)
 					: String(responseJson.error)
 			yield* Effect.logWarning("[IPFS] gateway returned error in body", {
 				...diagnostics,


### PR DESCRIPTION
## Summary

- Capture and log HTTP status, response time, Pinata/Cloudflare request IDs, rate-limit headers, and response body preview on every IPFS upload error path
- Handle non-JSON response bodies and non-2xx HTTP statuses as distinct failure cases (previously both surfaced as a generic JSON parse failure)
- Emit `Effect.logWarning` with the full diagnostic snapshot before each `Effect.fail`, so Sentry breadcrumbs carry per-attempt context for every retry

## Motivation

Production `IPFS gateway error: client disconnected` events at `ipfs.ts:167` currently surface no context about:
- Which HTTP status Pinata returned (2xx-with-error-body vs 4xx vs 5xx)
- Which Pinata edge / Cloudflare node handled the request
- Whether we were rate-limited (`retry-after`, `x-ratelimit-*`)
- What the actual response body looked like beyond the first `error` field

Two observed Sentry events (2026-04-15, 2026-04-20) show identical failure signatures (10 attempts, ~49s duration, 209-byte and 4,300-byte payloads), which rules out payload size and stalled-socket hypotheses. The current error message is too opaque to identify the root cause; this PR adds the observability needed to diagnose it.

## Test plan

- [x] `bun run format:check`
- [x] `bun run lint` (0 errors, pre-existing 132 warnings unchanged)
- [x] `bun run check` (typecheck)
- [x] `bun run test --exclude "**/__tests__/**"` (108 unit tests pass)
- [ ] After merge + deploy: verify the next IPFS upload error event in Sentry surfaces the new `pinataRequestId`, `httpStatus`, `rateLimitRemaining`, and `bodyPreview` fields