### PR TITLE
feat(hermes): update events decoding and transform

### DIFF
--- a/hermes-pipeline/src/decode.rs
+++ b/hermes-pipeline/src/decode.rs
@@ -259,16 +259,6 @@ const VOTING_SETTINGS_TUPLE_SIZE: usize = 7 * 32;
 /// `bytes` envelope (e.g., when `partial_percentage_support_threshold == 32`
 /// and `universal_percentage_support_threshold <= 160`), slice the buffer, and
 /// drop the event. Invert the order:
-///
-/// 1. If the payload is exactly 224 bytes, decode it as a raw tuple. Because
-///    `abi_decode` tolerates trailing bytes, a longer payload could otherwise
-///    spuriously decode a wrapped envelope's header as tuple fields, so we
-///    gate the raw attempt on exact-length to distinguish the cases.
-/// 2. Otherwise (or if the raw decode failed), strip one level of ABI `bytes`
-///    envelope (offset + length + content) if present and retry.
-/// 3. If that also fails, try one more `unwrap_bytes_once` to handle
-///    double-wrapping.
-/// 4. If all paths fail, return `DecodeError::AbiDecode`.
 pub fn decode_voting_settings_data(data: &[u8]) -> Result<VotingSettingsArgs, DecodeError> {
     if data.len() == VOTING_SETTINGS_TUPLE_SIZE
         && let Ok(args) = decode_voting_settings_data_inner(data)

--- a/hermes-pipeline/src/decode.rs
+++ b/hermes-pipeline/src/decode.rs
@@ -49,8 +49,8 @@ pub mod selectors {
     pub const UNFLAG: [u8; 4] = [0xc6, 0x96, 0x84, 0x0f];
     /// unrestrictSpace(bytes16)
     pub const UNRESTRICT_SPACE: [u8; 4] = [0xd6, 0xf8, 0x43, 0x2f];
-    /// updateVotingSettings((uint256,uint256,uint256,uint256))
-    pub const UPDATE_VOTING_SETTINGS: [u8; 4] = [0xd2, 0x1e, 0x85, 0x41];
+    /// updateVotingSettings((uint256,uint256,uint256,uint256,uint256,bool,uint256))
+    pub const UPDATE_VOTING_SETTINGS: [u8; 4] = [0xf2, 0x2e, 0xc6, 0xb2];
     /// ping(bytes32,bytes32,bytes)
     pub const PING: [u8; 4] = [0xc7, 0x0d, 0x82, 0x82];
 }
@@ -202,24 +202,36 @@ pub fn decode_flag_args(calldata: &[u8]) -> Result<FlagArgs, DecodeError> {
     })
 }
 
-/// Decoded voting settings update arguments.
+/// Decoded voting settings update arguments (V2, 7 fields).
+/// Field order matches the Solidity `VotingSettings` struct.
 #[derive(Debug, Clone)]
 pub struct VotingSettingsArgs {
-    /// Minimum total votes required
+    /// Slow path late execution threshold (0..RATIO_BASE, % of yes/no votes)
+    pub partial_percentage_support_threshold: u64,
+    /// Slow path early execution threshold (0..RATIO_BASE, % of total editors)
+    pub universal_percentage_support_threshold: u64,
+    /// Fast path absolute YES votes needed
+    pub flat_support_threshold: u64,
+    /// Minimum participating votes for slow path
     pub quorum: u64,
-    /// Fast path: absolute YES votes needed
-    pub fast_threshold: u64,
-    /// Slow path: percentage of RATIO_BASE (10,000,000)
-    pub slow_threshold: u64,
-    /// Voting duration
+    /// Voting window duration in seconds
     pub duration: u64,
+    /// Whether newly added members are restricted from the fast path
+    pub disable_fast_path_access_for_new_members: bool,
+    /// Seconds after `lastDate` during which a passed proposal may still be executed
+    pub execution_grace_period: u64,
 }
 
-/// Decode updateVotingSettings((uint256,uint256,uint256,uint256)) calldata.
+/// ABI shape for the V2 `VotingSettings` tuple.
+/// Used both by `decode_voting_settings_args` (function calldata) and
+/// `decode_voting_settings_data` (raw event payload).
+type VotingSettingsTuple = sol! { (uint256, uint256, uint256, uint256, uint256, bool, uint256) };
+
+/// Decode `updateVotingSettings((uint256,uint256,uint256,uint256,uint256,bool,uint256))` calldata.
 ///
 /// The calldata is:
 /// - 4 bytes: function selector
-/// - ABI-encoded tuple (quorum, fastThreshold, slowThreshold, duration)
+/// - ABI-encoded 7-field `VotingSettings` tuple
 pub fn decode_voting_settings_args(calldata: &[u8]) -> Result<VotingSettingsArgs, DecodeError> {
     if calldata.len() < 4 {
         return Err(DecodeError::DataTooShort {
@@ -229,21 +241,33 @@ pub fn decode_voting_settings_args(calldata: &[u8]) -> Result<VotingSettingsArgs
     }
 
     // Skip the 4-byte selector
-    let data = &calldata[4..];
+    decode_voting_settings_data(&calldata[4..])
+}
 
-    // Decode ((uint256, uint256, uint256, uint256))
-    // Note: Solidity struct is encoded as a tuple
-    type VotingSettingsArgsType = sol! { (uint256, uint256, uint256, uint256) };
-    let (quorum, fast_threshold, slow_threshold, duration) =
-        VotingSettingsArgsType::abi_decode(data)
-            .map_err(|e| DecodeError::AbiDecode(e.to_string()))?;
+/// Decode a raw ABI-encoded `VotingSettings` tuple (no function selector).
+///
+/// Used for the `VOTING_SETTINGS_UPDATED` action event, whose `data` field is
+/// `abi.encode(_votingSettings)` without any selector prefix.
+pub fn decode_voting_settings_data(data: &[u8]) -> Result<VotingSettingsArgs, DecodeError> {
+    let (
+        partial,
+        universal,
+        flat,
+        quorum,
+        duration,
+        disable_fast_path_access_for_new_members,
+        execution_grace_period,
+    ) = VotingSettingsTuple::abi_decode(data).map_err(|e| DecodeError::AbiDecode(e.to_string()))?;
 
     // Convert U256 to u64, saturating if too large
     Ok(VotingSettingsArgs {
+        partial_percentage_support_threshold: partial.try_into().unwrap_or(u64::MAX),
+        universal_percentage_support_threshold: universal.try_into().unwrap_or(u64::MAX),
+        flat_support_threshold: flat.try_into().unwrap_or(u64::MAX),
         quorum: quorum.try_into().unwrap_or(u64::MAX),
-        fast_threshold: fast_threshold.try_into().unwrap_or(u64::MAX),
-        slow_threshold: slow_threshold.try_into().unwrap_or(u64::MAX),
         duration: duration.try_into().unwrap_or(u64::MAX),
+        disable_fast_path_access_for_new_members,
+        execution_grace_period: execution_grace_period.try_into().unwrap_or(u64::MAX),
     })
 }
 
@@ -313,12 +337,14 @@ sol! {
 // PROPOSAL_CREATED: abi.encode(bytes16 proposalId, VotingMode, Action[])
 #[allow(dead_code)] // Used in tests for encoding
 type ProposalCreatedDataType = sol! { (bytes16, uint8, Action[]) };
-// PROPOSAL_SETTINGS_USED: abi.encode(startDate, lastDate, votingMode, quorum, supportThreshold)
-// Note: onchain start/last dates are uint256 timestamps.
+// PROPOSAL_SETTINGS_SELECTED (V2): abi.encode(ProposalParameters).
+// Field order matches the Solidity `ProposalParameters` struct:
+// (votingMode, partialPct, universalPct, flat, quorum, startDate, lastDate, executeBy).
 #[allow(dead_code)] // Used in tests for encoding
-type ProposalSettingsUsedDataType = sol! { (uint256, uint256, uint8, uint256, uint256) };
-// PROPOSAL_VOTED: abi.encode(bytes16 proposalId, VoteOption)
-type ProposalVotedDataType = sol! { (bytes16, uint8) };
+type ProposalSettingsUsedDataType =
+    sol! { (uint8, uint256, uint256, uint256, uint256, uint256, uint256, uint256) };
+// PROPOSAL_VOTED (V2): abi.encode(bytes16 proposalId, uint8 proposalVersion, VoteOption).
+type ProposalVotedDataType = sol! { (bytes16, uint8, uint8) };
 type VoteDataType = sol! { (uint16, bytes16, bytes16) };
 #[allow(dead_code)] // Prepared for future EDITS_PUBLISHED decoding
 type EditsPublishedDataType = sol! { (bytes, bytes) };
@@ -417,19 +443,26 @@ pub struct ProposalAction {
     pub data: Vec<u8>,
 }
 
-/// Decoded proposal settings from PROPOSAL_SETTINGS_USED.
+/// Decoded proposal settings from PROPOSAL_SETTINGS_SELECTED (V2 — 8 fields).
+/// Field order matches the Solidity `ProposalParameters` struct.
 #[derive(Debug, Clone)]
 pub struct ProposalSettingsData {
+    /// Voting mode (0=Slow, 1=Fast).
+    pub voting_mode: u8,
+    /// Slow path late execution threshold (0..RATIO_BASE, % of yes/no votes).
+    pub partial_percentage_support_threshold: u64,
+    /// Slow path early execution threshold (0..RATIO_BASE, % of total editors).
+    pub universal_percentage_support_threshold: u64,
+    /// Fast path absolute YES votes needed.
+    pub flat_support_threshold: u64,
+    /// Minimum participating votes for slow path (quorum).
+    pub quorum: u64,
     /// Block timestamp when voting starts.
     pub start_date: u64,
     /// Block timestamp when voting ends.
     pub last_date: u64,
-    /// Voting mode (0=Fast, 1=Slow).
-    pub voting_mode: u8,
-    /// Minimum total votes for slow path (quorum).
-    pub quorum: u64,
-    /// Support threshold (flat for fast path, percentage for slow path).
-    pub support_threshold: u64,
+    /// Inclusive upper bound timestamp for execution.
+    pub execute_by: u64,
 }
 
 /// Decode PROPOSAL_CREATED data.
@@ -471,13 +504,14 @@ pub fn decode_proposal_created(data: &[u8]) -> Result<(ProposalCreatedData, u8),
     ))
 }
 
-/// Decode PROPOSAL_SETTINGS_USED data.
+/// Decode PROPOSAL_SETTINGS_SELECTED data (V2).
 ///
-/// Encoding: `abi.encode(startDate, lastDate, votingMode, quorum, supportThreshold)`
+/// Encoding: `abi.encode(ProposalParameters)` where the struct is
+/// `(votingMode, partialPct, universalPct, flat, quorum, startDate, lastDate, executeBy)`.
 pub fn decode_proposal_settings_used(data: &[u8]) -> Result<ProposalSettingsData, DecodeError> {
     if data.is_empty() {
         return Err(DecodeError::DataTooShort {
-            expected: 160, // 5 * 32 bytes for uint64, uint64, uint8, uint256, uint256
+            expected: 256, // 8 * 32 bytes
             actual: 0,
         });
     }
@@ -499,15 +533,7 @@ pub fn decode_proposal_settings_used(data: &[u8]) -> Result<ProposalSettingsData
         }
     };
 
-    let (start_date, last_date, voting_mode, quorum, support_threshold) = decoded;
-
-    Ok(ProposalSettingsData {
-        start_date,
-        last_date,
-        voting_mode,
-        quorum,
-        support_threshold,
-    })
+    Ok(decoded)
 }
 
 fn decode_proposal_created_inner(data: &[u8]) -> Result<ProposalCreatedData, DecodeError> {
@@ -578,61 +604,64 @@ fn decode_proposal_created_inner(data: &[u8]) -> Result<ProposalCreatedData, Dec
     })
 }
 
-fn decode_proposal_settings_used_inner(
-    data: &[u8],
-) -> Result<(u64, u64, u8, u64, u64), DecodeError> {
+fn decode_proposal_settings_used_inner(data: &[u8]) -> Result<ProposalSettingsData, DecodeError> {
     let params = [
-        ParamType::Uint(256),
-        ParamType::Uint(256),
-        ParamType::Uint(8),
-        ParamType::Uint(256),
-        ParamType::Uint(256),
+        ParamType::Uint(8),   // votingMode
+        ParamType::Uint(256), // partialPercentageSupportThreshold
+        ParamType::Uint(256), // universalPercentageSupportThreshold
+        ParamType::Uint(256), // flatSupportThreshold
+        ParamType::Uint(256), // quorum
+        ParamType::Uint(256), // startDate
+        ParamType::Uint(256), // lastDate
+        ParamType::Uint(256), // executeBy
     ];
 
     let tokens =
         ethabi::decode(&params, data).map_err(|e| DecodeError::AbiDecode(e.to_string()))?;
 
-    let start = match &tokens[0] {
-        Token::Uint(v) => v.as_u64(),
-        _ => return Err(DecodeError::AbiDecode("Invalid start_date".to_string())),
+    let read_u8 = |i: usize, name: &str| -> Result<u8, DecodeError> {
+        match &tokens[i] {
+            Token::Uint(v) => Ok(v.low_u32() as u8),
+            _ => Err(DecodeError::AbiDecode(format!("Invalid {name}"))),
+        }
     };
-    let last = match &tokens[1] {
-        Token::Uint(v) => v.as_u64(),
-        _ => return Err(DecodeError::AbiDecode("Invalid last_date".to_string())),
-    };
-    let voting_mode = match &tokens[2] {
-        Token::Uint(v) => v.low_u32() as u8,
-        _ => return Err(DecodeError::AbiDecode("Invalid voting_mode".to_string())),
-    };
-    let quorum = match &tokens[3] {
-        Token::Uint(v) => v.as_u64(),
-        _ => return Err(DecodeError::AbiDecode("Invalid quorum".to_string())),
-    };
-    let support = match &tokens[4] {
-        Token::Uint(v) => v.as_u64(),
-        _ => {
-            return Err(DecodeError::AbiDecode(
-                "Invalid support_threshold".to_string(),
-            ));
+    let read_u64 = |i: usize, name: &str| -> Result<u64, DecodeError> {
+        match &tokens[i] {
+            Token::Uint(v) => Ok(v.as_u64()),
+            _ => Err(DecodeError::AbiDecode(format!("Invalid {name}"))),
         }
     };
 
-    Ok((start, last, voting_mode, quorum, support))
+    Ok(ProposalSettingsData {
+        voting_mode: read_u8(0, "voting_mode")?,
+        partial_percentage_support_threshold: read_u64(1, "partial_percentage_support_threshold")?,
+        universal_percentage_support_threshold: read_u64(
+            2,
+            "universal_percentage_support_threshold",
+        )?,
+        flat_support_threshold: read_u64(3, "flat_support_threshold")?,
+        quorum: read_u64(4, "quorum")?,
+        start_date: read_u64(5, "start_date")?,
+        last_date: read_u64(6, "last_date")?,
+        execute_by: read_u64(7, "execute_by")?,
+    })
 }
 
-/// Decoded proposal vote data.
+/// Decoded proposal vote data (V2 — includes proposal version).
 #[derive(Debug, Clone)]
 pub struct ProposalVotedData {
     /// Proposal ID (16 bytes).
     #[allow(dead_code)] // Available for callers who need it
     pub proposal_id: Vec<u8>,
+    /// Proposal version being voted on (uint8 on-chain, monotonically incremented on update).
+    pub proposal_version: u8,
     /// Vote option (0=None, 1=Yes, 2=No, 3=Abstain).
     pub vote: u8,
 }
 
-/// Decode PROPOSAL_VOTED data.
+/// Decode PROPOSAL_VOTED data (V2).
 ///
-/// Encoding: `abi.encode(bytes16 proposalId, VoteOption)`
+/// Encoding: `abi.encode(bytes16 proposalId, uint8 proposalVersion, VoteOption)`
 ///
 /// The data may arrive wrapped in an ABI `bytes` encoding (offset + length + content)
 /// because the SpaceRegistry's Action event emits `_data` as a non-indexed `bytes`
@@ -649,11 +678,12 @@ pub fn decode_proposal_voted(data: &[u8]) -> Result<ProposalVotedData, DecodeErr
 
     let current = maybe_unwrap_bytes(data);
 
-    let (proposal_id, vote_option) = ProposalVotedDataType::abi_decode(&current)
+    let (proposal_id, proposal_version, vote_option) = ProposalVotedDataType::abi_decode(&current)
         .map_err(|e| DecodeError::AbiDecode(e.to_string()))?;
 
     Ok(ProposalVotedData {
         proposal_id: proposal_id.to_vec(),
+        proposal_version,
         vote: vote_option,
     })
 }
@@ -802,7 +832,14 @@ pub fn decode_flag_data(data: &[u8]) -> Result<String, DecodeError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy::primitives::{Bytes as PrimBytes, FixedBytes};
+    use alloy::primitives::{Bytes as PrimBytes, FixedBytes, keccak256};
+
+    #[test]
+    fn update_voting_settings_selector_matches_v2_signature() {
+        let sig = "updateVotingSettings((uint256,uint256,uint256,uint256,uint256,bool,uint256))";
+        let expected: [u8; 4] = keccak256(sig.as_bytes()).0[..4].try_into().unwrap();
+        assert_eq!(selectors::UPDATE_VOTING_SETTINGS, expected);
+    }
 
     #[test]
     fn test_decode_proposal_created_empty() {
@@ -840,14 +877,99 @@ mod tests {
     }
 
     #[test]
-    fn test_decode_proposal_voted() {
+    fn test_decode_proposal_voted_v2() {
         let proposal_id = FixedBytes::<16>::from([0xCD; 16]);
+        let proposal_version = 7u8;
         let vote_option = 2u8; // No
-        let encoded = ProposalVotedDataType::abi_encode(&(proposal_id, vote_option));
+        let encoded =
+            ProposalVotedDataType::abi_encode(&(proposal_id, proposal_version, vote_option));
 
         let result = decode_proposal_voted(&encoded).unwrap();
         assert_eq!(result.proposal_id, vec![0xCD; 16]);
+        assert_eq!(result.proposal_version, 7);
         assert_eq!(result.vote, 2);
+    }
+
+    #[test]
+    fn decode_voting_settings_args_returns_v2_seven_fields() {
+        use alloy::primitives::U256;
+
+        let tuple = (
+            U256::from(1_000_000u64), // partial
+            U256::from(2_000_000u64), // universal
+            U256::from(3u64),         // flat
+            U256::from(4u64),         // quorum
+            U256::from(5u64),         // duration
+            true,                     // disableFastPathAccessForNewMembers
+            U256::from(6u64),         // executionGracePeriod
+        );
+        let tuple_bytes = VotingSettingsTuple::abi_encode(&tuple);
+
+        let mut calldata = Vec::with_capacity(4 + tuple_bytes.len());
+        calldata.extend_from_slice(&selectors::UPDATE_VOTING_SETTINGS);
+        calldata.extend_from_slice(&tuple_bytes);
+
+        let args = decode_voting_settings_args(&calldata).unwrap();
+        assert_eq!(args.partial_percentage_support_threshold, 1_000_000);
+        assert_eq!(args.universal_percentage_support_threshold, 2_000_000);
+        assert_eq!(args.flat_support_threshold, 3);
+        assert_eq!(args.quorum, 4);
+        assert_eq!(args.duration, 5);
+        assert!(args.disable_fast_path_access_for_new_members);
+        assert_eq!(args.execution_grace_period, 6);
+    }
+
+    #[test]
+    fn decode_voting_settings_data_accepts_raw_event_payload() {
+        use alloy::primitives::U256;
+
+        let tuple = (
+            U256::from(100u64),
+            U256::from(200u64),
+            U256::from(300u64),
+            U256::from(400u64),
+            U256::from(500u64),
+            false,
+            U256::from(600u64),
+        );
+        let data = VotingSettingsTuple::abi_encode(&tuple);
+
+        let args = decode_voting_settings_data(&data).unwrap();
+        assert_eq!(args.partial_percentage_support_threshold, 100);
+        assert_eq!(args.universal_percentage_support_threshold, 200);
+        assert_eq!(args.flat_support_threshold, 300);
+        assert_eq!(args.quorum, 400);
+        assert_eq!(args.duration, 500);
+        assert!(!args.disable_fast_path_access_for_new_members);
+        assert_eq!(args.execution_grace_period, 600);
+    }
+
+    #[test]
+    fn decode_proposal_settings_used_returns_v2_eight_fields_with_execute_by() {
+        use ethabi::ethereum_types::U256 as EthU256;
+
+        // Encode the V2 ProposalParameters tuple: (votingMode, partialPct,
+        // universalPct, flat, quorum, startDate, lastDate, executeBy).
+        let encoded = ethabi::encode(&[
+            Token::Uint(EthU256::from(1u8)),              // votingMode = Fast (1)
+            Token::Uint(EthU256::from(500_000u64)),       // partialPct
+            Token::Uint(EthU256::from(750_000u64)),       // universalPct
+            Token::Uint(EthU256::from(3u64)),             // flat
+            Token::Uint(EthU256::from(10u64)),            // quorum
+            Token::Uint(EthU256::from(1_700_000_000u64)), // startDate
+            Token::Uint(EthU256::from(1_700_086_400u64)), // lastDate
+            Token::Uint(EthU256::from(1_700_691_200u64)), // executeBy
+        ]);
+
+        let settings = decode_proposal_settings_used(&encoded).unwrap();
+        assert_eq!(settings.voting_mode, 1);
+        assert_eq!(settings.partial_percentage_support_threshold, 500_000);
+        assert_eq!(settings.universal_percentage_support_threshold, 750_000);
+        assert_eq!(settings.flat_support_threshold, 3);
+        assert_eq!(settings.quorum, 10);
+        assert_eq!(settings.start_date, 1_700_000_000);
+        assert_eq!(settings.last_date, 1_700_086_400);
+        assert_eq!(settings.execute_by, 1_700_691_200);
     }
 
     #[test]

--- a/hermes-pipeline/src/decode.rs
+++ b/hermes-pipeline/src/decode.rs
@@ -244,31 +244,52 @@ pub fn decode_voting_settings_args(calldata: &[u8]) -> Result<VotingSettingsArgs
     decode_voting_settings_data(&calldata[4..])
 }
 
+/// Size in bytes of the raw ABI-encoded `VotingSettings` tuple: 7 static
+/// words × 32 bytes each.
+const VOTING_SETTINGS_TUPLE_SIZE: usize = 7 * 32;
+
 /// Decode a raw ABI-encoded `VotingSettings` tuple (no function selector).
 ///
 /// Used for the `VOTING_SETTINGS_UPDATED` action event, whose `data` field is
 /// `abi.encode(_votingSettings)` without any selector prefix.
 ///
-/// Mirrors `decode_proposal_settings_used`: the EVM may deliver the payload
-/// wrapped in an ABI `bytes` envelope (offset + length + content), so we strip
-/// one level defensively and retry once on failure.
+/// The expected payload is a fixed-size static 7-word tuple (7 × 32 = 224 bytes),
+/// so we do not need to speculatively unwrap before trying to decode. The eager
+/// `maybe_unwrap_bytes` heuristic can mis-detect a valid raw tuple as an ABI
+/// `bytes` envelope (e.g., when `partial_percentage_support_threshold == 32`
+/// and `universal_percentage_support_threshold <= 160`), slice the buffer, and
+/// drop the event. Invert the order:
+///
+/// 1. If the payload is exactly 224 bytes, decode it as a raw tuple. Because
+///    `abi_decode` tolerates trailing bytes, a longer payload could otherwise
+///    spuriously decode a wrapped envelope's header as tuple fields, so we
+///    gate the raw attempt on exact-length to distinguish the cases.
+/// 2. Otherwise (or if the raw decode failed), strip one level of ABI `bytes`
+///    envelope (offset + length + content) if present and retry.
+/// 3. If that also fails, try one more `unwrap_bytes_once` to handle
+///    double-wrapping.
+/// 4. If all paths fail, return `DecodeError::AbiDecode`.
 pub fn decode_voting_settings_data(data: &[u8]) -> Result<VotingSettingsArgs, DecodeError> {
-    let current = maybe_unwrap_bytes(data);
-
-    match decode_voting_settings_data_inner(&current) {
-        Ok(args) => Ok(args),
-        Err(_) => {
-            let Some(unwrapped) = unwrap_bytes_once(current.as_ref()) else {
-                return Err(DecodeError::AbiDecode(
-                    "Failed to decode voting settings data".to_string(),
-                ));
-            };
-            let current = Cow::Owned(unwrapped);
-            decode_voting_settings_data_inner(&current).map_err(|_| {
-                DecodeError::AbiDecode("Failed to decode voting settings data".to_string())
-            })
-        }
+    if data.len() == VOTING_SETTINGS_TUPLE_SIZE
+        && let Ok(args) = decode_voting_settings_data_inner(data)
+    {
+        return Ok(args);
     }
+
+    let unwrapped_once = maybe_unwrap_bytes(data);
+    if let Ok(args) = decode_voting_settings_data_inner(&unwrapped_once) {
+        return Ok(args);
+    }
+
+    if let Some(unwrapped_twice) = unwrap_bytes_once(unwrapped_once.as_ref())
+        && let Ok(args) = decode_voting_settings_data_inner(&unwrapped_twice)
+    {
+        return Ok(args);
+    }
+
+    Err(DecodeError::AbiDecode(
+        "Failed to decode voting settings data".to_string(),
+    ))
 }
 
 fn decode_voting_settings_data_inner(data: &[u8]) -> Result<VotingSettingsArgs, DecodeError> {
@@ -993,6 +1014,43 @@ mod tests {
         let args = decode_voting_settings_data(&wrapped).unwrap();
         assert_eq!(args.partial_percentage_support_threshold, 1_000_000);
         assert_eq!(args.universal_percentage_support_threshold, 2_000_000);
+        assert_eq!(args.flat_support_threshold, 3);
+        assert_eq!(args.quorum, 4);
+        assert_eq!(args.duration, 5);
+        assert!(args.disable_fast_path_access_for_new_members);
+        assert_eq!(args.execution_grace_period, 6);
+    }
+
+    #[test]
+    fn decode_voting_settings_data_decodes_raw_tuple_with_small_partial_threshold() {
+        use alloy::primitives::U256;
+
+        // Regression test: `maybe_unwrap_bytes` looks at words 0 and 1 of the
+        // payload and treats `(offset=32, length<=data.len()-64)` as an ABI
+        // `bytes` envelope. For a raw `VotingSettings` tuple, word 0 is
+        // `partial_percentage_support_threshold` and word 1 is
+        // `universal_percentage_support_threshold`. Choosing `partial == 32`
+        // and `universal == 160` produces a valid tuple whose wire layout
+        // satisfies the envelope heuristic: the eager pre-unwrap would slice
+        // the buffer down to the inner 160 bytes and fail to decode the
+        // (now-truncated) 7-word tuple, causing the event to be dropped.
+        //
+        // With the fix, the raw tuple decode is attempted first and succeeds.
+        let tuple = (
+            U256::from(32u64),  // partial — matches the "offset" word
+            U256::from(160u64), // universal — matches the "length" word (<= 224 - 64)
+            U256::from(3u64),
+            U256::from(4u64),
+            U256::from(5u64),
+            true,
+            U256::from(6u64),
+        );
+        let data = VotingSettingsTuple::abi_encode(&tuple);
+        assert_eq!(data.len(), 224, "static 7-word tuple should be 224 bytes");
+
+        let args = decode_voting_settings_data(&data).unwrap();
+        assert_eq!(args.partial_percentage_support_threshold, 32);
+        assert_eq!(args.universal_percentage_support_threshold, 160);
         assert_eq!(args.flat_support_threshold, 3);
         assert_eq!(args.quorum, 4);
         assert_eq!(args.duration, 5);

--- a/hermes-pipeline/src/decode.rs
+++ b/hermes-pipeline/src/decode.rs
@@ -248,7 +248,30 @@ pub fn decode_voting_settings_args(calldata: &[u8]) -> Result<VotingSettingsArgs
 ///
 /// Used for the `VOTING_SETTINGS_UPDATED` action event, whose `data` field is
 /// `abi.encode(_votingSettings)` without any selector prefix.
+///
+/// Mirrors `decode_proposal_settings_used`: the EVM may deliver the payload
+/// wrapped in an ABI `bytes` envelope (offset + length + content), so we strip
+/// one level defensively and retry once on failure.
 pub fn decode_voting_settings_data(data: &[u8]) -> Result<VotingSettingsArgs, DecodeError> {
+    let current = maybe_unwrap_bytes(data);
+
+    match decode_voting_settings_data_inner(&current) {
+        Ok(args) => Ok(args),
+        Err(_) => {
+            let Some(unwrapped) = unwrap_bytes_once(current.as_ref()) else {
+                return Err(DecodeError::AbiDecode(
+                    "Failed to decode voting settings data".to_string(),
+                ));
+            };
+            let current = Cow::Owned(unwrapped);
+            decode_voting_settings_data_inner(&current).map_err(|_| {
+                DecodeError::AbiDecode("Failed to decode voting settings data".to_string())
+            })
+        }
+    }
+}
+
+fn decode_voting_settings_data_inner(data: &[u8]) -> Result<VotingSettingsArgs, DecodeError> {
     let (
         partial,
         universal,
@@ -942,6 +965,39 @@ mod tests {
         assert_eq!(args.duration, 500);
         assert!(!args.disable_fast_path_access_for_new_members);
         assert_eq!(args.execution_grace_period, 600);
+    }
+
+    #[test]
+    fn decode_voting_settings_data_accepts_bytes_wrapped_payload() {
+        use alloy::primitives::U256;
+        use alloy::sol_types::SolValue;
+
+        // The EVM may deliver Action.data wrapped in an ABI `bytes` envelope
+        // (offset + length + content). Verify the decoder transparently unwraps
+        // one level so VOTING_SETTINGS_UPDATED is not silently dropped.
+        let tuple = (
+            U256::from(1_000_000u64),
+            U256::from(2_000_000u64),
+            U256::from(3u64),
+            U256::from(4u64),
+            U256::from(5u64),
+            true,
+            U256::from(6u64),
+        );
+        let tuple_bytes = VotingSettingsTuple::abi_encode(&tuple);
+
+        // Wrap tuple encoding inside a `bytes` ABI envelope, mirroring the
+        // shape the EVM produces for a non-indexed `bytes` event parameter.
+        let wrapped = PrimBytes::from(tuple_bytes).abi_encode();
+
+        let args = decode_voting_settings_data(&wrapped).unwrap();
+        assert_eq!(args.partial_percentage_support_threshold, 1_000_000);
+        assert_eq!(args.universal_percentage_support_threshold, 2_000_000);
+        assert_eq!(args.flat_support_threshold, 3);
+        assert_eq!(args.quorum, 4);
+        assert_eq!(args.duration, 5);
+        assert!(args.disable_fast_path_access_for_new_members);
+        assert_eq!(args.execution_grace_period, 6);
     }
 
     #[test]

--- a/hermes-pipeline/src/emit.rs
+++ b/hermes-pipeline/src/emit.rs
@@ -782,6 +782,7 @@ mod tests {
             proposal_id: vec![0xCD; 16],
             vote: ProposalVoteOption::VoteOptionYes as i32,
             meta: None,
+            proposal_version: 1,
         };
         // Should key by space_id, not voter_id
         assert_eq!(event.key(), vec![0xAB; 16]);

--- a/hermes-pipeline/src/pipelines/governance.rs
+++ b/hermes-pipeline/src/pipelines/governance.rs
@@ -23,10 +23,11 @@ use crate::decode::{
 use hermes_relay::{Action, actions};
 use hermes_schema::pb::governance::{
     AddEditorAction, AddMemberAction, FlagAction, HermesProposalCreated, HermesProposalExecuted,
-    HermesProposalSettingsUpdated, HermesProposalUpdated, HermesProposalVoted, ProposalAction,
-    ProposalSettings, ProposalVoteOption, PublishAction, RemoveEditorAction, RemoveMemberAction,
-    SetTopicAction, SubspaceEdgeAction, SubspaceTopicAction, UnflagAction, UnflagEditorAction,
-    UnsetTopicAction, UpdateVotingSettingsAction, VotingMode, proposal_action,
+    HermesProposalSettingsUpdated, HermesProposalUpdated, HermesProposalVoted,
+    HermesVotingSettingsUpdated, ProposalAction, ProposalSettings, ProposalVoteOption,
+    PublishAction, RemoveEditorAction, RemoveMemberAction, SetTopicAction, SubspaceEdgeAction,
+    SubspaceTopicAction, UnflagAction, UnflagEditorAction, UnsetTopicAction,
+    UpdateVotingSettingsAction, VotingMode, proposal_action,
 };
 
 use super::BlockMetadata;
@@ -39,6 +40,7 @@ pub struct TransformResult {
     pub proposals_voted: Vec<HermesProposalVoted>,
     pub proposals_executed: Vec<HermesProposalExecuted>,
     pub proposals_settings_updated: Vec<HermesProposalSettingsUpdated>,
+    pub voting_settings_updated: Vec<HermesVotingSettingsUpdated>,
 }
 
 impl TransformResult {
@@ -48,6 +50,7 @@ impl TransformResult {
             + self.proposals_voted.len()
             + self.proposals_executed.len()
             + self.proposals_settings_updated.len()
+            + self.voting_settings_updated.len()
     }
 }
 
@@ -140,6 +143,14 @@ pub fn transform(
             )
             .in_scope(|| convert_proposal_executed(action, meta, sequence))?;
             result.proposals_executed.push(event);
+        } else if actions::matches(action_type, &actions::VOTING_SETTINGS_UPDATED)
+            && let Some(event) = debug_span!(
+                "convert.governance.voting_settings_updated",
+                space_id = %hex::encode(&action.from_id)
+            )
+            .in_scope(|| convert_voting_settings_updated(action, meta, sequence))
+        {
+            result.voting_settings_updated.push(event);
         }
     }
 
@@ -316,10 +327,15 @@ fn decode_proposal_action(
             let args = decode_voting_settings_args(calldata).ok()?;
             Some(proposal_action::Action::UpdateVotingSettings(
                 UpdateVotingSettingsAction {
+                    partial_percentage_support_threshold: args.partial_percentage_support_threshold,
+                    universal_percentage_support_threshold: args
+                        .universal_percentage_support_threshold,
+                    flat_support_threshold: args.flat_support_threshold,
                     quorum: args.quorum,
-                    fast_threshold: args.fast_threshold,
-                    slow_threshold: args.slow_threshold,
                     duration: args.duration,
+                    disable_fast_path_access_for_new_members: args
+                        .disable_fast_path_access_for_new_members,
+                    execution_grace_period: args.execution_grace_period,
                 },
             ))
         }
@@ -627,11 +643,9 @@ fn parse_proposal_settings_used(action: &Action, sequence: u32) -> Option<Propos
         }
     };
 
-    // Determine threshold type based on voting mode
-    // Slow=0 uses percentage threshold, Fast=1 uses flat threshold
-    let (flat_threshold, percentage_threshold) = match decoded.voting_mode {
-        0 => (0, decoded.support_threshold), // Slow path uses percentage threshold
-        1 => (decoded.support_threshold, 0), // Fast path uses flat threshold
+    let voting_mode = match decoded.voting_mode {
+        0 => VotingMode::Slow,
+        1 => VotingMode::Fast,
         _ => {
             let debug_chain = decode::unwrap_debug_chain(&action.data, 2);
             let mut levels: Vec<String> = Vec::new();
@@ -652,22 +666,18 @@ fn parse_proposal_settings_used(action: &Action, sequence: u32) -> Option<Propos
         }
     };
 
-    let voting_mode = match decoded.voting_mode {
-        0 => VotingMode::Slow,
-        1 => VotingMode::Fast,
-        _ => unreachable!(), // Already handled above
-    };
-
     Some(ProposalSettingsPending {
         space_id: action.from_id.clone(),
         sequence,
         settings: ProposalSettings {
+            voting_mode: voting_mode as i32,
+            partial_percentage_support_threshold: decoded.partial_percentage_support_threshold,
+            universal_percentage_support_threshold: decoded.universal_percentage_support_threshold,
+            flat_support_threshold: decoded.flat_support_threshold,
+            quorum: decoded.quorum,
             start_date: decoded.start_date,
             last_date: decoded.last_date,
-            voting_mode: voting_mode as i32,
-            quorum: decoded.quorum,
-            flat_threshold,
-            percentage_threshold,
+            execute_by: decoded.execute_by,
         },
     })
 }
@@ -686,21 +696,24 @@ fn convert_proposal_voted(
 ) -> Result<HermesProposalVoted> {
     // Decode the data field
     // VoteOption enum (IDAOSpace): None=0, Yes=1, No=2, Abstain=3
-    let vote = match decode::decode_proposal_voted(&action.data) {
-        Ok(decoded) => match decoded.vote {
-            0 => ProposalVoteOption::VoteOptionNone,
-            1 => ProposalVoteOption::VoteOptionYes,
-            2 => ProposalVoteOption::VoteOptionNo,
-            3 => ProposalVoteOption::VoteOptionAbstain,
-            _ => ProposalVoteOption::VoteOptionNone,
-        },
+    let (vote, proposal_version) = match decode::decode_proposal_voted(&action.data) {
+        Ok(decoded) => {
+            let vote_option = match decoded.vote {
+                0 => ProposalVoteOption::VoteOptionNone,
+                1 => ProposalVoteOption::VoteOptionYes,
+                2 => ProposalVoteOption::VoteOptionNo,
+                3 => ProposalVoteOption::VoteOptionAbstain,
+                _ => ProposalVoteOption::VoteOptionNone,
+            };
+            (vote_option, decoded.proposal_version)
+        }
         Err(e) => {
             warn!(
                 error = %e,
                 proposal_id = %hex::encode(&action.topic[..16]),
                 "Failed to decode proposal voted data"
             );
-            ProposalVoteOption::VoteOptionNone
+            (ProposalVoteOption::VoteOptionNone, 0)
         }
     };
 
@@ -713,6 +726,7 @@ fn convert_proposal_voted(
         proposal_id,
         vote: vote as i32,
         meta: Some(meta.to_proto(sequence)),
+        proposal_version: proposal_version as u32,
     })
 }
 
@@ -734,6 +748,46 @@ fn convert_proposal_executed(
     Ok(HermesProposalExecuted {
         space_id: action.from_id.clone(),
         proposal_id,
+        meta: Some(meta.to_proto(sequence)),
+    })
+}
+
+/// Convert a VOTING_SETTINGS_UPDATED action into a HermesVotingSettingsUpdated proto.
+///
+/// Event encoding (emitted by DAOSpace via SpaceRegistry._ping):
+/// - from_id: space_id that updated its settings
+/// - to_id:   space_id (same — ping event)
+/// - topic:   bytes32(0) (unused for this space-level event)
+/// - data:    abi.encode(VotingSettings) — 7-field tuple
+///
+/// Returns None if decoding fails (logged as a warning).
+fn convert_voting_settings_updated(
+    action: &Action,
+    meta: &BlockMetadata,
+    sequence: u32,
+) -> Option<HermesVotingSettingsUpdated> {
+    let decoded = match decode::decode_voting_settings_data(&action.data) {
+        Ok(decoded) => decoded,
+        Err(e) => {
+            warn!(
+                error = %e,
+                space_id = %hex::encode(&action.from_id),
+                data_len = action.data.len(),
+                "Failed to decode voting settings updated payload"
+            );
+            return None;
+        }
+    };
+
+    Some(HermesVotingSettingsUpdated {
+        space_id: action.from_id.clone(),
+        partial_percentage_support_threshold: decoded.partial_percentage_support_threshold,
+        universal_percentage_support_threshold: decoded.universal_percentage_support_threshold,
+        flat_support_threshold: decoded.flat_support_threshold,
+        quorum: decoded.quorum,
+        duration: decoded.duration,
+        disable_fast_path_access_for_new_members: decoded.disable_fast_path_access_for_new_members,
+        execution_grace_period: decoded.execution_grace_period,
         meta: Some(meta.to_proto(sequence)),
     })
 }
@@ -771,7 +825,11 @@ mod tests {
         ])
     }
 
-    // Helper to create encoded PROPOSAL_SETTINGS_SELECTED data
+    // Helper to create encoded PROPOSAL_SETTINGS_SELECTED data (V2 ProposalParameters shape).
+    // The single `threshold` parameter is mapped to `flat_support_threshold`; the
+    // other V2 threshold fields are zeroed for test simplicity. Field order matches
+    // the Solidity `ProposalParameters` struct: votingMode, partialPct, universalPct,
+    // flat, quorum, startDate, lastDate, executeBy.
     fn encode_proposal_settings_data(
         start_date: u64,
         last_date: u64,
@@ -782,11 +840,14 @@ mod tests {
         use ethabi::{Token, ethereum_types::U256 as EthU256};
 
         ethabi::encode(&[
+            Token::Uint(EthU256::from(voting_mode)),
+            Token::Uint(EthU256::zero()), // partial_percentage_support_threshold
+            Token::Uint(EthU256::zero()), // universal_percentage_support_threshold
+            Token::Uint(EthU256::from(threshold)), // flat_support_threshold
+            Token::Uint(EthU256::from(quorum)),
             Token::Uint(EthU256::from(start_date)),
             Token::Uint(EthU256::from(last_date)),
-            Token::Uint(EthU256::from(voting_mode)),
-            Token::Uint(EthU256::from(quorum)),
-            Token::Uint(EthU256::from(threshold)),
+            Token::Uint(EthU256::zero()), // execute_by
         ])
     }
 
@@ -831,7 +892,7 @@ mod tests {
         let settings = event.settings.as_ref().unwrap();
         assert_eq!(settings.start_date, 1000);
         assert_eq!(settings.last_date, 2000);
-        assert_eq!(settings.flat_threshold, 50); // Fast path uses flat threshold
+        assert_eq!(settings.flat_support_threshold, 50); // Fast path uses flat threshold
     }
 
     #[test]
@@ -1254,17 +1315,77 @@ mod tests {
         assert_eq!(result.proposals_executed.len(), 1);
     }
 
+    /// Encode a VOTING_SETTINGS_UPDATED event's `data` field: `abi.encode(VotingSettings)`
+    /// as a 7-field tuple.
+    fn encode_voting_settings_event(
+        partial: u64,
+        universal: u64,
+        flat: u64,
+        quorum: u64,
+        duration: u64,
+        disable_fast_path: bool,
+        grace_period: u64,
+    ) -> Vec<u8> {
+        use alloy::primitives::U256;
+        use alloy::sol_types::SolValue;
+
+        (
+            U256::from(partial),
+            U256::from(universal),
+            U256::from(flat),
+            U256::from(quorum),
+            U256::from(duration),
+            disable_fast_path,
+            U256::from(grace_period),
+        )
+            .abi_encode_params()
+    }
+
+    #[test]
+    fn transform_routes_voting_settings_updated_event() {
+        let space_id = vec![0x42; 16];
+
+        let test_actions = vec![Action {
+            from_id: space_id.clone(),
+            to_id: space_id.clone(),
+            action: actions::VOTING_SETTINGS_UPDATED.to_vec(),
+            topic: vec![0u8; 32], // bytes32(0) per contract
+            data: encode_voting_settings_event(
+                1_000_000, // partial
+                2_000_000, // universal
+                3,         // flat
+                4,         // quorum
+                5,         // duration
+                true,      // disableFastPathAccessForNewMembers
+                6,         // executionGracePeriod
+            ),
+        }];
+
+        let result = transform(&test_actions, &test_meta(), &empty_prefetch()).unwrap();
+
+        assert_eq!(result.voting_settings_updated.len(), 1);
+        let event = &result.voting_settings_updated[0];
+        assert_eq!(event.space_id, space_id);
+        assert_eq!(event.partial_percentage_support_threshold, 1_000_000);
+        assert_eq!(event.universal_percentage_support_threshold, 2_000_000);
+        assert_eq!(event.flat_support_threshold, 3);
+        assert_eq!(event.quorum, 4);
+        assert_eq!(event.duration, 5);
+        assert!(event.disable_fast_path_access_for_new_members);
+        assert_eq!(event.execution_grace_period, 6);
+    }
+
     /// Encode vote data matching Solidity's `abi.encode(bytes16 proposalId, VoteOption)`.
     ///
-    /// ABI encoding for `(bytes16, uint8)`:
-    ///   Word 0: bytes16 left-aligned, right-padded with zeros to 32 bytes
-    ///   Word 1: uint8 right-aligned, left-padded with zeros to 32 bytes
-    fn encode_vote_data(proposal_id: [u8; 16], vote_option: u8) -> Vec<u8> {
-        let mut data = vec![0u8; 64];
-        // Word 0: bytes16, left-aligned
+    /// ABI encoding for the V2 vote payload `(bytes16, uint8, uint8)`:
+    ///   Word 0: bytes16 proposalId (left-aligned, right-padded with zeros)
+    ///   Word 1: uint8  proposalVersion (right-aligned, left-padded with zeros)
+    ///   Word 2: uint8  voteOption (right-aligned, left-padded with zeros)
+    fn encode_vote_data(proposal_id: [u8; 16], proposal_version: u8, vote_option: u8) -> Vec<u8> {
+        let mut data = vec![0u8; 96];
         data[..16].copy_from_slice(&proposal_id);
-        // Word 1: uint8, right-aligned
-        data[63] = vote_option;
+        data[63] = proposal_version;
+        data[95] = vote_option;
         data
     }
 
@@ -1307,7 +1428,7 @@ mod tests {
                 to_id: space_id.clone(),
                 action: actions::PROPOSAL_VOTED.to_vec(),
                 topic: proposal_id.iter().copied().chain(vec![0; 16]).collect(),
-                data: encode_vote_data(proposal_id, vote_value),
+                data: encode_vote_data(proposal_id, 3, vote_value),
             };
 
             let result = convert_proposal_voted(&action, &test_meta(), 0)
@@ -1321,6 +1442,7 @@ mod tests {
             assert_eq!(result.voter_id, voter_id);
             assert_eq!(result.space_id, space_id);
             assert_eq!(result.proposal_id, proposal_id.to_vec());
+            assert_eq!(result.proposal_version, 3);
         }
     }
 
@@ -1344,8 +1466,8 @@ mod tests {
         ];
 
         for (vote_value, expected_proto, label) in cases {
-            // Inner data: abi.encode(bytes16 proposalId, uint8 VoteOption)
-            let inner = encode_vote_data(proposal_id, vote_value);
+            // Inner data: abi.encode(bytes16 proposalId, uint8 proposalVersion, uint8 VoteOption)
+            let inner = encode_vote_data(proposal_id, 1, vote_value);
             // Wrapped as the EVM would produce for a non-indexed `bytes` event parameter
             let wrapped = wrap_in_abi_bytes(&inner);
 
@@ -1390,12 +1512,14 @@ mod tests {
                 })),
             }],
             settings: Some(ProposalSettings {
+                voting_mode: 0,
+                partial_percentage_support_threshold: 0,
+                universal_percentage_support_threshold: 0,
+                flat_support_threshold: 0,
+                quorum: 0,
                 start_date: 0,
                 last_date: 0,
-                voting_mode: 0,
-                quorum: 0,
-                percentage_threshold: 0,
-                flat_threshold: 0,
+                execute_by: 0,
             }),
             meta: None,
         }
@@ -1663,12 +1787,14 @@ mod tests {
                 })),
             }],
             settings: Some(ProposalSettings {
+                voting_mode: 0,
+                partial_percentage_support_threshold: 0,
+                universal_percentage_support_threshold: 0,
+                flat_support_threshold: 0,
+                quorum: 0,
                 start_date: 0,
                 last_date: 0,
-                voting_mode: 0,
-                quorum: 0,
-                percentage_threshold: 0,
-                flat_threshold: 0,
+                execute_by: 0,
             }),
             meta: None,
         }];


### PR DESCRIPTION
## Summary

  **`decode.rs`**:
  - `UPDATE_VOTING_SETTINGS` selector → `0xf22ec6b2` (V2 7-field signature)
  - `VotingSettingsArgs` / `ProposalSettingsData` / `ProposalVotedData` reshaped to match V2 contract structs (7 / 8 / 3 fields, contract field order, `proposal_version` added)
  - New `decode_voting_settings_data` entry point for raw event payloads (no selector prefix)

  **`pipelines/governance.rs`**:
  - `TransformResult.voting_settings_updated` added; main loop routes `VOTING_SETTINGS_UPDATED` through new
  `convert_voting_settings_updated`
  - Proto constructors populate all 8 V2 settings fields and `proposal_version` on votes
  - Removed the old flat/percentage derivation — settings now map 1:1 from decoded fields

  ## Tests

  6 new (selector keccak verification + round-trips for each new/changed shape + full transform routing test). 2 existing vote tests updated to the V2 3-tuple encoding and now also assert `proposal_version` flows through.

  ## Test plan

  - [x] `cargo test -p hermes-pipeline` — 90 pass (6 new)
  - [x] fmt + clippy clean
  
  Closes GEO-475, GEO-477