### PR TITLE
feat(kg-indexer): wire voting setting events

### DIFF
--- a/kg-indexer/src/consumer.rs
+++ b/kg-indexer/src/consumer.rs
@@ -120,6 +120,7 @@ pub enum KgMessage {
     ProposalVoted(hermes_schema::pb::governance::HermesProposalVoted),
     ProposalExecuted(hermes_schema::pb::governance::HermesProposalExecuted),
     ProposalSettingsUpdated(hermes_schema::pb::governance::HermesProposalSettingsUpdated),
+    VotingSettingsUpdated(hermes_schema::pb::governance::HermesVotingSettingsUpdated),
 }
 
 impl KgMessage {
@@ -138,6 +139,7 @@ impl KgMessage {
             KgMessage::ProposalVoted(v) => v.meta.as_ref(),
             KgMessage::ProposalExecuted(e) => e.meta.as_ref(),
             KgMessage::ProposalSettingsUpdated(s) => s.meta.as_ref(),
+            KgMessage::VotingSettingsUpdated(v) => v.meta.as_ref(),
         }
     }
 
@@ -264,6 +266,17 @@ pub fn parse_message(
                         })?;
                     Ok(KgMessage::ProposalSettingsUpdated(settings_updated))
                 }
+                Some("VOTING_SETTINGS_UPDATED") => {
+                    let voting_settings_updated =
+                        hermes_schema::pb::governance::HermesVotingSettingsUpdated::decode(payload)
+                            .map_err(|e| {
+                                IndexerError::decode(format!(
+                                    "HermesVotingSettingsUpdated: {}",
+                                    e
+                                ))
+                            })?;
+                    Ok(KgMessage::VotingSettingsUpdated(voting_settings_updated))
+                }
                 _ => Err(IndexerError::decode(format!(
                     "unknown governance event type: {:?}",
                     event_type
@@ -295,6 +308,34 @@ mod tests {
                 assert_eq!(event.topic_id, vec![2; 16]);
             }
             _ => panic!("expected TopicDeclared"),
+        }
+    }
+
+    #[test]
+    fn test_parse_voting_settings_updated_message() {
+        let msg = hermes_schema::pb::governance::HermesVotingSettingsUpdated {
+            space_id: vec![7; 16],
+            partial_percentage_support_threshold: 500_000,
+            universal_percentage_support_threshold: 750_000,
+            flat_support_threshold: 3,
+            quorum: 10,
+            duration: 3_600,
+            disable_fast_path_access_for_new_members: false,
+            execution_grace_period: 600,
+            meta: None,
+        };
+        let payload = msg.encode_to_vec();
+
+        let parsed =
+            parse_message("space.governance", &payload, Some("VOTING_SETTINGS_UPDATED")).unwrap();
+
+        match parsed {
+            KgMessage::VotingSettingsUpdated(event) => {
+                assert_eq!(event.space_id, vec![7; 16]);
+                assert_eq!(event.partial_percentage_support_threshold, 500_000);
+                assert_eq!(event.universal_percentage_support_threshold, 750_000);
+            }
+            _ => panic!("expected VotingSettingsUpdated"),
         }
     }
 }

--- a/kg-indexer/src/handlers/governance.rs
+++ b/kg-indexer/src/handlers/governance.rs
@@ -242,7 +242,6 @@ fn legacy_threshold(voting_mode: &VotingMode, settings: &ProposalSettings) -> i6
 /// Process a HermesVotingSettingsUpdated message.
 ///
 /// Maps the DAO-global voting settings into `SpaceVotingSettingsItem`.
-#[allow(dead_code)] // wired by GEO-482 (consumer routing)
 pub fn handle_voting_settings_updated(
     msg: &HermesVotingSettingsUpdated,
 ) -> Result<SpaceVotingSettingsItem, HandlerError> {

--- a/kg-indexer/src/main.rs
+++ b/kg-indexer/src/main.rs
@@ -730,6 +730,7 @@ fn event_type_label(event: &BufferedEvent) -> String {
         KgMessage::ProposalVoted(_) => "PROPOSAL_VOTED".to_string(),
         KgMessage::ProposalExecuted(_) => "PROPOSAL_EXECUTED".to_string(),
         KgMessage::ProposalSettingsUpdated(_) => "PROPOSAL_SETTINGS_UPDATED".to_string(),
+        KgMessage::VotingSettingsUpdated(_) => "VOTING_SETTINGS_UPDATED".to_string(),
         KgMessage::BlockSummary(_) => "BLOCK_SUMMARY".to_string(),
     }
 }
@@ -1256,6 +1257,15 @@ async fn process_message(
                 .await?;
             1
         }
+        KgMessage::VotingSettingsUpdated(event) => {
+            let item = handlers::governance::handle_voting_settings_updated(&event)?;
+            debug!(
+                space_id = %item.space_id,
+                "Processing VotingSettingsUpdated"
+            );
+            storage.upsert_space_voting_settings(&item, &mut tx).await?;
+            1
+        }
     };
 
     tx.commit().await?;
@@ -1372,6 +1382,13 @@ async fn process_block(
                 "kg_indexer.handle_proposal_settings_updated",
                 event_id = event_id,
                 proposal_id = tracing::field::Empty,
+                space_id = tracing::field::Empty,
+                "otel.status_code" = tracing::field::Empty,
+                "otel.status_message" = tracing::field::Empty
+            ),
+            KgMessage::VotingSettingsUpdated(_) => info_span!(
+                "kg_indexer.handle_voting_settings_updated",
+                event_id = event_id,
                 space_id = tracing::field::Empty,
                 "otel.status_code" = tracing::field::Empty,
                 "otel.status_message" = tracing::field::Empty
@@ -1743,6 +1760,16 @@ async fn process_block(
                             &mut tx,
                         )
                         .await?;
+                    1
+                }
+                KgMessage::VotingSettingsUpdated(voting_settings_event) => {
+                    let item = handlers::governance::handle_voting_settings_updated(
+                        voting_settings_event,
+                    )?;
+
+                    event_span.record("space_id", display(item.space_id));
+
+                    storage.upsert_space_voting_settings(&item, &mut tx).await?;
                     1
                 }
                 KgMessage::BlockSummary(_) => 0,

--- a/kg-indexer/src/main.rs
+++ b/kg-indexer/src/main.rs
@@ -688,6 +688,7 @@ const EXPECTED_EVENT_TYPES: &[&str] = &[
     "PROPOSAL_VOTED",
     "PROPOSAL_EXECUTED",
     "PROPOSAL_SETTINGS_UPDATED",
+    "VOTING_SETTINGS_UPDATED",
 ];
 
 fn expected_count_for_indexer(

--- a/kg-indexer/src/storage.rs
+++ b/kg-indexer/src/storage.rs
@@ -1325,7 +1325,6 @@ impl Storage {
     /// On conflict, all settings fields are overwritten with the new values.
     /// Editor count is not stored here — compute it via the `editors` table
     /// (see the `space_editor_counts` view, GEO-514).
-    #[allow(dead_code)]
     pub async fn upsert_space_voting_settings(
         &self,
         settings: &SpaceVotingSettingsItem,


### PR DESCRIPTION
Closes [GEO-482](https://linear.app/defi-wonderland/issue/GEO-482).

## Summary
- Wires the `VOTING_SETTINGS_UPDATED` Hermes event through the KG indexer's consumer so DAO-level voting settings land in the `space_voting_settings` table.
- Both single-event (`process_message`) and batched block (`process_block`) paths dispatch to `handlers::governance::handle_voting_settings_updated` → `storage::upsert_space_voting_settings`.
- Drops the `#[allow(dead_code)]` placeholders on the handler and storage method now that they are called.

## Changes
- `kg-indexer/src/consumer.rs`:
  - New `KgMessage::VotingSettingsUpdated(HermesVotingSettingsUpdated)` variant, plus `meta()` match arm.
  - New `parse_message()` arm on the `space.governance` topic for the `"VOTING_SETTINGS_UPDATED"` event-type header.
  - Unit test covering the round-trip from proto payload → `KgMessage::VotingSettingsUpdated`.
- `kg-indexer/src/main.rs`:
  - Event-type string mapping (`"VOTING_SETTINGS_UPDATED"`), dispatch branch in both processing paths, and a `kg_indexer.handle_voting_settings_updated` tracing span recording `space_id`.
- `kg-indexer/src/handlers/governance.rs`, `kg-indexer/src/storage.rs`: remove `#[allow(dead_code)]` attributes.

## Scope note — what is *not* in this PR
The original ticket's "Downstream impact" section (as of GEO-481) called for maintaining a `space_voting_settings.total_editors` counter on `EDITOR_ADDED` / `EDITOR_REMOVED` events. [GEO-514](https://linear.app/defi-wonderland/issue/GEO-514) obsoleted that plan — the column was removed and editor counts are now derived on demand via the `space_editor_counts` view. The ticket description was updated to reflect this; no editor-role code is touched here.

## Related
- Depends on: #153 (GEO-481 storage) and #154 (GEO-514 view) — both merged into `feat/governance-v2-contract-migration`.
- Requires (not yet landed): [GEO-477](https://linear.app/defi-wonderland/issue/GEO-477) — the hermes-pipeline emit side. `hermes-pipeline/src/emit.rs` needs a `KafkaEvent` impl for `HermesVotingSettingsUpdated` before the event actually flows end-to-end. Until then, this consumer wiring is ready but will not receive messages.

## Test plan
- [x] `cargo check -p kg-indexer` passes
- [x] `cargo test -p kg-indexer --bin kg-indexer consumer::` — new `test_parse_voting_settings_updated_message` green
- [x] `cargo test -p kg-indexer --bin kg-indexer handlers::governance::tests::handle_voting_settings_updated_maps_all_fields` — still green
- [x] Once GEO-477 lands: end-to-end replay of a `VOTING_SETTINGS_UPDATED` event against a local KG indexer results in a row in `space_voting_settings`