### PR TITLE
feat(api): update proposal status + queries for governance V2

### DIFF
--- a/api/drizzle/0059_tidy_wendell_vaughn.sql
+++ b/api/drizzle/0059_tidy_wendell_vaughn.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "proposal_versions" ALTER COLUMN "partial_percentage_support_threshold" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "proposal_versions" ALTER COLUMN "universal_percentage_support_threshold" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "proposal_versions" ALTER COLUMN "flat_support_threshold" SET NOT NULL;

--- a/api/drizzle/meta/0059_snapshot.json
+++ b/api/drizzle/meta/0059_snapshot.json
@@ -1,0 +1,3590 @@
+{
+  "id": "0455ddd9-7607-481f-8788-752b61edf187",
+  "prevId": "9a3ef757-7ccd-4061-bf64-ba47401e37a3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.app_webhooks": {
+      "name": "app_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "app_name": {
+          "name": "app_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_webhooks_app_name_unique": {
+          "name": "app_webhooks_app_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "app_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.atlas_checkpoints": {
+      "name": "atlas_checkpoints",
+      "schema": "",
+      "columns": {
+        "indexer_id": {
+          "name": "indexer_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph_state_version": {
+          "name": "graph_state_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_compatibility_marker": {
+          "name": "runtime_compatibility_marker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_space_id": {
+          "name": "root_space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph_state_blob": {
+          "name": "graph_state_blob",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.edit_versions": {
+      "name": "edit_versions",
+      "schema": "",
+      "columns": {
+        "edit_id": {
+          "name": "edit_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_key": {
+          "name": "version_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "edit_versions_version_key_idx": {
+          "name": "edit_versions_version_key_idx",
+          "columns": [
+            {
+              "expression": "version_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "edit_versions_block_sequence_unique": {
+          "name": "edit_versions_block_sequence_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "block_number",
+            "sequence"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.editors": {
+      "name": "editors",
+      "schema": "",
+      "columns": {
+        "member_space_id": {
+          "name": "member_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "editors_space_id_idx": {
+          "name": "editors_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "editors_member_space_id_space_id_pk": {
+          "name": "editors_member_space_id_space_id_pk",
+          "columns": [
+            "member_space_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_block": {
+          "name": "created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at_block": {
+          "name": "updated_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "entities_updated_at_idx": {
+          "name": "entities_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entities_updated_at_id_idx": {
+          "name": "entities_updated_at_id_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entities_created_at_id_idx": {
+          "name": "entities_created_at_id_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.global_scores": {
+      "name": "global_scores",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ipfs_cache": {
+      "name": "ipfs_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_errored": {
+          "name": "is_errored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "block": {
+          "name": "block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space": {
+          "name": "space",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ipfs_cache_uri_unique": {
+          "name": "ipfs_cache_uri_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uri"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.local_scores": {
+      "name": "local_scores",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_local_scores_space_id": {
+          "name": "idx_local_scores_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_local_scores_entity_id": {
+          "name": "idx_local_scores_entity_id",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_local_scores_space_score": {
+          "name": "idx_local_scores_space_score",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "local_scores_entity_id_space_id_pk": {
+          "name": "local_scores_entity_id_space_id_pk",
+          "columns": [
+            "entity_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "member_space_id": {
+          "name": "member_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "members_space_id_idx": {
+          "name": "members_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "members_member_space_id_space_id_pk": {
+          "name": "members_member_space_id_space_id_pk",
+          "columns": [
+            "member_space_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta": {
+      "name": "meta",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_deliveries": {
+      "name": "notification_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "outbox_id": {
+          "name": "outbox_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_deliveries_pending": {
+          "name": "idx_deliveries_pending",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_deliveries_outbox_id_notification_outbox_id_fk": {
+          "name": "notification_deliveries_outbox_id_notification_outbox_id_fk",
+          "tableFrom": "notification_deliveries",
+          "tableTo": "notification_outbox",
+          "columnsFrom": [
+            "outbox_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_deliveries_webhook_id_app_webhooks_id_fk": {
+          "name": "notification_deliveries_webhook_id_app_webhooks_id_fk",
+          "tableFrom": "notification_deliveries",
+          "tableTo": "app_webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_deliveries_outbox_id_webhook_id_unique": {
+          "name": "notification_deliveries_outbox_id_webhook_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "outbox_id",
+            "webhook_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_outbox": {
+      "name": "notification_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_outbox_idempotency_key_unique": {
+          "name": "notification_outbox_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_actions": {
+      "name": "proposal_actions",
+      "schema": "",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposal_version": {
+          "name": "proposal_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "proposalActionType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_uri": {
+          "name": "content_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quorum": {
+          "name": "quorum",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fast_threshold": {
+          "name": "fast_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slow_threshold": {
+          "name": "slow_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "partial_percentage_support_threshold": {
+          "name": "partial_percentage_support_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "universal_percentage_support_threshold": {
+          "name": "universal_percentage_support_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flat_support_threshold": {
+          "name": "flat_support_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disable_fast_path_access_for_new_members": {
+          "name": "disable_fast_path_access_for_new_members",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_grace_period": {
+          "name": "execution_grace_period",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "proposal_actions_proposal_id_idx": {
+          "name": "proposal_actions_proposal_id_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_actions_action_type_idx": {
+          "name": "proposal_actions_action_type_idx",
+          "columns": [
+            {
+              "expression": "action_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_actions_proposal_action_target_idx": {
+          "name": "proposal_actions_proposal_action_target_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_actions_version_fk": {
+          "name": "proposal_actions_version_fk",
+          "tableFrom": "proposal_actions",
+          "tableTo": "proposal_versions",
+          "columnsFrom": [
+            "proposal_id",
+            "proposal_version"
+          ],
+          "columnsTo": [
+            "proposal_id",
+            "proposal_version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "proposal_actions_proposal_id_proposal_version_index_pk": {
+          "name": "proposal_actions_proposal_id_proposal_version_index_pk",
+          "columns": [
+            "proposal_id",
+            "proposal_version",
+            "index"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_tally_queue": {
+      "name": "proposal_tally_queue",
+      "schema": "",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "proposal_tally_queue_proposal_id_proposals_id_fk": {
+          "name": "proposal_tally_queue_proposal_id_proposals_id_fk",
+          "tableFrom": "proposal_tally_queue",
+          "tableTo": "proposals",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_versions": {
+      "name": "proposal_versions",
+      "schema": "",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposal_version": {
+          "name": "proposal_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voting_mode": {
+          "name": "voting_mode",
+          "type": "votingMode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quorum": {
+          "name": "quorum",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partial_percentage_support_threshold": {
+          "name": "partial_percentage_support_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "universal_percentage_support_threshold": {
+          "name": "universal_percentage_support_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flat_support_threshold": {
+          "name": "flat_support_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execute_by": {
+          "name": "execute_by",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yes_count": {
+          "name": "yes_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "no_count": {
+          "name": "no_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "abstain_count": {
+          "name": "abstain_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "version_created_at": {
+          "name": "version_created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_created_at_block": {
+          "name": "version_created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "proposal_versions_proposal_version_desc_idx": {
+          "name": "proposal_versions_proposal_version_desc_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "proposal_version",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_versions_end_time_idx": {
+          "name": "proposal_versions_end_time_idx",
+          "columns": [
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_versions_start_time_idx": {
+          "name": "proposal_versions_start_time_idx",
+          "columns": [
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_versions_proposal_id_proposals_id_fk": {
+          "name": "proposal_versions_proposal_id_proposals_id_fk",
+          "tableFrom": "proposal_versions",
+          "tableTo": "proposals",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "proposal_versions_proposal_id_proposal_version_pk": {
+          "name": "proposal_versions_proposal_id_proposal_version_pk",
+          "columns": [
+            "proposal_id",
+            "proposal_version"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "proposal_versions_idempotency_key": {
+          "name": "proposal_versions_idempotency_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "proposal_id",
+            "version_created_at_block"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_votes": {
+      "name": "proposal_votes",
+      "schema": "",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposal_version": {
+          "name": "proposal_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "voteOption",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_block": {
+          "name": "created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "proposal_votes_space_id_idx": {
+          "name": "proposal_votes_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_votes_voter_id_idx": {
+          "name": "proposal_votes_voter_id_idx",
+          "columns": [
+            {
+              "expression": "voter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_votes_vote_idx": {
+          "name": "proposal_votes_vote_idx",
+          "columns": [
+            {
+              "expression": "vote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_votes_space_id_spaces_id_fk": {
+          "name": "proposal_votes_space_id_spaces_id_fk",
+          "tableFrom": "proposal_votes",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "proposal_votes_version_fk": {
+          "name": "proposal_votes_version_fk",
+          "tableFrom": "proposal_votes",
+          "tableTo": "proposal_versions",
+          "columnsFrom": [
+            "proposal_id",
+            "proposal_version"
+          ],
+          "columnsTo": [
+            "proposal_id",
+            "proposal_version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "proposal_votes_proposal_id_proposal_version_voter_id_pk": {
+          "name": "proposal_votes_proposal_id_proposal_version_voter_id_pk",
+          "columns": [
+            "proposal_id",
+            "proposal_version",
+            "voter_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposals": {
+      "name": "proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by": {
+          "name": "proposed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_block": {
+          "name": "created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_version": {
+          "name": "current_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "proposals_space_id_idx": {
+          "name": "proposals_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_proposed_by_idx": {
+          "name": "proposals_proposed_by_idx",
+          "columns": [
+            {
+              "expression": "proposed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_created_at_idx": {
+          "name": "proposals_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_space_created_at_idx": {
+          "name": "proposals_space_created_at_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposals_space_id_spaces_id_fk": {
+          "name": "proposals_space_id_spaces_id_fk",
+          "tableFrom": "proposals",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relation_versions": {
+      "name": "relation_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "relation_id": {
+          "name": "relation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_space_id": {
+          "name": "from_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_entity_id": {
+          "name": "to_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_space_id": {
+          "name": "to_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_from_key": {
+          "name": "valid_from_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_to_key": {
+          "name": "valid_to_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_root_id": {
+          "name": "context_root_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_edge_type_id": {
+          "name": "context_edge_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "relation_versions_relation_idx": {
+          "name": "relation_versions_relation_idx",
+          "columns": [
+            {
+              "expression": "relation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_entity_idx": {
+          "name": "relation_versions_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_open_idx": {
+          "name": "relation_versions_open_idx",
+          "columns": [
+            {
+              "expression": "relation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"relation_versions\".\"valid_to_key\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_range_idx": {
+          "name": "relation_versions_range_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_from_entity_type_idx": {
+          "name": "relation_versions_from_entity_type_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_from_entity_valid_to_idx": {
+          "name": "relation_versions_from_entity_valid_to_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_to_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"relation_versions\".\"valid_to_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relations": {
+      "name": "relations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_space_id": {
+          "name": "from_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_version_id": {
+          "name": "from_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_entity_id": {
+          "name": "to_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_space_id": {
+          "name": "to_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_version_id": {
+          "name": "to_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "relations_entity_id_idx": {
+          "name": "relations_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_type_id_idx": {
+          "name": "relations_type_id_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_from_entity_id_idx": {
+          "name": "relations_from_entity_id_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_to_entity_id_idx": {
+          "name": "relations_to_entity_id_idx",
+          "columns": [
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_space_id_idx": {
+          "name": "relations_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_space_from_to_idx": {
+          "name": "relations_space_from_to_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_space_type_idx": {
+          "name": "relations_space_type_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_to_entity_space_idx": {
+          "name": "relations_to_entity_space_idx",
+          "columns": [
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_from_entity_space_idx": {
+          "name": "relations_from_entity_space_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_entity_type_space_idx": {
+          "name": "relations_entity_type_space_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_type_from_to_idx": {
+          "name": "relations_type_from_to_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.space_scores": {
+      "name": "space_scores",
+      "schema": "",
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.space_voting_settings": {
+      "name": "space_voting_settings",
+      "schema": "",
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "partial_percentage_support_threshold": {
+          "name": "partial_percentage_support_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "universal_percentage_support_threshold": {
+          "name": "universal_percentage_support_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flat_support_threshold": {
+          "name": "flat_support_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quorum": {
+          "name": "quorum",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disable_fast_path_access_for_new_members": {
+          "name": "disable_fast_path_access_for_new_members",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_grace_period": {
+          "name": "execution_grace_period",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at_block": {
+          "name": "updated_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "space_voting_settings_space_id_spaces_id_fk": {
+          "name": "space_voting_settings_space_id_spaces_id_fk",
+          "tableFrom": "space_voting_settings",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.spaces": {
+      "name": "spaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "spaceTypes",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "spaces_topic_id_idx": {
+          "name": "spaces_topic_id_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "spaces_topic_id_entities_id_fk": {
+          "name": "spaces_topic_id_entities_id_fk",
+          "tableFrom": "spaces",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subspace_topics": {
+      "name": "subspace_topics",
+      "schema": "",
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "subspace_topics_space_id_idx": {
+          "name": "subspace_topics_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subspace_topics_topic_id_idx": {
+          "name": "subspace_topics_topic_id_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subspace_topics_space_id_spaces_id_fk": {
+          "name": "subspace_topics_space_id_spaces_id_fk",
+          "tableFrom": "subspace_topics",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "subspace_topics_topic_id_entities_id_fk": {
+          "name": "subspace_topics_topic_id_entities_id_fk",
+          "tableFrom": "subspace_topics",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "subspace_topics_space_id_topic_id_pk": {
+          "name": "subspace_topics_space_id_topic_id_pk",
+          "columns": [
+            "space_id",
+            "topic_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subspaces": {
+      "name": "subspaces",
+      "schema": "",
+      "columns": {
+        "parent_space_id": {
+          "name": "parent_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_space_id": {
+          "name": "child_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "subspaceType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'verified'"
+        }
+      },
+      "indexes": {
+        "subspaces_parent_space_id_idx": {
+          "name": "subspaces_parent_space_id_idx",
+          "columns": [
+            {
+              "expression": "parent_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subspaces_child_space_id_idx": {
+          "name": "subspaces_child_space_id_idx",
+          "columns": [
+            {
+              "expression": "child_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subspaces_parent_space_id_spaces_id_fk": {
+          "name": "subspaces_parent_space_id_spaces_id_fk",
+          "tableFrom": "subspaces",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "parent_space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "subspaces_child_space_id_spaces_id_fk": {
+          "name": "subspaces_child_space_id_spaces_id_fk",
+          "tableFrom": "subspaces",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "child_space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "subspaces_parent_space_id_child_space_id_type_pk": {
+          "name": "subspaces_parent_space_id_child_space_id_type_pk",
+          "columns": [
+            "parent_space_id",
+            "child_space_id",
+            "type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_votes": {
+      "name": "user_votes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voted_at": {
+          "name": "voted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_user_votes_object": {
+          "name": "idx_user_votes_object",
+          "columns": [
+            {
+              "expression": "object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_votes_user_id_object_id_object_type_space_id_unique": {
+          "name": "user_votes_user_id_object_id_object_type_space_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "object_id",
+            "object_type",
+            "space_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.value_versions": {
+      "name": "value_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from_key": {
+          "name": "valid_from_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_to_key": {
+          "name": "valid_to_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boolean": {
+          "name": "boolean",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integer": {
+          "name": "integer",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "float": {
+          "name": "float",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decimal": {
+          "name": "decimal",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime": {
+          "name": "datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "point": {
+          "name": "point",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rect": {
+          "name": "rect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_utc": {
+          "name": "time_utc",
+          "type": "time with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime_utc": {
+          "name": "datetime_utc",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_root_id": {
+          "name": "context_root_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_edge_type_id": {
+          "name": "context_edge_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "value_versions_entity_idx": {
+          "name": "value_versions_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_lookup_idx": {
+          "name": "value_versions_lookup_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_open_idx": {
+          "name": "value_versions_open_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"value_versions\".\"valid_to_key\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_range_idx": {
+          "name": "value_versions_range_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_entity_space_valid_to_idx": {
+          "name": "value_versions_entity_space_valid_to_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_to_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"value_versions\".\"valid_to_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.values": {
+      "name": "values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boolean": {
+          "name": "boolean",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integer": {
+          "name": "integer",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "float": {
+          "name": "float",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decimal": {
+          "name": "decimal",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime": {
+          "name": "datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "point": {
+          "name": "point",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rect": {
+          "name": "rect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_utc": {
+          "name": "time_utc",
+          "type": "time with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime_utc": {
+          "name": "datetime_utc",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "values_property_id_idx": {
+          "name": "values_property_id_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_entity_id_idx": {
+          "name": "values_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_space_id_idx": {
+          "name": "values_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_boolean_idx": {
+          "name": "values_boolean_idx",
+          "columns": [
+            {
+              "expression": "boolean",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_integer_idx": {
+          "name": "values_integer_idx",
+          "columns": [
+            {
+              "expression": "integer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_float_idx": {
+          "name": "values_float_idx",
+          "columns": [
+            {
+              "expression": "float",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_decimal_idx": {
+          "name": "values_decimal_idx",
+          "columns": [
+            {
+              "expression": "decimal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_text_idx": {
+          "name": "values_text_idx",
+          "columns": [
+            {
+              "expression": "text",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "length(\"values\".\"text\") <= 2000",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_date_idx": {
+          "name": "values_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_time_idx": {
+          "name": "values_time_idx",
+          "columns": [
+            {
+              "expression": "time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_datetime_idx": {
+          "name": "values_datetime_idx",
+          "columns": [
+            {
+              "expression": "datetime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_point_idx": {
+          "name": "values_point_idx",
+          "columns": [
+            {
+              "expression": "point",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_rect_idx": {
+          "name": "values_rect_idx",
+          "columns": [
+            {
+              "expression": "rect",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_entity_property_idx": {
+          "name": "values_entity_property_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_entity_space_idx": {
+          "name": "values_entity_space_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_property_space_idx": {
+          "name": "values_property_space_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_entity_property_space_idx": {
+          "name": "values_entity_property_space_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_language_idx": {
+          "name": "values_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_unit_idx": {
+          "name": "values_unit_idx",
+          "columns": [
+            {
+              "expression": "unit",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_time_utc_idx": {
+          "name": "values_time_utc_idx",
+          "columns": [
+            {
+              "expression": "time_utc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_datetime_utc_idx": {
+          "name": "values_datetime_utc_idx",
+          "columns": [
+            {
+              "expression": "datetime_utc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_timestamp": {
+          "name": "block_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_votes_voter_id": {
+          "name": "idx_votes_voter_id",
+          "columns": [
+            {
+              "expression": "voter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_votes_object_type_object_id_space_id": {
+          "name": "idx_votes_object_type_object_id_space_id",
+          "columns": [
+            {
+              "expression": "object_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes_count": {
+      "name": "votes_count",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upvotes": {
+          "name": "upvotes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "downvotes": {
+          "name": "downvotes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "votes_count_object_id_object_type_space_id_unique": {
+          "name": "votes_count_object_id_object_type_space_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "object_id",
+            "object_type",
+            "space_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.proposalActionType": {
+      "name": "proposalActionType",
+      "schema": "public",
+      "values": [
+        "AddMember",
+        "RemoveMember",
+        "AddEditor",
+        "RemoveEditor",
+        "UnflagEditor",
+        "Publish",
+        "Flag",
+        "Unflag",
+        "UpdateVotingSettings",
+        "Unknown",
+        "SubspaceVerified",
+        "SubspaceUnverified",
+        "SubspaceRelated",
+        "SubspaceUnrelated",
+        "SubspaceTopicDeclared",
+        "SubspaceTopicRemoved",
+        "SetTopic",
+        "UnsetTopic"
+      ]
+    },
+    "public.spaceTypes": {
+      "name": "spaceTypes",
+      "schema": "public",
+      "values": [
+        "DAO",
+        "Personal"
+      ]
+    },
+    "public.subspaceType": {
+      "name": "subspaceType",
+      "schema": "public",
+      "values": [
+        "verified",
+        "related"
+      ]
+    },
+    "public.voteOption": {
+      "name": "voteOption",
+      "schema": "public",
+      "values": [
+        "Yes",
+        "No",
+        "Abstain"
+      ]
+    },
+    "public.votingMode": {
+      "name": "votingMode",
+      "schema": "public",
+      "values": [
+        "Fast",
+        "Slow"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.proposals_current": {
+      "columns": {},
+      "definition": "select \"proposals\".\"id\", \"proposals\".\"space_id\", \"proposals\".\"proposed_by\", \"proposals\".\"created_at\", \"proposals\".\"created_at_block\", \"proposals\".\"current_version\", \"proposal_versions\".\"proposal_id\", \"proposal_versions\".\"proposal_version\", \"proposal_versions\".\"voting_mode\", \"proposal_versions\".\"start_time\", \"proposal_versions\".\"end_time\", \"proposal_versions\".\"quorum\", \"proposal_versions\".\"threshold\", \"proposal_versions\".\"partial_percentage_support_threshold\", \"proposal_versions\".\"universal_percentage_support_threshold\", \"proposal_versions\".\"flat_support_threshold\", \"proposal_versions\".\"execute_by\", \"proposal_versions\".\"executed_at\", \"proposal_versions\".\"name\", \"proposal_versions\".\"yes_count\", \"proposal_versions\".\"no_count\", \"proposal_versions\".\"abstain_count\", \"proposal_versions\".\"version_created_at\", \"proposal_versions\".\"version_created_at_block\" from \"proposals\" inner join \"proposal_versions\" on \"proposal_versions\".\"proposal_id\" = \"proposals\".\"id\" AND \"proposal_versions\".\"proposal_version\" = \"proposals\".\"current_version\"",
+      "name": "proposals_current",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    },
+    "public.space_editor_counts": {
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_editors": {
+          "name": "total_editors",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "definition": "SELECT space_id, COUNT(*)::bigint AS total_editors FROM editors GROUP BY space_id",
+      "name": "space_editor_counts",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -414,6 +414,13 @@
       "when": 1776872188819,
       "tag": "0058_easy_magdalene",
       "breakpoints": true
+    },
+    {
+      "idx": 59,
+      "version": "7",
+      "when": 1776884234643,
+      "tag": "0059_tidy_wendell_vaughn",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/proposals/__tests__/queries.test.ts
+++ b/api/src/proposals/__tests__/queries.test.ts
@@ -79,16 +79,24 @@ function makeDbProposalRow(overrides: Partial<Record<string, unknown>> = {}) {
  */
 function makeProposal(overrides: Partial<ProposalWithVotes> = {}): ProposalWithVotes {
 	const now = BigInt(Math.floor(Date.now() / 1000))
+	const votingMode = overrides.votingMode ?? "Fast"
+	const threshold = overrides.threshold ?? 10n
 	return {
 		id: "test-proposal-id",
 		spaceId: "test-space-id",
 		name: "Test Proposal",
 		proposedBy: "test-proposer-id",
-		votingMode: "Fast",
+		proposalVersion: 1,
+		votingMode,
 		startTime: now - 3600n,
 		endTime: now + 3600n,
 		quorum: 10n,
-		threshold: 10n,
+		threshold,
+		flatSupportThreshold: votingMode === "Fast" ? threshold : 0n,
+		partialPercentageSupportThreshold: votingMode === "Slow" ? threshold : 0n,
+		universalPercentageSupportThreshold: 0n,
+		executeBy: null,
+		totalEditors: 0n,
 		executedAt: null,
 		yesCount: 0n,
 		noCount: 0n,

--- a/api/src/proposals/__tests__/queries.test.ts
+++ b/api/src/proposals/__tests__/queries.test.ts
@@ -51,19 +51,32 @@ function setupTestApp() {
 
 /**
  * Create a test proposal row as returned from the database.
+ *
+ * Shape mirrors what `proposals_current` (view) + `space_editor_counts`
+ * (LEFT JOIN) return after GEO-481/514: V1 threshold is still projected for
+ * compat, but V2 per-mode fields + executeBy + proposal_version +
+ * total_editors are the canonical values.
  */
 function makeDbProposalRow(overrides: Partial<Record<string, unknown>> = {}) {
 	const now = Math.floor(Date.now() / 1000)
+	const votingMode = (overrides.voting_mode as string | undefined) ?? "Fast"
+	const threshold = (overrides.threshold as string | undefined) ?? "10"
 	return {
 		id: "550e8400-e29b-41d4-a716-446655440000",
 		space_id: "660e8400-e29b-41d4-a716-446655440000",
 		name: "Test Proposal",
 		proposed_by: "770e8400-e29b-41d4-a716-446655440000",
-		voting_mode: "Fast",
+		proposal_version: 1,
+		voting_mode: votingMode,
 		start_time: String(now - 3600),
 		end_time: String(now + 3600),
 		quorum: "10",
-		threshold: "10",
+		threshold,
+		flat_support_threshold: votingMode === "Fast" ? threshold : "0",
+		partial_percentage_support_threshold: votingMode === "Slow" ? threshold : "0",
+		universal_percentage_support_threshold: "0",
+		execute_by: null,
+		total_editors: "0",
 		executed_at: null,
 		created_at: new Date().toISOString(),
 		yes_count: "0",
@@ -226,6 +239,98 @@ describe("GET /proposals/space/:spaceId/status", () => {
 			expect(body.proposals).toBeInstanceOf(Array)
 			expect(body.proposals).toHaveLength(1)
 			expect(body.nextCursor).toBeNull()
+		})
+
+		it("surfaces V2 fields (proposalVersion, executeBy) on list items", async () => {
+			const row = makeDbProposalRow({
+				proposal_version: 3,
+				execute_by: "1750000000",
+			})
+			db.execute.mockResolvedValueOnce({rows: [row]})
+
+			const res = await app.request("/proposals/space/660e8400-e29b-41d4-a716-446655440000/status")
+
+			expect(res.status).toBe(200)
+			const body = await res.json()
+			expect(body.proposals[0].proposalVersion).toBe(3)
+			expect(body.proposals[0].executeBy).toBe(1_750_000_000)
+		})
+
+		it("returns null executeBy for legacy proposals with no deadline", async () => {
+			const row = makeDbProposalRow({execute_by: null})
+			db.execute.mockResolvedValueOnce({rows: [row]})
+
+			const res = await app.request("/proposals/space/660e8400-e29b-41d4-a716-446655440000/status")
+
+			const body = await res.json()
+			expect(body.proposals[0].executeBy).toBeNull()
+		})
+
+		it("projects legacy threshold.required from flatSupportThreshold for Fast proposals", async () => {
+			const row = makeDbProposalRow({
+				voting_mode: "Fast",
+				threshold: "999", // stale legacy value — should be ignored in favor of flat
+				flat_support_threshold: "42",
+			})
+			db.execute.mockResolvedValueOnce({rows: [row]})
+
+			const res = await app.request("/proposals/space/660e8400-e29b-41d4-a716-446655440000/status")
+
+			const body = await res.json()
+			expect(body.proposals[0].threshold.required).toBe("42")
+		})
+
+		it("projects legacy threshold.required from partialPercentageSupportThreshold for Slow proposals", async () => {
+			const row = makeDbProposalRow({
+				voting_mode: "Slow",
+				threshold: "999",
+				partial_percentage_support_threshold: "5000000",
+			})
+			db.execute.mockResolvedValueOnce({rows: [row]})
+
+			const res = await app.request("/proposals/space/660e8400-e29b-41d4-a716-446655440000/status")
+
+			const body = await res.json()
+			expect(body.proposals[0].threshold.required).toBe("5000000")
+		})
+
+		it("surfaces V2 fields on UpdateVotingSettings action responses", async () => {
+			const row = makeDbProposalRow({
+				actions_json: [
+					{
+						action_type: "UpdateVotingSettings",
+						target_id: null,
+						content_uri: null,
+						content_id: null,
+						quorum: 10,
+						fast_threshold: 3,
+						slow_threshold: 5_000_000,
+						duration: 3600,
+						partial_percentage_support_threshold: 5_000_000,
+						universal_percentage_support_threshold: 7_500_000,
+						flat_support_threshold: 3,
+						disable_fast_path_access_for_new_members: true,
+						execution_grace_period: 600,
+					},
+				],
+			})
+			db.execute.mockResolvedValueOnce({rows: [row]})
+
+			const res = await app.request("/proposals/space/660e8400-e29b-41d4-a716-446655440000/status")
+
+			const body = await res.json()
+			expect(body.proposals[0].actions[0]).toEqual({
+				actionType: "UPDATE_VOTING_SETTINGS",
+				quorum: 10,
+				fastThreshold: 3,
+				slowThreshold: 5_000_000,
+				duration: 3600,
+				partialPercentageSupportThreshold: 5_000_000,
+				universalPercentageSupportThreshold: 7_500_000,
+				flatSupportThreshold: 3,
+				disableFastPathAccessForNewMembers: true,
+				executionGracePeriod: 600,
+			})
 		})
 
 		it("maps SET_TOPIC and UNSET_TOPIC actions in list responses", async () => {
@@ -590,31 +695,31 @@ describe("SQL/TypeScript status parity", () => {
 			expect(result.status).toBe("EXECUTABLE")
 		})
 
-		it("handles zero threshold with zero yes votes (Fast path NOT executable)", () => {
-			// This is the edge case: threshold=0 means we need yes > -1, which means yes >= 0
-			// But the contract logic uses yes > (threshold - 1), with threshold - 1 = 0 when threshold = 0
-			// So we need yes > 0, meaning at least 1 yes vote
+		it("handles zero flatSupportThreshold with zero yes votes (Fast path IS executable)", () => {
+			// V2 formula: yesCount >= flatSupportThreshold. With flat=0, any vote
+			// count — including zero — passes the threshold check.
 			const proposal = makeProposal({
 				votingMode: "Fast",
-				threshold: 0n,
+				threshold: 0n, // mirrors to flatSupportThreshold=0 via the helper
 				yesCount: 0n,
-				endTime: now + 3600n, // voting not ended
+				endTime: now + 3600n,
 			})
 			const result = computeProposalStatus(proposal, now)
-			// With threshold=0 and yesCount=0, threshold formula is yes > max(threshold-1, 0) = yes > 0
-			// 0 > 0 is false, so NOT executable yet
-			expect(result.status).toBe("PROPOSED")
+			expect(result.status).toBe("EXECUTABLE")
 		})
 
-		it("handles zero threshold with zero yes votes after voting ends (REJECTED)", () => {
+		it("handles zero flatSupportThreshold with zero yes votes after voting ends (EXECUTABLE)", () => {
+			// Even after voting ends, a Fast proposal that meets its (trivial)
+			// threshold is EXECUTABLE — voting end only matters when the
+			// threshold is NOT met.
 			const proposal = makeProposal({
 				votingMode: "Fast",
 				threshold: 0n,
 				yesCount: 0n,
-				endTime: now - 100n, // voting ended
+				endTime: now - 100n,
 			})
 			const result = computeProposalStatus(proposal, now)
-			expect(result.status).toBe("REJECTED")
+			expect(result.status).toBe("EXECUTABLE")
 		})
 
 		it("handles threshold=1 exactly met", () => {

--- a/api/src/proposals/__tests__/status.test.ts
+++ b/api/src/proposals/__tests__/status.test.ts
@@ -468,3 +468,251 @@ describe("computeProposalStatus - edge cases", () => {
 		expect(result2.status).toBe("EXECUTABLE")
 	})
 })
+
+// =============================================================================
+// V2: Fast path reads flatSupportThreshold (not legacy threshold)
+// =============================================================================
+
+describe("computeProposalStatus - V2 fast path uses flatSupportThreshold", () => {
+	it("fast path executes when yesCount reaches flatSupportThreshold, ignoring legacy threshold", () => {
+		// flat=3 is the real V2 threshold; legacy threshold is a stale/bogus value.
+		const proposal = makeProposal({
+			votingMode: "Fast",
+			threshold: 100n, // legacy (should be ignored by V2 fast path)
+			flatSupportThreshold: 3n,
+			yesCount: 5n,
+		})
+
+		const result = computeProposalStatus(proposal, proposal.startTime + 1n)
+
+		expect(result.status).toBe("EXECUTABLE")
+		expect(result.isThresholdReached).toBe(true)
+		expect(result.isEarlyExecutable).toBe(false)
+	})
+
+	it("fast path stays PROPOSED when yesCount is below flatSupportThreshold", () => {
+		const proposal = makeProposal({
+			votingMode: "Fast",
+			threshold: 0n, // would pass under legacy threshold reading
+			flatSupportThreshold: 10n,
+			yesCount: 5n,
+		})
+
+		const result = computeProposalStatus(proposal, proposal.startTime + 1n)
+
+		expect(result.status).toBe("PROPOSED")
+		expect(result.isEarlyExecutable).toBe(false)
+	})
+})
+
+// =============================================================================
+// V2: Slow-path late execution reads partialPercentageSupportThreshold
+// =============================================================================
+
+describe("computeProposalStatus - V2 slow late uses partialPercentageSupportThreshold", () => {
+	it("slow late path uses partial threshold (not legacy)", () => {
+		// Under legacy threshold=9M (90%), 5 yes vs 3 no would fail.
+		// Under V2 partial=5M (50%), 5 yes vs 3 no passes.
+		const proposal = makeProposal({
+			votingMode: "Slow",
+			threshold: 9_000_000n, // 90% — stale/bogus under V2
+			partialPercentageSupportThreshold: 5_000_000n, // 50%
+			quorum: 5n,
+			yesCount: 5n,
+			noCount: 3n,
+			abstainCount: 0n,
+		})
+
+		const result = computeProposalStatus(proposal, proposal.endTime + 1n)
+
+		// (RATIO_BASE - partial) * yes > partial * no
+		// (10M - 5M) * 5 > 5M * 3 => 25M > 15M ✓
+		expect(result.status).toBe("EXECUTABLE")
+		expect(result.isThresholdReached).toBe(true)
+		expect(result.isEarlyExecutable).toBe(false)
+	})
+})
+
+// =============================================================================
+// V2: Slow-path early execution (NEW) — universalPercentageSupportThreshold × totalEditors
+// =============================================================================
+
+describe("computeProposalStatus - V2 slow early execution", () => {
+	it("becomes EXECUTABLE before voting ends when yesCount meets the universal/totalEditors ratio", () => {
+		// ceil(75% × 4 editors) = ceil(30M/10M) = 3 yes-votes required.
+		const proposal = makeProposal({
+			votingMode: "Slow",
+			universalPercentageSupportThreshold: 7_500_000n, // 75%
+			totalEditors: 4n,
+			partialPercentageSupportThreshold: 5_000_000n,
+			quorum: 10n,
+			yesCount: 4n, // above the ceiling
+			noCount: 0n,
+			abstainCount: 0n,
+		})
+
+		// Voting is still ongoing.
+		const result = computeProposalStatus(proposal, proposal.startTime + 1n)
+
+		expect(result.status).toBe("EXECUTABLE")
+		expect(result.isEarlyExecutable).toBe(true)
+	})
+
+	it("does not early-execute below the universal threshold — stays PROPOSED during voting", () => {
+		// Requires 3 yes; only has 2.
+		const proposal = makeProposal({
+			votingMode: "Slow",
+			universalPercentageSupportThreshold: 7_500_000n, // 75%
+			totalEditors: 4n,
+			partialPercentageSupportThreshold: 5_000_000n,
+			quorum: 10n,
+			yesCount: 2n,
+			noCount: 0n,
+			abstainCount: 0n,
+		})
+
+		const result = computeProposalStatus(proposal, proposal.startTime + 1n)
+
+		expect(result.status).toBe("PROPOSED")
+		expect(result.isEarlyExecutable).toBe(false)
+	})
+
+	it("rounds the universal × totalEditors ratio up (ceiling)", () => {
+		// 33% × 10 editors = 3.3 → ceil = 4 yes-votes required.
+		const proposal = makeProposal({
+			votingMode: "Slow",
+			universalPercentageSupportThreshold: 3_333_333n, // ~33.33%
+			totalEditors: 10n,
+			partialPercentageSupportThreshold: 5_000_000n,
+			quorum: 10n,
+			yesCount: 3n, // below ceiling of 4
+			noCount: 0n,
+			abstainCount: 0n,
+		})
+
+		const result = computeProposalStatus(proposal, proposal.startTime + 1n)
+		expect(result.status).toBe("PROPOSED")
+		expect(result.isEarlyExecutable).toBe(false)
+
+		const proposal2 = makeProposal({
+			...proposal,
+			yesCount: 4n,
+		})
+		const result2 = computeProposalStatus(proposal2, proposal2.startTime + 1n)
+		expect(result2.status).toBe("EXECUTABLE")
+		expect(result2.isEarlyExecutable).toBe(true)
+	})
+
+	it("does not apply early execution when totalEditors is 0 (no editors indexed yet)", () => {
+		// Without a known editor count, we can't evaluate the formula safely.
+		// Falls through to the normal slow-path behavior (must wait for voting end).
+		const proposal = makeProposal({
+			votingMode: "Slow",
+			universalPercentageSupportThreshold: 7_500_000n,
+			totalEditors: 0n,
+			partialPercentageSupportThreshold: 5_000_000n,
+			quorum: 10n,
+			yesCount: 1_000_000n, // extremely high
+			noCount: 0n,
+			abstainCount: 0n,
+		})
+
+		const result = computeProposalStatus(proposal, proposal.startTime + 1n)
+
+		expect(result.status).toBe("PROPOSED")
+		expect(result.isEarlyExecutable).toBe(false)
+	})
+})
+
+// =============================================================================
+// V2: executeBy deadline
+// =============================================================================
+
+describe("computeProposalStatus - V2 executeBy deadline", () => {
+	it("REJECTS an otherwise-executable fast proposal past executeBy", () => {
+		const now = BigInt(Math.floor(Date.now() / 1000))
+		const proposal = makeProposal({
+			votingMode: "Fast",
+			flatSupportThreshold: 3n,
+			yesCount: 100n, // well past threshold
+			executeBy: now - 10n, // deadline passed
+			endTime: now + 3600n, // voting window still open
+		})
+
+		const result = computeProposalStatus(proposal, now)
+
+		expect(result.status).toBe("REJECTED")
+	})
+
+	it("REJECTS an otherwise-early-executable slow proposal past executeBy", () => {
+		const now = BigInt(Math.floor(Date.now() / 1000))
+		const proposal = makeProposal({
+			votingMode: "Slow",
+			universalPercentageSupportThreshold: 5_000_000n,
+			totalEditors: 2n, // ceil(50%×2)=1 yes required
+			partialPercentageSupportThreshold: 5_000_000n,
+			quorum: 1n,
+			yesCount: 2n,
+			executeBy: now - 10n,
+			endTime: now + 3600n,
+		})
+
+		const result = computeProposalStatus(proposal, now)
+
+		expect(result.status).toBe("REJECTED")
+		expect(result.isEarlyExecutable).toBe(false)
+	})
+
+	it("falls through to normal V1 behavior when executeBy is null (legacy proposals)", () => {
+		const now = BigInt(Math.floor(Date.now() / 1000))
+		const proposal = makeProposal({
+			votingMode: "Fast",
+			flatSupportThreshold: 3n,
+			yesCount: 5n,
+			executeBy: null,
+			endTime: now - 10n, // voting ended
+		})
+
+		const result = computeProposalStatus(proposal, now)
+
+		expect(result.status).toBe("EXECUTABLE")
+	})
+
+	it("does not reject exactly at executeBy (boundary: now == executeBy still allowed)", () => {
+		const now = BigInt(Math.floor(Date.now() / 1000))
+		const proposal = makeProposal({
+			votingMode: "Fast",
+			flatSupportThreshold: 3n,
+			yesCount: 5n,
+			executeBy: now,
+			endTime: now + 3600n,
+		})
+
+		const result = computeProposalStatus(proposal, now)
+
+		// `now > executeBy` is strictly greater; at the boundary, still executable.
+		expect(result.status).toBe("EXECUTABLE")
+	})
+})
+
+// =============================================================================
+// V2: isEarlyExecutable flag is false for all non-slow-early paths
+// =============================================================================
+
+describe("computeProposalStatus - isEarlyExecutable default", () => {
+	it.each([
+		["fast executable", {votingMode: "Fast" as const, flatSupportThreshold: 1n, yesCount: 5n}],
+		["fast proposed", {votingMode: "Fast" as const, flatSupportThreshold: 100n, yesCount: 0n}],
+	])("returns isEarlyExecutable=false for %s", (_label, overrides) => {
+		const proposal = makeProposal(overrides)
+		const result = computeProposalStatus(proposal, proposal.startTime + 1n)
+		expect(result.isEarlyExecutable).toBe(false)
+	})
+
+	it("returns isEarlyExecutable=false for ACCEPTED (already executed) proposals", () => {
+		const proposal = makeProposal({executedAt: 1234567890n})
+		const result = computeProposalStatus(proposal, proposal.startTime + 1n)
+		expect(result.status).toBe("ACCEPTED")
+		expect(result.isEarlyExecutable).toBe(false)
+	})
+})

--- a/api/src/proposals/__tests__/status.test.ts
+++ b/api/src/proposals/__tests__/status.test.ts
@@ -15,19 +15,33 @@ import {type ProposalWithVotes, RATIO_BASE} from "../types"
 
 /**
  * Create a test proposal with sensible defaults.
+ *
+ * The V2 thresholds default so the legacy `threshold` field semantics still
+ * hold for callers that only set `threshold`: Fast-mode proposals mirror
+ * `threshold` into `flatSupportThreshold`, and Slow-mode proposals mirror it
+ * into `partialPercentageSupportThreshold`. Callers can always override a
+ * V2 field directly when a test needs it.
  */
 function makeProposal(overrides: Partial<ProposalWithVotes> = {}): ProposalWithVotes {
 	const now = BigInt(Math.floor(Date.now() / 1000))
+	const votingMode = overrides.votingMode ?? "Fast"
+	const threshold = overrides.threshold ?? 10n
 	return {
 		id: "test-proposal-id",
 		spaceId: "test-space-id",
 		name: "Test Proposal",
 		proposedBy: "test-proposer-id",
-		votingMode: "Fast",
+		proposalVersion: 1,
+		votingMode,
 		startTime: now - 3600n, // Started 1 hour ago
 		endTime: now + 3600n, // Ends in 1 hour
 		quorum: 10n,
-		threshold: 10n,
+		threshold,
+		flatSupportThreshold: votingMode === "Fast" ? threshold : 0n,
+		partialPercentageSupportThreshold: votingMode === "Slow" ? threshold : 0n,
+		universalPercentageSupportThreshold: 0n,
+		executeBy: null,
+		totalEditors: 0n,
 		executedAt: null,
 		yesCount: 0n,
 		noCount: 0n,

--- a/api/src/proposals/queries.ts
+++ b/api/src/proposals/queries.ts
@@ -680,8 +680,10 @@ export function listProposalsInSpace(
 			const cursorCondition = buildCursorCondition(cursor, orderBy, orderDirection)
 			const orderClause = buildOrderClause(orderBy, orderDirection)
 
-			// Build action type filter conditions
-			// Use EXISTS subquery instead of JOIN to avoid SQL injection and cartesian products
+			// Build action type filter conditions.
+			// Use EXISTS subquery instead of JOIN to avoid SQL injection and cartesian products.
+			// Scope by proposal_version so historical actions from prior versions don't
+			// match the current-version list.
 			let actionTypeCondition = sql``
 			if (actionTypes && actionTypes.length > 0) {
 				// Include filter: proposal must have at least one of these action types
@@ -689,8 +691,10 @@ export function listProposalsInSpace(
 				const actionTypeChecks = actionTypes.map((t) => sql`pa_filter.action_type = ${t}::"proposalActionType"`)
 				const actionTypeOr = actionTypeChecks.reduce((acc, check) => sql`${acc} OR ${check}`)
 				actionTypeCondition = sql`AND EXISTS (
-          SELECT 1 FROM proposal_actions pa_filter 
-          WHERE pa_filter.proposal_id = p.id AND (${actionTypeOr})
+          SELECT 1 FROM proposal_actions pa_filter
+          WHERE pa_filter.proposal_id = p.id
+            AND pa_filter.proposal_version = p.proposal_version
+            AND (${actionTypeOr})
         )`
 			} else if (excludeActionTypes && excludeActionTypes.length > 0) {
 				// Exclude filter: proposal must NOT have any of these action types
@@ -699,8 +703,10 @@ export function listProposalsInSpace(
 				)
 				const excludeTypeOr = excludeTypeChecks.reduce((acc, check) => sql`${acc} OR ${check}`)
 				actionTypeCondition = sql`AND NOT EXISTS (
-          SELECT 1 FROM proposal_actions pa_exclude 
-          WHERE pa_exclude.proposal_id = p.id AND (${excludeTypeOr})
+          SELECT 1 FROM proposal_actions pa_exclude
+          WHERE pa_exclude.proposal_id = p.id
+            AND pa_exclude.proposal_version = p.proposal_version
+            AND (${excludeTypeOr})
         )`
 			}
 

--- a/api/src/proposals/queries.ts
+++ b/api/src/proposals/queries.ts
@@ -36,6 +36,11 @@ interface ActionJsonRow {
 	fast_threshold: number | null
 	slow_threshold: number | null
 	duration: number | null
+	partial_percentage_support_threshold: number | null
+	universal_percentage_support_threshold: number | null
+	flat_support_threshold: number | null
+	disable_fast_path_access_for_new_members: boolean | null
+	execution_grace_period: number | null
 }
 
 /** Raw vote row from JSON aggregation */
@@ -44,17 +49,32 @@ interface VoteJsonRow {
 	vote: string
 }
 
-/** Base proposal row fields shared between queries */
+/**
+ * Base proposal row fields shared between queries.
+ *
+ * Rows come from the `proposals_current` view (identity joined with the
+ * current `proposal_versions` entry) LEFT-JOINed implicitly — via a
+ * correlated subquery — to `space_editor_counts` for `total_editors`.
+ *
+ * The legacy `threshold` column is retained on the view for backcompat but
+ * new logic reads the per-mode V2 fields directly.
+ */
 interface BaseProposalRow extends Record<string, unknown> {
 	id: string
 	space_id: string
 	name: string | null
 	proposed_by: string
+	proposal_version: number
 	voting_mode: "Fast" | "Slow"
 	start_time: string
 	end_time: string
 	quorum: string
 	threshold: string
+	flat_support_threshold: string
+	partial_percentage_support_threshold: string
+	universal_percentage_support_threshold: string
+	execute_by: string | null
+	total_editors: string
 	executed_at: string | null
 	yes_count: string
 	no_count: string
@@ -75,6 +95,11 @@ function mapActionsFromJson(actionsJson: ActionJsonRow[] | null): ProposalAction
 		fastThreshold: a.fast_threshold,
 		slowThreshold: a.slow_threshold,
 		duration: a.duration,
+		partialPercentageSupportThreshold: a.partial_percentage_support_threshold,
+		universalPercentageSupportThreshold: a.universal_percentage_support_threshold,
+		flatSupportThreshold: a.flat_support_threshold,
+		disableFastPathAccessForNewMembers: a.disable_fast_path_access_for_new_members,
+		executionGracePeriod: a.execution_grace_period,
 	}))
 }
 
@@ -99,19 +124,34 @@ function mapVotesFromJson(votesJson: VoteJsonRow[] | null): Vote[] {
 
 /**
  * Maps shared base fields from a proposal row.
+ *
+ * Computes the legacy `threshold` compatibility projection: Fast proposals
+ * use `flatSupportThreshold`, Slow proposals use
+ * `partialPercentageSupportThreshold`. New callers should read the per-mode
+ * V2 field directly; `threshold` stays for existing API response clients.
  */
 function mapBaseFields(row: BaseProposalRow) {
+	const votingMode = row.voting_mode as VotingMode
+	const flat = BigInt(row.flat_support_threshold)
+	const partial = BigInt(row.partial_percentage_support_threshold)
+	const legacyThreshold = votingMode === "Fast" ? flat : partial
 	return {
 		id: row.id,
 		spaceId: row.space_id,
 		name: row.name,
 		proposedBy: row.proposed_by,
-		votingMode: row.voting_mode as VotingMode,
+		proposalVersion: row.proposal_version,
+		votingMode,
 		startTime: BigInt(row.start_time),
 		endTime: BigInt(row.end_time),
 		quorum: BigInt(row.quorum),
-		threshold: BigInt(row.threshold),
-		executedAt: row.executed_at ? BigInt(row.executed_at) : null,
+		threshold: legacyThreshold,
+		flatSupportThreshold: flat,
+		partialPercentageSupportThreshold: partial,
+		universalPercentageSupportThreshold: BigInt(row.universal_percentage_support_threshold),
+		executeBy: row.execute_by !== null ? BigInt(row.execute_by) : null,
+		totalEditors: BigInt(row.total_editors),
+		executedAt: row.executed_at !== null ? BigInt(row.executed_at) : null,
 		yesCount: BigInt(row.yes_count),
 		noCount: BigInt(row.no_count),
 		abstainCount: BigInt(row.abstain_count),
@@ -170,30 +210,36 @@ export function getProposalWithVotes(
 			// Use JSON aggregation to get votes and actions in a single query
 			// Vote counts use denormalized columns; individual votes fetched via LATERAL
 			const result = await db.execute<BaseProposalRow & {votes_json: VoteJsonRow[] | null}>(sql`
-        SELECT 
+        SELECT
           p.id,
           p.space_id,
           p.name,
           p.proposed_by,
+          p.proposal_version,
           p.voting_mode,
           p.start_time,
           p.end_time,
           p.quorum,
           p.threshold,
+          p.flat_support_threshold,
+          p.partial_percentage_support_threshold,
+          p.universal_percentage_support_threshold,
+          p.execute_by,
+          ${sqlTotalEditors()} AS total_editors,
           p.executed_at,
           p.yes_count,
           p.no_count,
           p.abstain_count,
           v.votes_json,
           a.actions_json
-        FROM proposals p
+        FROM proposals_current p
         LEFT JOIN LATERAL (
           SELECT COALESCE(json_agg(json_build_object(
             'voter_id', voter_id,
             'vote', vote
           )), '[]'::json) as votes_json
           FROM proposal_votes
-          WHERE proposal_id = p.id
+          WHERE proposal_id = p.id AND proposal_version = p.proposal_version
         ) v ON true
         LEFT JOIN LATERAL (
           SELECT COALESCE(json_agg(json_build_object(
@@ -204,10 +250,15 @@ export function getProposalWithVotes(
             'quorum', quorum,
             'fast_threshold', fast_threshold,
             'slow_threshold', slow_threshold,
-            'duration', duration
+            'duration', duration,
+            'partial_percentage_support_threshold', partial_percentage_support_threshold,
+            'universal_percentage_support_threshold', universal_percentage_support_threshold,
+            'flat_support_threshold', flat_support_threshold,
+            'disable_fast_path_access_for_new_members', disable_fast_path_access_for_new_members,
+            'execution_grace_period', execution_grace_period
           )), '[]'::json) as actions_json
           FROM proposal_actions
-          WHERE proposal_id = p.id
+          WHERE proposal_id = p.id AND proposal_version = p.proposal_version
         ) a ON true
         WHERE p.id = ${proposalId}::uuid
       `)
@@ -278,10 +329,16 @@ export interface ListProposalsResult {
  * must be made in BOTH places. Run tests in __tests__/queries.test.ts to
  * verify implementations match.
  *
- * These fragment builders are the single source of truth for SQL status
- * conditions. All query functions (listProposalsInSpace, hasActiveProposalForTarget)
- * compose from these fragments rather than duplicating the logic.
+ * Fragments assume `p` is an alias of `proposals_current` (the view that
+ * joins identity + the current version row). Editor-count is read via a
+ * correlated subquery against the `space_editor_counts` view so fragments
+ * stay self-contained across call sites.
  */
+
+/** Correlated subquery: per-space editor count, 0 if the space has no indexed editors. */
+function sqlTotalEditors() {
+	return sql`COALESCE((SELECT sec.total_editors FROM space_editor_counts sec WHERE sec.space_id = p.space_id), 0)`
+}
 
 /** Proposal is ACCEPTED: already executed. */
 function sqlIsAccepted() {
@@ -289,55 +346,82 @@ function sqlIsAccepted() {
 }
 
 /**
- * Proposal is PROPOSED: not executed, voting not ended, and not yet
- * executable on the fast path.
- */
-function sqlIsProposed(nowSeconds: bigint) {
-	return sql`(
-		p.executed_at IS NULL
-		AND ${nowSeconds}::bigint <= p.end_time
-		AND (
-			p.voting_mode = 'Slow'
-			OR (p.voting_mode = 'Fast' AND p.yes_count <= GREATEST(p.threshold - 1, 0))
-		)
-	)`
-}
-
-/**
- * Proposal is EXECUTABLE: not executed, and threshold conditions met.
- * Fast path: yes_count > threshold - 1 (equivalent to yes >= threshold).
- * Slow path: voting ended, quorum met, and ratio-based threshold met.
+ * Proposal is EXECUTABLE iff not executed, deadline not passed, and any
+ * path produces an executable outcome:
+ *   - Fast: yes_count >= flat_support_threshold
+ *   - Slow early: voting ongoing AND total_editors > 0 AND universal > 0
+ *                 AND yes_count >= ceil(universal * total_editors / RATIO_BASE)
+ *   - Slow late:  voting ended AND quorum met
+ *                 AND (RATIO_BASE - partial) * yes > partial * no
  */
 function sqlIsExecutable(nowSeconds: bigint) {
 	return sql`(
 		p.executed_at IS NULL
+		AND (p.execute_by IS NULL OR ${nowSeconds}::bigint <= p.execute_by)
 		AND (
-			(p.voting_mode = 'Fast' AND p.yes_count > GREATEST(p.threshold - 1, 0))
+			(p.voting_mode = 'Fast' AND p.yes_count >= p.flat_support_threshold)
+			OR (
+				p.voting_mode = 'Slow'
+				AND ${nowSeconds}::bigint <= p.end_time
+				AND ${sqlTotalEditors()} > 0
+				AND p.universal_percentage_support_threshold > 0
+				AND p.yes_count::numeric >= CEIL(
+					(p.universal_percentage_support_threshold::numeric * ${sqlTotalEditors()}::numeric)
+					/ ${RATIO_BASE}::numeric
+				)
+			)
 			OR (
 				p.voting_mode = 'Slow'
 				AND ${nowSeconds}::bigint > p.end_time
 				AND (p.yes_count + p.no_count + p.abstain_count) >= p.quorum
-				AND (${RATIO_BASE}::numeric - p.threshold::numeric) * p.yes_count::numeric > p.threshold::numeric * p.no_count::numeric
+				AND (${RATIO_BASE}::numeric - p.partial_percentage_support_threshold::numeric) * p.yes_count::numeric > p.partial_percentage_support_threshold::numeric * p.no_count::numeric
 			)
 		)
 	)`
 }
 
 /**
- * Proposal is REJECTED: not executed, voting ended, and threshold/quorum
- * not met.
+ * Proposal is PROPOSED iff not executed, deadline not passed, voting
+ * ongoing, and no executable path is already matched.
+ */
+function sqlIsProposed(nowSeconds: bigint) {
+	return sql`(
+		p.executed_at IS NULL
+		AND (p.execute_by IS NULL OR ${nowSeconds}::bigint <= p.execute_by)
+		AND ${nowSeconds}::bigint <= p.end_time
+		AND NOT (
+			(p.voting_mode = 'Fast' AND p.yes_count >= p.flat_support_threshold)
+			OR (
+				p.voting_mode = 'Slow'
+				AND ${sqlTotalEditors()} > 0
+				AND p.universal_percentage_support_threshold > 0
+				AND p.yes_count::numeric >= CEIL(
+					(p.universal_percentage_support_threshold::numeric * ${sqlTotalEditors()}::numeric)
+					/ ${RATIO_BASE}::numeric
+				)
+			)
+		)
+	)`
+}
+
+/**
+ * Proposal is REJECTED iff not executed and either the executeBy deadline
+ * has passed, or voting ended without any executable path matching.
  */
 function sqlIsRejected(nowSeconds: bigint) {
 	return sql`(
 		p.executed_at IS NULL
-		AND ${nowSeconds}::bigint > p.end_time
 		AND (
-			(p.voting_mode = 'Fast' AND p.yes_count <= GREATEST(p.threshold - 1, 0))
+			(p.execute_by IS NOT NULL AND ${nowSeconds}::bigint > p.execute_by)
 			OR (
-				p.voting_mode = 'Slow'
-				AND (
-					(p.yes_count + p.no_count + p.abstain_count) < p.quorum
-					OR (${RATIO_BASE}::numeric - p.threshold::numeric) * p.yes_count::numeric <= p.threshold::numeric * p.no_count::numeric
+				${nowSeconds}::bigint > p.end_time
+				AND NOT (
+					(p.voting_mode = 'Fast' AND p.yes_count >= p.flat_support_threshold)
+					OR (
+						p.voting_mode = 'Slow'
+						AND (p.yes_count + p.no_count + p.abstain_count) >= p.quorum
+						AND (${RATIO_BASE}::numeric - p.partial_percentage_support_threshold::numeric) * p.yes_count::numeric > p.partial_percentage_support_threshold::numeric * p.no_count::numeric
+					)
 				)
 			)
 		)
@@ -530,12 +614,13 @@ function hasActiveProposalForTarget(
 
 			const result = await db.execute<{exists: boolean}>(sql`
 				SELECT EXISTS (
-					SELECT 1 FROM proposals p
+					SELECT 1 FROM proposals_current p
 					WHERE p.space_id = ${spaceId}::uuid
 						AND p.executed_at IS NULL
 						AND EXISTS (
 							SELECT 1 FROM proposal_actions pa
 							WHERE pa.proposal_id = p.id
+								AND pa.proposal_version = p.proposal_version
 								AND pa.action_type = ${actionType}::"proposalActionType"
 								AND pa.target_id = ${targetSpaceId}::uuid
 						)
@@ -647,13 +732,15 @@ export function listProposalsInSpace(
 				statusCondition = sql`AND (${statusOr})`
 			}
 
-			// Vote counts are denormalized on the proposals table.
+			// Vote counts are denormalized on the current proposal_version.
 			// Individual voters are omitted for performance (use single proposal endpoint for full voter list).
-			// When voterId is provided, we fetch just the user's vote via a LATERAL join.
+			// When voterId is provided, we fetch just the user's vote on the current version via a LATERAL join.
 			const userVoteJoin = voterId
 				? sql`LEFT JOIN LATERAL (
             SELECT vote FROM proposal_votes
-            WHERE proposal_id = p.id AND voter_id = ${voterId}::uuid
+            WHERE proposal_id = p.id
+              AND proposal_version = p.proposal_version
+              AND voter_id = ${voterId}::uuid
             LIMIT 1
           ) user_vote ON true`
 				: sql``
@@ -661,16 +748,22 @@ export function listProposalsInSpace(
 
 			const result = await db.execute<BaseProposalRow & {created_at: string; user_vote?: string | null}>(
 				sql`
-        SELECT 
+        SELECT
           p.id,
           p.space_id,
           p.name,
           p.proposed_by,
+          p.proposal_version,
           p.voting_mode,
           p.start_time,
           p.end_time,
           p.quorum,
           p.threshold,
+          p.flat_support_threshold,
+          p.partial_percentage_support_threshold,
+          p.universal_percentage_support_threshold,
+          p.execute_by,
+          ${sqlTotalEditors()} AS total_editors,
           p.executed_at,
           p.created_at,
           p.yes_count,
@@ -678,7 +771,7 @@ export function listProposalsInSpace(
           p.abstain_count,
           actions_agg.actions_json
           ${userVoteSelect}
-        FROM proposals p
+        FROM proposals_current p
         LEFT JOIN LATERAL (
           SELECT COALESCE(json_agg(json_build_object(
             'action_type', action_type,
@@ -688,10 +781,15 @@ export function listProposalsInSpace(
             'quorum', quorum,
             'fast_threshold', fast_threshold,
             'slow_threshold', slow_threshold,
-            'duration', duration
+            'duration', duration,
+            'partial_percentage_support_threshold', partial_percentage_support_threshold,
+            'universal_percentage_support_threshold', universal_percentage_support_threshold,
+            'flat_support_threshold', flat_support_threshold,
+            'disable_fast_path_access_for_new_members', disable_fast_path_access_for_new_members,
+            'execution_grace_period', execution_grace_period
           )), '[]'::json) as actions_json
           FROM proposal_actions
-          WHERE proposal_id = p.id
+          WHERE proposal_id = p.id AND proposal_version = p.proposal_version
         ) actions_agg ON true
         ${userVoteJoin}
         WHERE p.space_id = ${spaceId}::uuid

--- a/api/src/proposals/router.ts
+++ b/api/src/proposals/router.ts
@@ -127,6 +127,11 @@ function mapToActionResponse(action: ProposalWithVotes["actions"][number]): Acti
 				fastThreshold: action.fastThreshold,
 				slowThreshold: action.slowThreshold,
 				duration: action.duration,
+				partialPercentageSupportThreshold: action.partialPercentageSupportThreshold,
+				universalPercentageSupportThreshold: action.universalPercentageSupportThreshold,
+				flatSupportThreshold: action.flatSupportThreshold,
+				disableFastPathAccessForNewMembers: action.disableFastPathAccessForNewMembers,
+				executionGracePeriod: action.executionGracePeriod,
 			}
 		case "SubspaceVerified":
 			if (!action.targetId) return {actionType: "UNKNOWN"}
@@ -199,6 +204,8 @@ function computeResponseFields(proposal: ProposalWithVotes | ProposalListItem, n
 		spaceId: normalizeUuid(proposal.spaceId),
 		name: proposal.name,
 		proposedBy: normalizeUuid(proposal.proposedBy),
+		proposalVersion: proposal.proposalVersion,
+		executeBy: proposal.executeBy !== null ? Number(proposal.executeBy) : null,
 		status,
 		votingMode: proposal.votingMode.toUpperCase() as "FAST" | "SLOW",
 		actions: proposal.actions.map(mapToActionResponse),

--- a/api/src/proposals/status.ts
+++ b/api/src/proposals/status.ts
@@ -2,21 +2,30 @@
  * Proposal status computation matching the smart contract logic.
  *
  * This module provides a pure function for computing proposal status,
- * matching the contract's `isSupportThresholdReached()` implementation.
+ * matching the contract's `isSupportThresholdReached()` / `canExecuteProposal()`
+ * V2 implementation.
  */
 
 import type {ProposalListItem, ProposalWithVotes, StatusComputationResult} from "./types"
 import {RATIO_BASE} from "./types"
 
 /**
- * Computes proposal status matching the smart contract's isSupportThresholdReached() logic.
+ * Computes proposal status matching the V2 smart contract logic.
  *
  * This is a PURE function - time is injected to enable deterministic testing.
  *
- * Contract logic:
- * - Fast path: flat threshold (yes > threshold - 1, equivalent to yes >= threshold)
- * - Slow path: percentage threshold with quorum, voting must end first
- *   Formula: (RATIO_BASE - threshold) * yes > threshold * no
+ * Decision order:
+ * 1. Already executed → ACCEPTED
+ * 2. Past `executeBy` deadline → REJECTED
+ * 3. Fast path: `yesCount >= flatSupportThreshold` → EXECUTABLE
+ * 4. Slow-path early execution (before voting ends): when
+ *    `yesCount >= ceil(universalPercentageSupportThreshold × totalEditors / RATIO_BASE)`.
+ * 5. Slow-path late execution (after voting ends): quorum + the classic
+ *    `(RATIO_BASE - partial) × yes > partial × no` ratio.
+ *
+ * Must stay byte-for-byte consistent with the SQL fragments in `queries.ts`
+ * (`sqlIsExecutable` / `sqlIsProposed` / `sqlIsRejected`). The parity tests
+ * in `__tests__/queries.test.ts` validate this — update both sides together.
  *
  * @param proposal - The proposal with aggregated vote counts (using bigint)
  * @param nowSeconds - Current time in seconds (inject for testability)
@@ -26,62 +35,107 @@ export function computeProposalStatus(
 	proposal: ProposalWithVotes | ProposalListItem,
 	nowSeconds: bigint,
 ): StatusComputationResult {
-	// Already executed -> ACCEPTED (regardless of votes)
+	// Already executed -> ACCEPTED (regardless of votes or deadline)
 	if (proposal.executedAt !== null) {
 		return {
 			status: "ACCEPTED",
-			isQuorumReached: true, // Must have been reached to execute
+			isQuorumReached: true,
 			isThresholdReached: true,
+			isEarlyExecutable: false,
+		}
+	}
+
+	// Past the on-chain `executeBy` deadline → REJECTED, regardless of vote outcome.
+	// Null `executeBy` means no deadline (legacy V1 rows).
+	if (proposal.executeBy !== null && nowSeconds > proposal.executeBy) {
+		return {
+			status: "REJECTED",
+			isQuorumReached: false,
+			isThresholdReached: false,
+			isEarlyExecutable: false,
 		}
 	}
 
 	const isVotingEnded = nowSeconds > proposal.endTime
 	const totalVotes = proposal.yesCount + proposal.noCount + proposal.abstainCount
-
-	// Quorum check (applies to both paths, but only enforced in slow path)
 	const isQuorumReached = totalVotes >= proposal.quorum
 
 	if (proposal.votingMode === "Fast") {
-		// Fast path: flat threshold (absolute yes votes needed)
-		// Contract uses `yes > threshold - 1` which is equivalent to `yes >= threshold`
-		// We subtract 1 to match the contract's strict inequality
-		const fastThreshold = proposal.threshold === 0n ? 0n : proposal.threshold - 1n
-		const isThresholdReached = proposal.yesCount > fastThreshold
+		const isThresholdReached = proposal.yesCount >= proposal.flatSupportThreshold
 
 		if (isThresholdReached) {
-			return {status: "EXECUTABLE", isQuorumReached, isThresholdReached}
+			return {
+				status: "EXECUTABLE",
+				isQuorumReached,
+				isThresholdReached,
+				isEarlyExecutable: false,
+			}
 		}
 		return {
 			status: isVotingEnded ? "REJECTED" : "PROPOSED",
 			isQuorumReached,
 			isThresholdReached,
+			isEarlyExecutable: false,
 		}
 	}
 
-	// Slow path: percentage threshold with quorum check
-	// Formula from contract: (RATIO_BASE - threshold) * yes > threshold * no
-	// With RATIO_BASE = 10_000_000 and threshold = 5_000_000 (50%):
-	// 5_000_000 * yes > 5_000_000 * no -> yes > no
-	// Note: A tie (yes == no) results in REJECTED (threshold not reached)
-	const threshold = proposal.threshold
-	const isThresholdReached = (RATIO_BASE - threshold) * proposal.yesCount > threshold * proposal.noCount
-
-	// Must wait for voting period to end before determining outcome
-	if (!isVotingEnded) {
-		// During voting, compute threshold for UI display but status is PROPOSED
-		return {status: "PROPOSED", isQuorumReached, isThresholdReached}
+	// Slow path — early execution (before voting ends).
+	// Skip the check when we can't evaluate it safely: totalEditors = 0 means
+	// the space has no indexed editors yet; universal = 0 means no configured
+	// early-execution threshold.
+	if (
+		!isVotingEnded &&
+		proposal.totalEditors > 0n &&
+		proposal.universalPercentageSupportThreshold > 0n
+	) {
+		const required = ceilDiv(
+			proposal.universalPercentageSupportThreshold * proposal.totalEditors,
+			RATIO_BASE,
+		)
+		if (proposal.yesCount >= required) {
+			return {
+				status: "EXECUTABLE",
+				isQuorumReached,
+				isThresholdReached: true,
+				isEarlyExecutable: true,
+			}
+		}
 	}
 
-	// Voting ended - check quorum first
+	// Slow path — late execution (after voting ends).
+	const partial = proposal.partialPercentageSupportThreshold
+	const isThresholdReached =
+		(RATIO_BASE - partial) * proposal.yesCount > partial * proposal.noCount
+
+	if (!isVotingEnded) {
+		return {
+			status: "PROPOSED",
+			isQuorumReached,
+			isThresholdReached,
+			isEarlyExecutable: false,
+		}
+	}
+
 	if (!isQuorumReached) {
-		return {status: "REJECTED", isQuorumReached, isThresholdReached: false}
+		return {
+			status: "REJECTED",
+			isQuorumReached,
+			isThresholdReached: false,
+			isEarlyExecutable: false,
+		}
 	}
 
 	return {
 		status: isThresholdReached ? "EXECUTABLE" : "REJECTED",
 		isQuorumReached,
 		isThresholdReached,
+		isEarlyExecutable: false,
 	}
+}
+
+// Integer ceiling division for bigint. Assumes `divisor > 0n` and `dividend >= 0n`.
+function ceilDiv(dividend: bigint, divisor: bigint): bigint {
+	return (dividend + divisor - 1n) / divisor
 }
 
 /**

--- a/api/src/proposals/types.ts
+++ b/api/src/proposals/types.ts
@@ -79,12 +79,22 @@ export interface ProposalAction {
 	contentId: string | null
 	/** New quorum for UpdateVotingSettings */
 	quorum: number | null
-	/** New fast threshold for UpdateVotingSettings */
+	/** New fast threshold for UpdateVotingSettings (legacy: == flatSupportThreshold) */
 	fastThreshold: number | null
-	/** New slow threshold for UpdateVotingSettings */
+	/** New slow threshold for UpdateVotingSettings (legacy: == partialPercentageSupportThreshold) */
 	slowThreshold: number | null
 	/** New duration for UpdateVotingSettings */
 	duration: number | null
+	/** V2: slow-path late-execution threshold (percentage of RATIO_BASE) */
+	partialPercentageSupportThreshold: number | null
+	/** V2: slow-path early-execution threshold (percentage of RATIO_BASE) */
+	universalPercentageSupportThreshold: number | null
+	/** V2: fast-path threshold (absolute yes-count) */
+	flatSupportThreshold: number | null
+	/** V2: whether newly added members get fast-path access */
+	disableFastPathAccessForNewMembers: boolean | null
+	/** V2: grace period in seconds applied after voting ends */
+	executionGracePeriod: number | null
 }
 
 /**
@@ -98,6 +108,8 @@ export interface ProposalWithVotes {
 	name: string | null
 	/** Member space ID of the proposer */
 	proposedBy: string
+	/** Proposal version number (incremented on each update; starts at 1) */
+	proposalVersion: number
 	votingMode: VotingMode
 	/** Unix timestamp in seconds when voting starts */
 	startTime: bigint
@@ -105,8 +117,25 @@ export interface ProposalWithVotes {
 	endTime: bigint
 	/** Minimum total votes required (for slow path) */
 	quorum: bigint
-	/** Threshold for passing - interpretation depends on votingMode */
+	/**
+	 * Legacy threshold compatibility projection.
+	 *
+	 * For Fast proposals: mirrors `flatSupportThreshold`.
+	 * For Slow proposals: mirrors `partialPercentageSupportThreshold`.
+	 *
+	 * New code should read the per-mode V2 field directly.
+	 */
 	threshold: bigint
+	/** V2: fast-path threshold (absolute yes-count needed to pass) */
+	flatSupportThreshold: bigint
+	/** V2: slow-path late-execution threshold (percentage of RATIO_BASE) */
+	partialPercentageSupportThreshold: bigint
+	/** V2: slow-path early-execution threshold (percentage of RATIO_BASE) */
+	universalPercentageSupportThreshold: bigint
+	/** V2: execution deadline (Unix seconds) — past this, the proposal is REJECTED. Null on legacy rows. */
+	executeBy: bigint | null
+	/** V2: total editor count for the proposal's space, used by the slow-path early-execution formula */
+	totalEditors: bigint
 	/** Unix timestamp when executed, null if not executed */
 	executedAt: bigint | null
 	/** Number of yes votes */
@@ -138,6 +167,14 @@ export interface StatusComputationResult {
 	status: ProposalStatus
 	isQuorumReached: boolean
 	isThresholdReached: boolean
+	/**
+	 * True when a Slow-mode proposal became EXECUTABLE *before* its voting
+	 * period ended via the slow-path early-execution formula
+	 * (`yesCount >= ceil(universalPercentageSupportThreshold * totalEditors / RATIO_BASE)`).
+	 * Always false for Fast-mode and for Slow proposals that execute after
+	 * voting ends.
+	 */
+	isEarlyExecutable: boolean
 }
 
 // =============================================================================
@@ -223,12 +260,22 @@ export interface UpdateVotingSettingsAction {
 	actionType: "UPDATE_VOTING_SETTINGS"
 	/** New minimum total votes required for slow path */
 	quorum: number
-	/** New threshold for fast path (absolute yes votes needed) */
+	/** New threshold for fast path (legacy: == flatSupportThreshold) */
 	fastThreshold: number
-	/** New threshold for slow path (percentage as RATIO_BASE fraction) */
+	/** New threshold for slow path (legacy: == partialPercentageSupportThreshold) */
 	slowThreshold: number
 	/** New voting duration in seconds */
 	duration: number
+	/** V2: slow-path late-execution threshold (percentage of RATIO_BASE) */
+	partialPercentageSupportThreshold: number | null
+	/** V2: slow-path early-execution threshold (percentage of RATIO_BASE) */
+	universalPercentageSupportThreshold: number | null
+	/** V2: fast-path absolute yes-count threshold */
+	flatSupportThreshold: number | null
+	/** V2: whether newly added members get fast-path access */
+	disableFastPathAccessForNewMembers: boolean | null
+	/** V2: grace period in seconds applied after voting ends */
+	executionGracePeriod: number | null
 }
 
 /**
@@ -318,6 +365,10 @@ interface ProposalResponseBase {
 	name: string | null
 	/** Member space ID of the proposer (dashless UUID) */
 	proposedBy: string
+	/** Proposal version number (incremented on each update; starts at 1) */
+	proposalVersion: number
+	/** Execution deadline (Unix seconds) — past this, the proposal is REJECTED. Null on legacy rows. */
+	executeBy: number | null
 	status: ProposalStatus
 	votingMode: "FAST" | "SLOW"
 	/** Actions in this proposal */

--- a/api/src/services/storage/schema.ts
+++ b/api/src/services/storage/schema.ts
@@ -546,14 +546,14 @@ export const proposalVersions = pgTable(
 		/** V2: slow-path late execution threshold (0..RATIO_BASE). */
 		partialPercentageSupportThreshold: bigint("partial_percentage_support_threshold", {
 			mode: "number",
-		}),
+		}).notNull(),
 		/** V2: slow-path early execution threshold (0..RATIO_BASE). */
 		universalPercentageSupportThreshold: bigint("universal_percentage_support_threshold", {
 			mode: "number",
-		}),
+		}).notNull(),
 		/** V2: fast-path absolute YES votes needed. */
-		flatSupportThreshold: bigint("flat_support_threshold", {mode: "number"}),
-		/** V2: inclusive upper bound timestamp for execution. `null` for V1 rows. */
+		flatSupportThreshold: bigint("flat_support_threshold", {mode: "number"}).notNull(),
+		/** V2: inclusive upper bound timestamp for execution. `null` when the proposal has no deadline. */
 		executeBy: bigint("execute_by", {mode: "number"}),
 		/**
 		 * Timestamp/block when this proposal was executed, if any. Version-specific:


### PR DESCRIPTION
Closes [GEO-483](https://linear.app/defi-wonderland/issue/GEO-483) and [GEO-484](https://linear.app/defi-wonderland/issue/GEO-484). Bundled because both live in `api/src/proposals/` and would conflict if done separately.

## Why bundled

- GEO-483 rewrites `status.ts` to read the V2 per-mode thresholds.
- GEO-484 rewrites `queries.ts` / `router.ts` to select and project those fields.

Shipping only one half leaves the other broken: if `status.ts` reads fields `queries.ts` doesn't SELECT, they're `undefined`; if `queries.ts` projects fields `status.ts` doesn't consume, the SQL parity fragments disagree with the TS function. Parity tests would be red either way.

## What it also fixes

The API's proposal queries were **broken on the integration branch** after GEO-481 landed. `queries.ts` still read `p.yes_count`, `p.threshold`, `p.voting_mode`, `p.executed_at`, `p.start_time`, `p.end_time`, `p.quorum`, `p.name` from `proposals` — all dropped in migration `0057` and moved to `proposal_versions`. The existing TS unit tests passed because they mock rows; the SQL was never exercised. Switching `FROM proposals p` → `FROM proposals_current p` (view added in GEO-481) unbreaks all read paths in one move.

## V2 decision tree (status.ts + SQL parity fragments)

1. `executed_at IS NOT NULL` → `ACCEPTED`
2. `execute_by IS NOT NULL AND now > execute_by` → `REJECTED` (deadline overrides votes)
3. **Fast**: `yes_count >= flat_support_threshold` → `EXECUTABLE`
4. **Slow-path early** (NEW, voting ongoing): `total_editors > 0 AND universal > 0 AND yes_count >= ceil(universal × total_editors / RATIO_BASE)` → `EXECUTABLE` (`isEarlyExecutable: true`)
5. **Slow-path late** (voting ended): quorum met AND `(RATIO_BASE - partial) × yes > partial × no` → `EXECUTABLE`; else `REJECTED`
6. Otherwise `PROPOSED`

`total_editors` comes from the `space_editor_counts` view added in GEO-514, read via correlated subquery so the SQL fragments stay self-contained.

## Changes

### `api/src/proposals/types.ts`
- `ProposalWithVotes` / `ProposalListItem`: `proposalVersion`, `flatSupportThreshold`, `partialPercentageSupportThreshold`, `universalPercentageSupportThreshold`, `executeBy` (nullable), `totalEditors`.
- Legacy `threshold: bigint` retained as computed compatibility projection (Fast → flat, Slow → partial).
- `StatusComputationResult.isEarlyExecutable` flag.
- `UpdateVotingSettingsAction` (internal + response): 5 V2 fields added, 4 legacy kept.
- `ProposalResponseBase`: `proposalVersion` + `executeBy`.

### `api/src/proposals/status.ts`
Full rewrite of `computeProposalStatus` with the decision tree above. Bigint ceiling-division helper. `executeBy` strict-greater comparison (boundary `now === executeBy` still executable). `isEarlyExecutable` set only on the slow-early branch.

### `api/src/proposals/queries.ts`
- `FROM proposals_current p` in every read (getProposalWithVotes, listProposalsInSpace, hasActiveProposalForTarget).
- `BaseProposalRow` + `ActionJsonRow` extended with V2 columns.
- `mapBaseFields` computes legacy `threshold` projection.
- `proposal_actions` / `proposal_votes` joins scoped by `(proposal_id, proposal_version)` so historical-version rows don't leak into current tallies.
- New `sqlTotalEditors()` helper (correlated subquery against `space_editor_counts`, COALESCE to 0).
- `sqlIsAccepted/Proposed/Executable/Rejected` rewritten to mirror `status.ts` exactly — Fast (`yes >= flat`), Slow-early (ceiling formula), Slow-late (partial + quorum), `executeBy` guard.
- Actions JSON aggregation extended with 5 V2 UpdateVotingSettings fields.

### `api/src/proposals/router.ts`
- `proposalVersion` and `executeBy` in response shape.
- 5 V2 UpdateVotingSettings fields in action response.
- Legacy threshold / fastThreshold / slowThreshold / quorum / duration preserved for compat.

## Tests

TDD-authored. Test count before → after: 58 → 95 (`src/proposals/__tests__/`).

- **status.test.ts**: 22 legacy V1 cases preserved (helper mirrors `threshold` into the relevant V2 field). 14 new cases: Fast path reads `flat` specifically, Slow-late reads `partial`, slow-early EXECUTABLE with `isEarlyExecutable: true`, ceiling rounding, `totalEditors = 0` fallback, `executeBy` deadline (past / boundary / null), `isEarlyExecutable` default false across other branches.
- **queries.test.ts**: `makeDbProposalRow` extended with V2 columns. Two obsolete V1 zero-threshold edge tests rewritten for `yes >= flat` semantics (threshold=0 is trivially executable under V2, vs. V1's `yes > 0` strict-inequality quirk). 5 new tests for V2 response shape: `proposalVersion`, `executeBy` (with null case), legacy-threshold projection from `flat` vs `partial`, V2 `UpdateVotingSettings` action fields.

## Backward compat

No breaking API changes. Existing clients continue to work:
- `threshold.required` still in responses (now computed from the per-mode V2 field).
- V1 `UpdateVotingSettingsAction` fields (`quorum`, `fastThreshold`, `slowThreshold`, `duration`) still present.
- No renamed response fields. No new required query parameters.

## Known pre-existing failures (not this PR)

Two test files fail against a DB at migration 0057+ because they hand-insert into the dropped `proposals` columns:
- `api/src/versioned/__tests__/integration.test.ts`
- `api/src/versioned/__tests__/proposal-diff-edit-flow.test.ts`

Both contain `INSERT INTO proposals (id, space_id, proposed_by, voting_mode, start_time, end_time, quorum, threshold, ...)` fixtures. Verified present on `wonderland/feat/governance-v2-contract-migration` tip before this PR. Separate follow-up.

## Test plan

- [x] `bun test src/proposals/__tests__/` — 95/95 green
- [x] `bun run check` (tsc --noEmit) — clean
- [x] `bun test` (full suite) — 495 pass / 2 fail (pre-existing, see above)
- [ ] Manual: hit `/proposals/space/:spaceId/status` against a DB with V2 data; verify `proposalVersion`, `executeBy`, and V2 `UpdateVotingSettings` fields in response.
- [ ] Manual: confirm slow-path-early EXECUTABLE on a Slow proposal with `yesCount` above the `universal × totalEditors / RATIO_BASE` ceiling before voting ends.