### PR TITLE
feat(hermes): update protobuf definitions

### DIFF
--- a/hermes-schema/proto/governance.proto
+++ b/hermes-schema/proto/governance.proto
@@ -83,12 +83,17 @@ message UnflagAction {
   bytes content_id = 1;  // Content identifier being unflagged
 }
 
-// Decoded action: update voting settings
+// Decoded action: update voting settings (V2 — 7 fields matching contract VotingSettings)
 message UpdateVotingSettingsAction {
-  uint64 quorum = 1;            // Minimum total votes required
-  uint64 fast_threshold = 2;    // Fast path: absolute YES votes needed
-  uint64 slow_threshold = 3;    // Slow path: percentage of RATIO_BASE (10,000,000)
-  uint64 duration = 4;          // Voting duration
+  reserved 1, 2, 3, 4;
+  reserved "fast_threshold", "slow_threshold";
+  uint64 partial_percentage_support_threshold = 5;      // Slow path late execution (0..RATIO_BASE)
+  uint64 universal_percentage_support_threshold = 6;    // Slow path early execution (0..RATIO_BASE)
+  uint64 flat_support_threshold = 7;                    // Fast path absolute YES votes
+  uint64 quorum = 8;                                    // Minimum participating votes for slow path
+  uint64 duration = 9;                                  // Voting window duration in seconds
+  bool disable_fast_path_access_for_new_members = 10;   // Whether new members get fast-path access
+  uint64 execution_grace_period = 11;                   // Seconds after lastDate that execution is allowed
 }
 
 // Decoded action: subspace edge operation (add/remove verified or related edge)
@@ -139,14 +144,19 @@ message ProposalAction {
   }
 }
 
-// Voting settings for a proposal, from PROPOSAL_SETTINGS_USED event
+// Voting settings for a proposal, from PROPOSAL_SETTINGS_SELECTED event.
+// V2 — 8 fields matching contract ProposalParameters, with per-proposal executeBy.
 message ProposalSettings {
-  uint64 start_date = 1;              // Block timestamp when voting starts
-  uint64 last_date = 2;               // Block timestamp when voting ends
-  VotingMode voting_mode = 3;         // Slow (0) or Fast (1)
-  uint64 quorum = 4;                  // Minimum total votes for slow path
-  uint64 flat_threshold = 5;          // Fast path: absolute number of YES votes needed
-  uint64 percentage_threshold = 6;    // Slow path: percentage of RATIO_BASE (10,000,000)
+  reserved 1, 2, 3, 4, 5, 6;
+  reserved "flat_threshold", "percentage_threshold";
+  VotingMode voting_mode = 7;                           // Slow (0) or Fast (1)
+  uint64 partial_percentage_support_threshold = 8;      // Slow path late execution (0..RATIO_BASE)
+  uint64 universal_percentage_support_threshold = 9;    // Slow path early execution (0..RATIO_BASE)
+  uint64 flat_support_threshold = 10;                   // Fast path absolute YES votes
+  uint64 quorum = 11;                                   // Minimum participating votes for slow path
+  uint64 start_date = 12;                               // Block timestamp when voting starts
+  uint64 last_date = 13;                                // Block timestamp when voting ends
+  uint64 execute_by = 14;                               // Inclusive upper bound timestamp for execution
 }
 
 // HermesProposalCreated - squashed from PROPOSAL_CREATED + PROPOSAL_SETTINGS_USED
@@ -178,13 +188,14 @@ message HermesProposalUpdated {
 }
 
 // HermesProposalVoted - emitted when a vote is cast on a proposal
-// Data encoding: abi.encode(bytes16 proposalId, VoteOption)
+// Data encoding: abi.encode(bytes16 proposalId, uint8 proposalVersion, VoteOption)
 message HermesProposalVoted {
   bytes voter_id = 1;                                   // 16 bytes - space casting the vote (from from_id)
   bytes space_id = 2;                                   // 16 bytes - space that owns the proposal (from to_id)
   bytes proposal_id = 3;                                // 16 bytes - proposal being voted on
   ProposalVoteOption vote = 4;                          // The vote cast
   blockchain_metadata.BlockchainMetadata meta = 5;
+  uint32 proposal_version = 6;                          // Proposal version being voted on (uint8 on-chain)
 }
 
 // HermesProposalExecuted - emitted when a passed proposal is executed
@@ -205,4 +216,19 @@ message HermesProposalSettingsUpdated {
   bytes proposal_id = 2;                                // 16 bytes - proposal identifier
   ProposalSettings settings = 3;                        // Updated voting settings
   blockchain_metadata.BlockchainMetadata meta = 4;
+}
+
+// HermesVotingSettingsUpdated - emitted when DAO-global voting settings change.
+// Data encoding: abi.encode(VotingSettings) — the full 7-field V2 struct.
+// Subject topic is bytes32(0) since this is a space-level (not proposal-level) event.
+message HermesVotingSettingsUpdated {
+  bytes space_id = 1;                                   // 16 bytes - space whose settings changed (from_id)
+  uint64 partial_percentage_support_threshold = 2;      // Slow path late execution threshold (0..RATIO_BASE)
+  uint64 universal_percentage_support_threshold = 3;    // Slow path early execution threshold (0..RATIO_BASE)
+  uint64 flat_support_threshold = 4;                    // Fast path absolute YES votes needed
+  uint64 quorum = 5;                                    // Minimum participating votes for slow path
+  uint64 duration = 6;                                  // Voting window duration in seconds
+  bool disable_fast_path_access_for_new_members = 7;    // Whether newly added members get fast-path access
+  uint64 execution_grace_period = 8;                    // Seconds after lastDate that execution is allowed
+  blockchain_metadata.BlockchainMetadata meta = 9;
 }

--- a/hermes-schema/src/pb/governance.rs
+++ b/hermes-schema/src/pb/governance.rs
@@ -61,6 +61,31 @@ pub struct UnflagAction {
     #[prost(bytes = "vec", tag = "1")]
     pub content_id: ::prost::alloc::vec::Vec<u8>,
 }
+/// Decoded action: update voting settings (V2 — 7 fields matching contract VotingSettings)
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct UpdateVotingSettingsAction {
+    /// Slow path late execution (0..RATIO_BASE)
+    #[prost(uint64, tag = "5")]
+    pub partial_percentage_support_threshold: u64,
+    /// Slow path early execution (0..RATIO_BASE)
+    #[prost(uint64, tag = "6")]
+    pub universal_percentage_support_threshold: u64,
+    /// Fast path absolute YES votes
+    #[prost(uint64, tag = "7")]
+    pub flat_support_threshold: u64,
+    /// Minimum participating votes for slow path
+    #[prost(uint64, tag = "8")]
+    pub quorum: u64,
+    /// Voting window duration in seconds
+    #[prost(uint64, tag = "9")]
+    pub duration: u64,
+    /// Whether new members get fast-path access
+    #[prost(bool, tag = "10")]
+    pub disable_fast_path_access_for_new_members: bool,
+    /// Seconds after lastDate that execution is allowed
+    #[prost(uint64, tag = "11")]
+    pub execution_grace_period: u64,
+}
 /// Decoded action: subspace edge operation (add/remove verified or related edge)
 /// The specific operation type is determined by the ProposalActionType enum value.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -87,22 +112,6 @@ pub struct SetTopicAction {
 /// Decoded action: unset the current space topic
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct UnsetTopicAction {}
-/// Decoded action: update voting settings
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
-pub struct UpdateVotingSettingsAction {
-    /// Minimum total votes required
-    #[prost(uint64, tag = "1")]
-    pub quorum: u64,
-    /// Fast path: absolute YES votes needed
-    #[prost(uint64, tag = "2")]
-    pub fast_threshold: u64,
-    /// Slow path: percentage of RATIO_BASE (10,000,000)
-    #[prost(uint64, tag = "3")]
-    pub slow_threshold: u64,
-    /// Voting duration
-    #[prost(uint64, tag = "4")]
-    pub duration: u64,
-}
 /// Action to be executed when proposal passes
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ProposalAction {
@@ -163,27 +172,34 @@ pub mod proposal_action {
         UnsetTopic(super::UnsetTopicAction),
     }
 }
-/// Voting settings for a proposal, from PROPOSAL_SETTINGS_USED event
+/// Voting settings for a proposal, from PROPOSAL_SETTINGS_SELECTED event.
+/// V2 — 8 fields matching contract ProposalParameters, with per-proposal executeBy.
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct ProposalSettings {
+    /// Slow (0) or Fast (1)
+    #[prost(enumeration = "VotingMode", tag = "7")]
+    pub voting_mode: i32,
+    /// Slow path late execution (0..RATIO_BASE)
+    #[prost(uint64, tag = "8")]
+    pub partial_percentage_support_threshold: u64,
+    /// Slow path early execution (0..RATIO_BASE)
+    #[prost(uint64, tag = "9")]
+    pub universal_percentage_support_threshold: u64,
+    /// Fast path absolute YES votes
+    #[prost(uint64, tag = "10")]
+    pub flat_support_threshold: u64,
+    /// Minimum participating votes for slow path
+    #[prost(uint64, tag = "11")]
+    pub quorum: u64,
     /// Block timestamp when voting starts
-    #[prost(uint64, tag = "1")]
+    #[prost(uint64, tag = "12")]
     pub start_date: u64,
     /// Block timestamp when voting ends
-    #[prost(uint64, tag = "2")]
+    #[prost(uint64, tag = "13")]
     pub last_date: u64,
-    /// Slow (0) or Fast (1)
-    #[prost(enumeration = "VotingMode", tag = "3")]
-    pub voting_mode: i32,
-    /// Minimum total votes for slow path
-    #[prost(uint64, tag = "4")]
-    pub quorum: u64,
-    /// Fast path: absolute number of YES votes needed
-    #[prost(uint64, tag = "5")]
-    pub flat_threshold: u64,
-    /// Slow path: percentage of RATIO_BASE (10,000,000)
-    #[prost(uint64, tag = "6")]
-    pub percentage_threshold: u64,
+    /// Inclusive upper bound timestamp for execution
+    #[prost(uint64, tag = "14")]
+    pub execute_by: u64,
 }
 /// HermesProposalCreated - squashed from PROPOSAL_CREATED + PROPOSAL_SETTINGS_USED
 /// Contains all actions in a single message with voting settings.
@@ -240,7 +256,7 @@ pub struct HermesProposalUpdated {
     pub meta: ::core::option::Option<super::blockchain_metadata::BlockchainMetadata>,
 }
 /// HermesProposalVoted - emitted when a vote is cast on a proposal
-/// Data encoding: abi.encode(bytes16 proposalId, VoteOption)
+/// Data encoding: abi.encode(bytes16 proposalId, uint8 proposalVersion, VoteOption)
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HermesProposalVoted {
     /// 16 bytes - space casting the vote (from from_id)
@@ -257,6 +273,9 @@ pub struct HermesProposalVoted {
     pub vote: i32,
     #[prost(message, optional, tag = "5")]
     pub meta: ::core::option::Option<super::blockchain_metadata::BlockchainMetadata>,
+    /// Proposal version being voted on (uint8 on-chain)
+    #[prost(uint32, tag = "6")]
+    pub proposal_version: u32,
 }
 /// HermesProposalExecuted - emitted when a passed proposal is executed
 /// Data encoding: abi.encode(bytes16 proposalId)
@@ -288,6 +307,38 @@ pub struct HermesProposalSettingsUpdated {
     #[prost(message, optional, tag = "3")]
     pub settings: ::core::option::Option<ProposalSettings>,
     #[prost(message, optional, tag = "4")]
+    pub meta: ::core::option::Option<super::blockchain_metadata::BlockchainMetadata>,
+}
+/// HermesVotingSettingsUpdated - emitted when DAO-global voting settings change.
+/// Data encoding: abi.encode(VotingSettings) — the full 7-field V2 struct.
+/// Subject topic is bytes32(0) since this is a space-level (not proposal-level) event.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HermesVotingSettingsUpdated {
+    /// 16 bytes - space whose settings changed (from_id)
+    #[prost(bytes = "vec", tag = "1")]
+    pub space_id: ::prost::alloc::vec::Vec<u8>,
+    /// Slow path late execution threshold (0..RATIO_BASE)
+    #[prost(uint64, tag = "2")]
+    pub partial_percentage_support_threshold: u64,
+    /// Slow path early execution threshold (0..RATIO_BASE)
+    #[prost(uint64, tag = "3")]
+    pub universal_percentage_support_threshold: u64,
+    /// Fast path absolute YES votes needed
+    #[prost(uint64, tag = "4")]
+    pub flat_support_threshold: u64,
+    /// Minimum participating votes for slow path
+    #[prost(uint64, tag = "5")]
+    pub quorum: u64,
+    /// Voting window duration in seconds
+    #[prost(uint64, tag = "6")]
+    pub duration: u64,
+    /// Whether newly added members get fast-path access
+    #[prost(bool, tag = "7")]
+    pub disable_fast_path_access_for_new_members: bool,
+    /// Seconds after lastDate that execution is allowed
+    #[prost(uint64, tag = "8")]
+    pub execution_grace_period: u64,
+    #[prost(message, optional, tag = "9")]
     pub meta: ::core::option::Option<super::blockchain_metadata::BlockchainMetadata>,
 }
 /// Voting mode for proposals
@@ -366,7 +417,6 @@ pub enum ProposalActionType {
     ProposalActionUnflag = 7,
     ProposalActionUnflagEditor = 8,
     ProposalActionUpdateVotingSettings = 9,
-    /// Was PROPOSAL_ACTION_PING (10) — now reserved, sub-classified into 11-16
     ProposalActionSubspaceVerified = 11,
     ProposalActionSubspaceUnverified = 12,
     ProposalActionSubspaceRelated = 13,
@@ -392,13 +442,21 @@ impl ProposalActionType {
             Self::ProposalActionFlag => "PROPOSAL_ACTION_FLAG",
             Self::ProposalActionUnflag => "PROPOSAL_ACTION_UNFLAG",
             Self::ProposalActionUnflagEditor => "PROPOSAL_ACTION_UNFLAG_EDITOR",
-            Self::ProposalActionUpdateVotingSettings => "PROPOSAL_ACTION_UPDATE_VOTING_SETTINGS",
+            Self::ProposalActionUpdateVotingSettings => {
+                "PROPOSAL_ACTION_UPDATE_VOTING_SETTINGS"
+            }
             Self::ProposalActionSubspaceVerified => "PROPOSAL_ACTION_SUBSPACE_VERIFIED",
-            Self::ProposalActionSubspaceUnverified => "PROPOSAL_ACTION_SUBSPACE_UNVERIFIED",
+            Self::ProposalActionSubspaceUnverified => {
+                "PROPOSAL_ACTION_SUBSPACE_UNVERIFIED"
+            }
             Self::ProposalActionSubspaceRelated => "PROPOSAL_ACTION_SUBSPACE_RELATED",
             Self::ProposalActionSubspaceUnrelated => "PROPOSAL_ACTION_SUBSPACE_UNRELATED",
-            Self::ProposalActionSubspaceTopicDeclared => "PROPOSAL_ACTION_SUBSPACE_TOPIC_DECLARED",
-            Self::ProposalActionSubspaceTopicRemoved => "PROPOSAL_ACTION_SUBSPACE_TOPIC_REMOVED",
+            Self::ProposalActionSubspaceTopicDeclared => {
+                "PROPOSAL_ACTION_SUBSPACE_TOPIC_DECLARED"
+            }
+            Self::ProposalActionSubspaceTopicRemoved => {
+                "PROPOSAL_ACTION_SUBSPACE_TOPIC_REMOVED"
+            }
             Self::ProposalActionSetTopic => "PROPOSAL_ACTION_SET_TOPIC",
             Self::ProposalActionUnsetTopic => "PROPOSAL_ACTION_UNSET_TOPIC",
         }
@@ -418,10 +476,18 @@ impl ProposalActionType {
             "PROPOSAL_ACTION_UPDATE_VOTING_SETTINGS" => {
                 Some(Self::ProposalActionUpdateVotingSettings)
             }
-            "PROPOSAL_ACTION_SUBSPACE_VERIFIED" => Some(Self::ProposalActionSubspaceVerified),
-            "PROPOSAL_ACTION_SUBSPACE_UNVERIFIED" => Some(Self::ProposalActionSubspaceUnverified),
-            "PROPOSAL_ACTION_SUBSPACE_RELATED" => Some(Self::ProposalActionSubspaceRelated),
-            "PROPOSAL_ACTION_SUBSPACE_UNRELATED" => Some(Self::ProposalActionSubspaceUnrelated),
+            "PROPOSAL_ACTION_SUBSPACE_VERIFIED" => {
+                Some(Self::ProposalActionSubspaceVerified)
+            }
+            "PROPOSAL_ACTION_SUBSPACE_UNVERIFIED" => {
+                Some(Self::ProposalActionSubspaceUnverified)
+            }
+            "PROPOSAL_ACTION_SUBSPACE_RELATED" => {
+                Some(Self::ProposalActionSubspaceRelated)
+            }
+            "PROPOSAL_ACTION_SUBSPACE_UNRELATED" => {
+                Some(Self::ProposalActionSubspaceUnrelated)
+            }
             "PROPOSAL_ACTION_SUBSPACE_TOPIC_DECLARED" => {
                 Some(Self::ProposalActionSubspaceTopicDeclared)
             }

--- a/hermes-schema/tests/governance_schema.rs
+++ b/hermes-schema/tests/governance_schema.rs
@@ -1,0 +1,78 @@
+use hermes_schema::pb::governance;
+use prost::Message;
+
+#[test]
+fn hermes_voting_settings_updated_roundtrips_all_fields() {
+    let msg = governance::HermesVotingSettingsUpdated {
+        space_id: vec![0xAB; 16],
+        partial_percentage_support_threshold: 1_000_000,
+        universal_percentage_support_threshold: 2_000_000,
+        flat_support_threshold: 3,
+        quorum: 4,
+        duration: 5,
+        disable_fast_path_access_for_new_members: true,
+        execution_grace_period: 6,
+        meta: None,
+    };
+
+    let bytes = msg.encode_to_vec();
+    let decoded = governance::HermesVotingSettingsUpdated::decode(&*bytes).unwrap();
+
+    assert_eq!(msg, decoded);
+}
+
+#[test]
+fn hermes_proposal_voted_carries_proposal_version() {
+    let msg = governance::HermesProposalVoted {
+        voter_id: vec![0x11; 16],
+        space_id: vec![0x22; 16],
+        proposal_id: vec![0x33; 16],
+        vote: governance::ProposalVoteOption::VoteOptionYes as i32,
+        meta: None,
+        proposal_version: 7,
+    };
+
+    let bytes = msg.encode_to_vec();
+    let decoded = governance::HermesProposalVoted::decode(&*bytes).unwrap();
+
+    assert_eq!(msg, decoded);
+    assert_eq!(decoded.proposal_version, 7);
+}
+
+#[test]
+fn update_voting_settings_action_has_v2_seven_fields() {
+    let msg = governance::UpdateVotingSettingsAction {
+        partial_percentage_support_threshold: 1,
+        universal_percentage_support_threshold: 2,
+        flat_support_threshold: 3,
+        quorum: 4,
+        duration: 5,
+        disable_fast_path_access_for_new_members: true,
+        execution_grace_period: 6,
+    };
+
+    let bytes = msg.encode_to_vec();
+    let decoded = governance::UpdateVotingSettingsAction::decode(&*bytes).unwrap();
+
+    assert_eq!(msg, decoded);
+}
+
+#[test]
+fn proposal_settings_has_v2_eight_fields_with_execute_by() {
+    let msg = governance::ProposalSettings {
+        voting_mode: governance::VotingMode::Slow as i32,
+        partial_percentage_support_threshold: 500_000,
+        universal_percentage_support_threshold: 750_000,
+        flat_support_threshold: 3,
+        quorum: 10,
+        start_date: 1_700_000_000,
+        last_date: 1_700_086_400,
+        execute_by: 1_700_691_200,
+    };
+
+    let bytes = msg.encode_to_vec();
+    let decoded = governance::ProposalSettings::decode(&*bytes).unwrap();
+
+    assert_eq!(msg, decoded);
+    assert_eq!(decoded.execute_by, 1_700_691_200);
+}


### PR DESCRIPTION
## Summary

  Expand the governance protobuf schema to carry the full V2 contract shape without lossy threshold reduction:

  - **`UpdateVotingSettingsAction`**: 4 → 7 fields (adds `partialPct`, `universalPct`, `flat` thresholds; adds
  `disableFastPathAccessForNewMembers`, `executionGracePeriod`).
  - **`ProposalSettings`**: 6 → 8 fields (per-proposal `executeBy` deadline + three separate thresholds).
  - **`HermesProposalVoted`**: new `uint32 proposal_version = 6` field (matches V2 contract's `uint8` version on vote
  payloads).
  - **`HermesVotingSettingsUpdated`**: new top-level message for the `VOTING_SETTINGS_UPDATED` action event.

  ## Breaking change

  Both replaced messages use **fresh tag numbers** with old tags reserved. Old fields removed, not deprecated. Mainnet
  launches with no historical data so wire compat is a non-goal; keeping collapsed thresholds alongside expanded ones would reintroduce the lossy reduction this PR exists to remove.

  **Expected consequence**: `hermes-pipeline` does not compile against this PR alone — GEO-475 (decode) and GEO-477 (transform) follow to restore the build. Integration branch stays red between those merges. This is the agreed tradeoff for strict stacking.

  ## Regeneration

  Generated bindings in `hermes-schema/src/pb/governance.rs` were refreshed per the [README workflow](hermes-schema/README.md): uncomment `build.rs`, `cargo build -p hermes-schema`, re-comment, commit. Ran `cargo fmt -p hermes-schema` on the result (new rustfmt preferred slightly different wrapping). Unrelated regen drift in `knowledge.rs` / `topology.rs` was reverted — only intentional changes to `governance.rs` remain.

  ## Tests

  New integration test file `hermes-schema/tests/governance_schema.rs` — one round-trip `encode_to_vec` + `decode` test per affected shape. Each test constructs the struct with every field populated, serializes via prost, decodes, and asserts equality. Catches any future accidental tag-number reshuffle or field type change at compile + wire level.

  ## Test plan

  - [x] `cargo test -p hermes-schema --test governance_schema` — 4/4 pass
  - [x] `cargo fmt -p hermes-schema --check` + `cargo clippy -p hermes-schema --all-targets -- -D warnings` clean
  - [x] `cargo check -p hermes-pipeline` **fails as expected** with exactly the 5 field errors for removed/added fields