### PR TITLE
feat(executor): V2 slow-path detection with executeBy + early-exec branch

### DIFF
--- a/proposal-executor/src/detect.ts
+++ b/proposal-executor/src/detect.ts
@@ -1,11 +1,21 @@
 /**
  * Database connection and detection query for executable slow-path proposals.
  *
- * Detection SQL is a third copy of proposal status logic (after computeProposalStatus()
- * in api/src/proposals/status.ts and sqlIsExecutable() in api/src/proposals/queries.ts).
- * It adds a 60s clock-skew buffer not present in the other copies.
+ * Detection SQL is a third copy of proposal status logic (after
+ * computeProposalStatus() in api/src/proposals/status.ts and sqlIsExecutable()
+ * in api/src/proposals/queries.ts). Any change to the decision tree must land
+ * in all three. V2 (GEO-485):
+ *   - Reads from the `proposals_current` view (identity + current version).
+ *   - Uses `partial_percentage_support_threshold` for slow-late and
+ *     `universal_percentage_support_threshold` for slow-early.
+ *   - Enforces `execute_by` as the deadline, with a MAX_PROPOSAL_AGE fallback
+ *     for proposals that have no deadline set (NULL `execute_by`).
+ *   - Adds the 60s CLOCK_SKEW_BUFFER only on the slow-late `end_time` check
+ *     (slow-early runs while voting is ongoing, so no buffer needed).
  *
- * See: docs/plans/2026-03-02-feat-proposal-auto-executor-plan.md §Detection Query
+ * Fast-path proposals are NOT handled here — they auto-execute on-chain when
+ * yes_count reaches `flat_support_threshold`, and the kg-indexer picks up
+ * the resulting PROPOSAL_EXECUTED event.
  */
 
 import {Effect} from "effect"
@@ -50,34 +60,69 @@ export const MAX_PROPOSAL_AGE = 7 * 24 * 60 * 60 // 7 days
 // ---------------------------------------------------------------------------
 
 /**
- * Finds slow-path proposals that are EXECUTABLE:
- * - Not yet executed (executed_at IS NULL)
- * - Slow voting mode
- * - Created in the past (guards against corrupt future timestamps)
- * - Created within MAX_PROPOSAL_AGE (7 days) — older proposals are likely stuck
- * - Voting period ended (with clock-skew buffer)
- * - Quorum reached (total votes >= quorum)
- * - Threshold reached: (RATIO_BASE - threshold) * yes > threshold * no
+ * Finds Slow-mode proposals that are EXECUTABLE right now. Two branches:
  *
- * The RATIO_BASE constant (10,000,000) matches the smart contract value.
- * Source: api/src/proposals/types.ts — RATIO_BASE = 10_000_000n
+ *   Slow-late (after voting ends):
+ *     - `now > end_time + CLOCK_SKEW_BUFFER`
+ *     - quorum met
+ *     - `(RATIO_BASE - partial) × yes > partial × no`
  *
- * ORDER BY created_at::bigint ASC for FIFO ordering. The created_at column
- * stores Unix timestamps as text, so ::bigint cast ensures numeric ordering.
+ *   Slow-early (voting still ongoing, NEW in V2 via GEO-514):
+ *     - `now <= end_time`
+ *     - `universal_percentage_support_threshold > 0` (feature enabled)
+ *     - space has indexed editors (`space_editor_counts.total_editors > 0`)
+ *     - `yes_count >= ceil(universal × total_editors / RATIO_BASE)`
+ *
+ * Both branches additionally require:
+ *   - not yet executed (`executed_at IS NULL`)
+ *   - within execution deadline: `now <= execute_by` when set, else within
+ *     MAX_PROPOSAL_AGE of `created_at` (fallback for proposals without a
+ *     deadline — prevents the executor from retrying permanently stuck
+ *     proposals forever).
+ *
+ * RATIO_BASE (10,000,000) matches the smart contract. Source of truth:
+ * api/src/proposals/types.ts.
+ *
+ * ORDER BY created_at::bigint ASC for FIFO ordering — created_at is text, so
+ * the cast ensures numeric comparison.
  */
-const DETECTION_SQL = `
-SELECT p.id, p.space_id AS "spaceId"
-FROM proposals p
-WHERE p.executed_at IS NULL
-  AND p.voting_mode = 'Slow'
-  AND p.created_at::bigint <= $1::bigint
-  AND $1::bigint - p.created_at::bigint < ${MAX_PROPOSAL_AGE}
-  AND $1::bigint > p.end_time + ${CLOCK_SKEW_BUFFER}
-  AND (p.yes_count + p.no_count + p.abstain_count) >= p.quorum
-  -- RATIO_BASE = 10,000,000 (protocol constant from api/src/proposals/types.ts)
-  AND (${RATIO_BASE} - p.threshold::numeric) * p.yes_count::numeric
-      > p.threshold::numeric * p.no_count::numeric
-ORDER BY p.created_at::bigint ASC
+export const DETECTION_SQL = `
+SELECT pc.id, pc.space_id AS "spaceId"
+FROM proposals_current pc
+WHERE pc.executed_at IS NULL
+  AND pc.voting_mode = 'Slow'
+  AND pc.created_at::bigint <= $1::bigint
+  AND (
+    (pc.execute_by IS NOT NULL AND $1::bigint <= pc.execute_by)
+    OR (pc.execute_by IS NULL AND $1::bigint - pc.created_at::bigint < ${MAX_PROPOSAL_AGE})
+  )
+  AND (
+    -- Slow-late: voting ended + quorum met + partial ratio
+    (
+      $1::bigint > pc.end_time + ${CLOCK_SKEW_BUFFER}
+      AND (pc.yes_count + pc.no_count + pc.abstain_count) >= pc.quorum
+      AND (${RATIO_BASE} - pc.partial_percentage_support_threshold::numeric) * pc.yes_count::numeric
+          > pc.partial_percentage_support_threshold::numeric * pc.no_count::numeric
+    )
+    -- Slow-early: voting still ongoing + yes_count meets universal × total_editors ceiling
+    OR (
+      $1::bigint <= pc.end_time
+      AND pc.universal_percentage_support_threshold > 0
+      AND COALESCE(
+        (SELECT sec.total_editors FROM space_editor_counts sec WHERE sec.space_id = pc.space_id),
+        0
+      ) > 0
+      AND pc.yes_count::numeric >= CEIL(
+        pc.universal_percentage_support_threshold::numeric
+        * COALESCE(
+          (SELECT sec.total_editors FROM space_editor_counts sec WHERE sec.space_id = pc.space_id),
+          0
+        )::numeric
+        / ${RATIO_BASE}::numeric
+      )
+    )
+  )
+ORDER BY pc.created_at::bigint ASC
 `
 
 // ---------------------------------------------------------------------------

--- a/proposal-executor/tests/detect.test.ts
+++ b/proposal-executor/tests/detect.test.ts
@@ -8,6 +8,7 @@
 
 import {describe, expect, test} from "bun:test"
 import {RATIO_BASE} from "../src/contracts.js"
+import {DETECTION_SQL, MAX_PROPOSAL_AGE} from "../src/detect.js"
 
 // ---------------------------------------------------------------------------
 // RATIO_BASE cross-validation
@@ -72,5 +73,70 @@ describe("Proposal type", () => {
 		}
 		expect(proposal.id).toContain("-") // UUID with dashes
 		expect(proposal.spaceId).toContain("-") // UUID with dashes
+	})
+})
+
+// ---------------------------------------------------------------------------
+// V2 detection SQL structure (GEO-485)
+//
+// These tests inspect the module-exported DETECTION_SQL string to verify it
+// reads from the post-GEO-481 schema shape. No DB is involved — just string
+// assertions.
+// ---------------------------------------------------------------------------
+
+describe("V2 detection SQL", () => {
+	test("reads from proposals_current, not the identity-only proposals table", () => {
+		expect(DETECTION_SQL).toMatch(/FROM\s+proposals_current/)
+		// Guard against the legacy shape coming back: `FROM proposals p` with a
+		// `WHERE p.voting_mode …` clause would fail at runtime against 0057+.
+		expect(DETECTION_SQL).not.toMatch(/FROM\s+proposals\s+p\b/)
+	})
+
+	test("filters by voting_mode = 'Slow' (Fast-path auto-exec is handled by the indexer)", () => {
+		expect(DETECTION_SQL).toMatch(/voting_mode\s*=\s*'Slow'/)
+	})
+
+	test("uses partial_percentage_support_threshold in the slow-late ratio", () => {
+		// V1 used a single `threshold` column; V2 slow-late must use `partial`.
+		expect(DETECTION_SQL).toContain("partial_percentage_support_threshold")
+		// The ratio formula shape should still be (RATIO_BASE - partial) * yes > partial * no
+		expect(DETECTION_SQL).toMatch(
+			/\(\s*10000000\s*-\s*[a-z0-9_.]*partial_percentage_support_threshold::numeric\s*\)\s*\*\s*[a-z0-9_.]*yes_count::numeric\s*>\s*[a-z0-9_.]*partial_percentage_support_threshold::numeric\s*\*\s*[a-z0-9_.]*no_count::numeric/,
+		)
+	})
+
+	test("enforces executeBy deadline with MAX_PROPOSAL_AGE fallback for proposals with no deadline", () => {
+		expect(DETECTION_SQL).toContain("execute_by")
+		// `execute_by IS NOT NULL` → now <= execute_by
+		expect(DETECTION_SQL).toMatch(/execute_by\s+IS\s+NOT\s+NULL[\s\S]*<=\s*[a-z0-9_.]*execute_by/)
+		// `execute_by IS NULL` → fall back to MAX_PROPOSAL_AGE cap
+		expect(DETECTION_SQL).toMatch(/execute_by\s+IS\s+NULL/)
+		expect(DETECTION_SQL).toContain(String(MAX_PROPOSAL_AGE))
+	})
+
+	test("includes a slow-path early-execution branch using space_editor_counts", () => {
+		// Early-exec: voting still ongoing + universal threshold > 0 +
+		// yes_count >= ceil(universal × total_editors / RATIO_BASE)
+		expect(DETECTION_SQL).toContain("universal_percentage_support_threshold")
+		expect(DETECTION_SQL).toContain("space_editor_counts")
+		expect(DETECTION_SQL).toMatch(/CEIL|ceil/)
+	})
+
+	test("does not reference the legacy single-column threshold in any new comparison", () => {
+		// The legacy `threshold` column is retained on proposal_versions for
+		// backcompat, but V2 detection must use the per-mode field. Guard
+		// against a stale `p.threshold::numeric` comparison creeping back.
+		const threshold_compare_pattern = /[a-z0-9_.]*\bthreshold::numeric/g
+		const matches = DETECTION_SQL.match(threshold_compare_pattern) ?? []
+		// Any threshold compare must be a V2 field (partial/universal/flat),
+		// not the bare `threshold`.
+		for (const m of matches) {
+			expect(m).toMatch(/partial_percentage_support_threshold|universal_percentage_support_threshold|flat_support_threshold/)
+		}
+	})
+
+	test("preserves CLOCK_SKEW_BUFFER on the slow-late end_time check", () => {
+		// Slow-late path gates on: now > end_time + CLOCK_SKEW_BUFFER
+		expect(DETECTION_SQL).toMatch(/end_time\s*\+\s*60/)
 	})
 })


### PR DESCRIPTION
Closes [GEO-485](https://linear.app/defi-wonderland/issue/GEO-485).

## Summary

Rewrite `proposal-executor/src/detect.ts` for governance V2. The executor's detection SQL was broken against migration 0057+ because it selected columns dropped from `proposals` (`voting_mode`, `yes_count`, `threshold`, `end_time`, `executed_at`, `quorum`, etc.) — same class of bug that PR #156 fixed in the API. This PR unbreaks it and adds V2-specific detection logic.

## What changed

### `proposal-executor/src/detect.ts`

- **`FROM proposals_current pc`** (the view from GEO-481 that joins identity + current version). Unbreaks the query against 0057+.
- **Slow-late branch** uses `partial_percentage_support_threshold` in the ratio formula (replaces the legacy `threshold`). Keeps the 60s `CLOCK_SKEW_BUFFER` on the `end_time` check.
- **`execute_by` deadline enforcement** with `MAX_PROPOSAL_AGE` (7d) fallback for proposals without a deadline:
  ```sql
  (pc.execute_by IS NOT NULL AND $1::bigint <= pc.execute_by)
  OR (pc.execute_by IS NULL AND $1::bigint - pc.created_at::bigint < MAX_PROPOSAL_AGE)
  ```
- **Slow-path early-execution branch (NEW)** — uses `universal_percentage_support_threshold` and `space_editor_counts` (the view from GEO-514). Triggers when voting is still ongoing and `yes_count >= ceil(universal × total_editors / RATIO_BASE)`. Guarded by `universal > 0` AND `total_editors > 0` so spaces without indexed editors or without early-exec configured fall through safely.
- `DETECTION_SQL` exported (module-private previously) so structural tests can inspect the query string.
- Docstring updated to describe the V2 decision tree and explain why Fast-path is out of scope.

### `proposal-executor/tests/detect.test.ts`

6 new structural assertions on `DETECTION_SQL`:
- reads from `proposals_current`, not a raw `proposals p` alias
- filters `voting_mode = 'Slow'`
- slow-late ratio uses `partial_percentage_support_threshold` (not legacy `threshold`)
- `execute_by` deadline clause with `MAX_PROPOSAL_AGE` fallback for NULL
- slow-early branch references `universal_percentage_support_threshold` and `space_editor_counts` with `CEIL`
- no stale `threshold::numeric` comparison on the bare legacy column
- `CLOCK_SKEW_BUFFER = 60` preserved on the slow-late `end_time` check

## Scope — why Fast-path isn't here

The DAOSpace contract auto-executes Fast-path proposals inline when `yes_count >= flat_support_threshold` and does **not** emit a `PROPOSAL_EXECUTED` event. The kg-indexer infers Fast-path execution from vote tallies — see `kg-indexer/src/storage.rs:1475-1520` (the comment block explains the contract quirk; the SQL at 1491-1519 does the inline update on `proposal_versions.executed_at` using `flat_support_threshold` + the `execute_by` guard). So the executor correctly scopes to `voting_mode = 'Slow'` only.

## Verification

- `bun test tests/detect.test.ts` — 12/12 passing (6 new V2 + 6 pre-existing constants).
- `bun test` (full executor suite) — 54/54 passing.
- `bun run typecheck` — clean.

## Follow-up spotted during this PR

[GEO-531](https://linear.app/defi-wonderland/issue/GEO-531) — move `executed_at` from `proposal_versions` to `proposals` (identity). Every read/write site already treats it as identity-level via `current_version` joins. Low-risk cleanup, best done in the pre-prod window. Not blocking this PR.

## Related

- Depends on: #156 (GEO-483/484 — API V2 status + queries, merged into this branch's base)
- Uses: `space_editor_counts` view from GEO-514 (PR #154, merged)
- Follow-up: GEO-517 (E2E test for the V2 pipeline) will exercise the actual SQL against a real DB — this PR covers only structural tests.

## Test plan

- [x] `bun test` in `proposal-executor/` — all green
- [x] `bun run typecheck` — clean
- [ ] Manual (post-merge, staging): trigger a slow-path proposal that meets `partial` threshold after voting ends, confirm CronJob picks it up and calls `enter(PROPOSAL_EXECUTED)`.
- [ ] Manual (post-merge, staging): trigger a slow-path proposal that meets `universal × total_editors / RATIO_BASE` while voting is still active; confirm the executor picks it up via the slow-early branch.
- [ ] Manual: proposal with `execute_by` set and in the past — confirm executor does NOT pick it up.