### PR TITLE
fix(scoring-service): stream emit_all to prevent OOM in cron

### DIFF
--- a/scoring-service/cronjob/src/scoring_data_emitter/scoring_data_emitter.py
+++ b/scoring-service/cronjob/src/scoring_data_emitter/scoring_data_emitter.py
@@ -23,6 +23,7 @@ class ScoringDataEmitter:
         username: str | None = None,
         password: str | None = None,
         ssl_ca_pem: str | None = None,
+        emit_progress_every: int = 500,
     ):
         """Initialize the ScoringDataEmitter with Kafka configuration.
 
@@ -33,9 +34,12 @@ class ScoringDataEmitter:
             username: SASL username for authentication (optional).
             password: SASL password for authentication (optional).
             ssl_ca_pem: Custom CA certificate PEM content (optional).
+            emit_progress_every: Log an INFO progress line every N non-final
+                batches produced. Set high enough that small runs stay quiet.
         """
         self._topic = topic
         self._batch_size = batch_size
+        self._emit_progress_every = emit_progress_every
 
         # Build Kafka producer config
         config: dict[str, str | Callable[[str, bytes], bytes]] = {
@@ -108,12 +112,33 @@ class ScoringDataEmitter:
         items_in_current = 0
         batch_sequence = 0
 
+        non_final_flushed = 0
+        entities_flushed = 0
+        perspectives_flushed = 0
+        spaces_flushed = 0
+        n_entities = 0
+        n_perspectives = 0
+        n_spaces = 0
+
+        def flush_non_final(batch: HermesScoresBatch) -> None:
+            nonlocal non_final_flushed, entities_flushed, perspectives_flushed, spaces_flushed
+            entities_flushed += len(batch.entity_scores)
+            perspectives_flushed += len(batch.perspective_scores)
+            spaces_flushed += len(batch.space_scores)
+            self._produce_batch(batch, is_final=False)
+            non_final_flushed += 1
+            if non_final_flushed % self._emit_progress_every == 0:
+                logger.info(
+                    "Emit progress: %d batches produced (%d entities, %d perspectives, %d spaces so far)",
+                    non_final_flushed, entities_flushed, perspectives_flushed, spaces_flushed,
+                )
+
         def rotate_if_full() -> None:
             nonlocal pending, current, items_in_current, batch_sequence
             if items_in_current < self._batch_size:
                 return
             if pending is not None:
-                self._produce_batch(pending, is_final=False)
+                flush_non_final(pending)
             pending = current
             batch_sequence += 1
             current = self._new_batch(computed_at, batch_sequence)
@@ -126,6 +151,9 @@ class ScoringDataEmitter:
             s.score = entity.normalized_score
             s.updated_at = computed_at
             items_in_current += 1
+            n_entities += 1
+        if n_entities > 0:
+            logger.info("Finished emitting entity scores: %d items", n_entities)
 
         for entity in entities:
             for perspective in entity.perspectives:
@@ -136,6 +164,9 @@ class ScoringDataEmitter:
                 s.score = perspective.normalized_score
                 s.updated_at = computed_at
                 items_in_current += 1
+                n_perspectives += 1
+        if n_perspectives > 0:
+            logger.info("Finished emitting perspective scores: %d items", n_perspectives)
 
         for space in spaces:
             rotate_if_full()
@@ -144,13 +175,16 @@ class ScoringDataEmitter:
             s.score = space.space_score
             s.updated_at = computed_at
             items_in_current += 1
+            n_spaces += 1
+        if n_spaces > 0:
+            logger.info("Finished emitting space scores: %d items", n_spaces)
 
         # Terminal flush. rotate_if_full is called before each append, so
         # current always has items whenever we added anything at all.
         batches_produced = 0
         if items_in_current > 0:
             if pending is not None:
-                self._produce_batch(pending, is_final=False)
+                flush_non_final(pending)
             self._produce_batch(current, is_final=True)
             batches_produced = batch_sequence + 1
 

--- a/scoring-service/cronjob/src/scoring_data_emitter/scoring_data_emitter.py
+++ b/scoring-service/cronjob/src/scoring_data_emitter/scoring_data_emitter.py
@@ -36,7 +36,15 @@ class ScoringDataEmitter:
             ssl_ca_pem: Custom CA certificate PEM content (optional).
             emit_progress_every: Log an INFO progress line every N non-final
                 batches produced. Set high enough that small runs stay quiet.
+
+        Raises:
+            ValueError: If ``batch_size`` or ``emit_progress_every`` is < 1.
         """
+        if batch_size < 1:
+            raise ValueError("batch_size must be >= 1")
+        if emit_progress_every < 1:
+            raise ValueError("emit_progress_every must be >= 1")
+
         self._topic = topic
         self._batch_size = batch_size
         self._emit_progress_every = emit_progress_every

--- a/scoring-service/cronjob/src/scoring_data_emitter/scoring_data_emitter.py
+++ b/scoring-service/cronjob/src/scoring_data_emitter/scoring_data_emitter.py
@@ -7,7 +7,7 @@ from typing import Callable
 from confluent_kafka import Producer
 
 from src.algorithm.models import Entity, Space
-from src.pb import EntityScore, HermesScoresBatch, PerspectiveScore, SpaceScore
+from src.pb import HermesScoresBatch
 
 logger = logging.getLogger(__name__)
 
@@ -86,153 +86,97 @@ class ScoringDataEmitter:
     def emit_all(self, entities: list[Entity], spaces: list[Space]) -> None:
         """Emit all scores to Kafka in batches.
 
-        Scores are grouped into HermesScoresBatch messages respecting the
-        configured batch_size. Each batch includes entity scores, perspective
-        scores, and space scores.
+        Iterates entities (for global scores), then entity perspectives (for
+        local scores), then spaces — appending each item directly into a
+        HermesScoresBatch of up to batch_size items. No intermediate lists of
+        per-item protobufs are materialized, keeping peak memory bounded to
+        one in-flight batch plus the previous "pending" batch awaiting a
+        final-flag decision.
 
         Args:
             entities: List of Entity objects with calculated normalized_score and perspectives.
             spaces: List of Space objects with calculated space_score.
         """
         computed_at = int(time.time())
-
-        # Prepare all scores
         t0 = time.time()
-        entity_scores = self._prepare_entity_scores(entities, computed_at)
-        perspective_scores = self._prepare_perspective_scores(entities, computed_at)
-        space_scores = self._prepare_space_scores(spaces, computed_at)
 
-        logger.info(
-            f"Preparing to emit scores: {len(entity_scores)} entities, "
-            f"{len(perspective_scores)} perspectives, {len(space_scores)} spaces"
-        )
-
-        # Calculate total batches needed
-        total_items = len(entity_scores) + len(perspective_scores) + len(space_scores)
-        total_batches = max(1, (total_items + self._batch_size - 1) // self._batch_size)
-
-        # Emit in batches
+        # "pending" holds the last fully-filled batch: we delay producing it
+        # until we know whether more items follow, so we can set is_final=True
+        # on the actual last batch even when it happens to be exactly full.
+        pending: HermesScoresBatch | None = None
+        current = self._new_batch(computed_at, batch_sequence=0)
+        items_in_current = 0
         batch_sequence = 0
-        entity_idx = 0
-        perspective_idx = 0
-        space_idx = 0
 
-        while entity_idx < len(entity_scores) or \
-              perspective_idx < len(perspective_scores) or \
-              space_idx < len(space_scores):
-
-            batch = HermesScoresBatch()
-            batch.computed_at = computed_at
-            batch.batch_sequence = batch_sequence
-
-            items_in_batch = 0
-
-            # Add entity scores to batch
-            while entity_idx < len(entity_scores) and items_in_batch < self._batch_size:
-                score = batch.entity_scores.add()
-                src = entity_scores[entity_idx]
-                score.entity_id = src.entity_id
-                score.score = src.score
-                score.updated_at = src.updated_at
-                entity_idx += 1
-                items_in_batch += 1
-
-            # Add perspective scores to batch
-            while perspective_idx < len(perspective_scores) and items_in_batch < self._batch_size:
-                score = batch.perspective_scores.add()
-                src = perspective_scores[perspective_idx]
-                score.entity_id = src.entity_id
-                score.space_id = src.space_id
-                score.score = src.score
-                score.updated_at = src.updated_at
-                perspective_idx += 1
-                items_in_batch += 1
-
-            # Add space scores to batch
-            while space_idx < len(space_scores) and items_in_batch < self._batch_size:
-                score = batch.space_scores.add()
-                src = space_scores[space_idx]
-                score.space_id = src.space_id
-                score.score = src.score
-                score.updated_at = src.updated_at
-                space_idx += 1
-                items_in_batch += 1
-
-            # Mark final batch
-            is_final = (
-                entity_idx >= len(entity_scores) and
-                perspective_idx >= len(perspective_scores) and
-                space_idx >= len(space_scores)
-            )
-            batch.is_final = is_final
-
-            # Serialize and produce
-            message = batch.SerializeToString()
-            self._producer.produce(
-                self._topic,
-                value=message,
-                callback=self._delivery_callback,
-            )
-
-            # Poll to handle delivery callbacks
-            self._producer.poll(0)
-
+        def rotate_if_full() -> None:
+            nonlocal pending, current, items_in_current, batch_sequence
+            if items_in_current < self._batch_size:
+                return
+            if pending is not None:
+                self._produce_batch(pending, is_final=False)
+            pending = current
             batch_sequence += 1
+            current = self._new_batch(computed_at, batch_sequence)
+            items_in_current = 0
 
-            logger.debug(
-                f"Produced batch {batch_sequence}/{total_batches} "
-                f"({len(batch.entity_scores)} entities, "
-                f"{len(batch.perspective_scores)} perspectives, "
-                f"{len(batch.space_scores)} spaces, "
-                f"is_final={is_final})"
-            )
+        for entity in entities:
+            rotate_if_full()
+            s = current.entity_scores.add()
+            s.entity_id = self._uuid_str_to_bytes(entity.id)
+            s.score = entity.normalized_score
+            s.updated_at = computed_at
+            items_in_current += 1
+
+        for entity in entities:
+            for perspective in entity.perspectives:
+                rotate_if_full()
+                s = current.perspective_scores.add()
+                s.entity_id = self._uuid_str_to_bytes(perspective.entity_id)
+                s.space_id = self._uuid_str_to_bytes(perspective.space_id)
+                s.score = perspective.normalized_score
+                s.updated_at = computed_at
+                items_in_current += 1
+
+        for space in spaces:
+            rotate_if_full()
+            s = current.space_scores.add()
+            s.space_id = self._uuid_str_to_bytes(space.id)
+            s.score = space.space_score
+            s.updated_at = computed_at
+            items_in_current += 1
+
+        # Terminal flush. rotate_if_full is called before each append, so
+        # current always has items whenever we added anything at all.
+        batches_produced = 0
+        if items_in_current > 0:
+            if pending is not None:
+                self._produce_batch(pending, is_final=False)
+            self._produce_batch(current, is_final=True)
+            batches_produced = batch_sequence + 1
 
         elapsed = time.time() - t0
         logger.info(
             "Produced %d batches to topic '%s' in %.1fs",
-            batch_sequence, self._topic, elapsed,
+            batches_produced, self._topic, elapsed,
         )
 
-    def _prepare_entity_scores(
-        self, entities: list[Entity], updated_at: int
-    ) -> list[EntityScore]:
-        """Prepare EntityScore messages from entities."""
-        scores = []
-        for entity in entities:
-            score = EntityScore()
-            score.entity_id = self._uuid_str_to_bytes(entity.id)
-            score.score = entity.normalized_score
-            score.updated_at = updated_at
-            scores.append(score)
-        return scores
+    def _new_batch(self, computed_at: int, batch_sequence: int) -> HermesScoresBatch:
+        """Create an empty HermesScoresBatch with header fields set."""
+        batch = HermesScoresBatch()
+        batch.computed_at = computed_at
+        batch.batch_sequence = batch_sequence
+        return batch
 
-    def _prepare_perspective_scores(
-        self, entities: list[Entity], updated_at: int
-    ) -> list[PerspectiveScore]:
-        """Prepare PerspectiveScore messages from entity perspectives."""
-        scores = []
-        for entity in entities:
-            for perspective in entity.perspectives:
-                score = PerspectiveScore()
-                score.entity_id = self._uuid_str_to_bytes(perspective.entity_id)
-                score.space_id = self._uuid_str_to_bytes(perspective.space_id)
-                score.score = perspective.normalized_score
-                score.updated_at = updated_at
-                scores.append(score)
-        return scores
-
-    def _prepare_space_scores(
-        self, spaces: list[Space], updated_at: int
-    ) -> list[SpaceScore]:
-        """Prepare SpaceScore messages from spaces."""
-        scores = []
-        for space in spaces:
-            score = SpaceScore()
-            score.space_id = self._uuid_str_to_bytes(space.id)
-            score.score = space.space_score
-            score.updated_at = updated_at
-            scores.append(score)
-        return scores
+    def _produce_batch(self, batch: HermesScoresBatch, is_final: bool) -> None:
+        """Serialize a batch and hand it to the Kafka producer."""
+        batch.is_final = is_final
+        message = batch.SerializeToString()
+        self._producer.produce(
+            self._topic,
+            value=message,
+            callback=self._delivery_callback,
+        )
+        self._producer.poll(0)
 
     def flush(self, timeout: float = 30.0) -> int:
         """Flush pending messages and wait for delivery.

--- a/scoring-service/cronjob/tests/test_scoring_data_emitter.py
+++ b/scoring-service/cronjob/tests/test_scoring_data_emitter.py
@@ -3,6 +3,8 @@
 from datetime import datetime
 from unittest.mock import MagicMock, call, patch
 
+import logging
+
 import pytest
 
 from src.algorithm.models import Entity, Perspective, Space
@@ -336,6 +338,81 @@ class TestEmittedContent:
         first_batch = HermesScoresBatch()
         first_batch.ParseFromString(first_message)
         assert first_batch.is_final is False
+
+
+class TestEmitProgressLogging:
+    """Verify the emit phase emits transition and periodic progress logs.
+
+    Rationale: the emit phase in production handles ~5M items and previously
+    logged nothing between "Emitting scores to Kafka" and "Scores emitted to
+    Kafka successfully" — when it OOMed mid-phase there was no way to tell
+    which item kind was the culprit.
+    """
+
+    def test_transition_log_fires_after_each_non_empty_kind(self, caplog, mock_producer, sample_entities, sample_spaces):
+        emitter = ScoringDataEmitter(broker="localhost:9092", topic="test.scores", batch_size=100)
+        with caplog.at_level(logging.INFO, logger="src.scoring_data_emitter.scoring_data_emitter"):
+            emitter.emit_all(sample_entities, sample_spaces)
+
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("Finished emitting entity scores" in m and "2 items" in m for m in messages), messages
+        assert any("Finished emitting perspective scores" in m and "3 items" in m for m in messages), messages
+        assert any("Finished emitting space scores" in m and "2 items" in m for m in messages), messages
+
+    def test_transition_log_is_skipped_for_empty_kind(self, caplog, mock_producer):
+        """Don't emit noise lines for kinds that had no items."""
+        emitter = ScoringDataEmitter(broker="localhost:9092", topic="test.scores", batch_size=100)
+        now = datetime.now()
+        # Only entities, no perspectives, no spaces
+        entities = [Entity(id=f"{i:032x}", created_at=now) for i in range(3)]
+        for e in entities:
+            e.normalized_score = 0.5
+            e.perspectives = []
+
+        with caplog.at_level(logging.INFO, logger="src.scoring_data_emitter.scoring_data_emitter"):
+            emitter.emit_all(entities, [])
+
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("Finished emitting entity scores" in m for m in messages)
+        assert not any("Finished emitting perspective scores" in m for m in messages)
+        assert not any("Finished emitting space scores" in m for m in messages)
+
+    def test_progress_log_fires_at_configured_interval(self, caplog, mock_producer):
+        """With emit_progress_every=2 and 5 batches, we expect 2 progress lines
+        (after the 2nd and 4th non-final produce). The final batch is not
+        counted — it's covered by the summary log."""
+        emitter = ScoringDataEmitter(
+            broker="localhost:9092",
+            topic="test.scores",
+            batch_size=2,
+            emit_progress_every=2,
+        )
+        now = datetime.now()
+        # 9 items / batch_size=2 → 5 batches (4 non-final + 1 final)
+        entities = [Entity(id=f"{i:032x}", created_at=now) for i in range(9)]
+        for e in entities:
+            e.normalized_score = 0.5
+            e.perspectives = []
+
+        with caplog.at_level(logging.INFO, logger="src.scoring_data_emitter.scoring_data_emitter"):
+            emitter.emit_all(entities, [])
+
+        progress_messages = [r.getMessage() for r in caplog.records if "Emit progress" in r.getMessage()]
+        assert len(progress_messages) == 2, progress_messages
+        # First progress log fires after 2 non-final batches (4 entities emitted in flushed batches)
+        assert "4 entities" in progress_messages[0]
+        # Second fires after 4 non-final batches (8 entities in flushed batches)
+        assert "8 entities" in progress_messages[1]
+
+    def test_progress_log_silent_for_small_runs(self, caplog, mock_producer, sample_entities, sample_spaces):
+        """With default interval of 500 and only a handful of items, no progress
+        logs should fire — the transition and summary logs are enough."""
+        emitter = ScoringDataEmitter(broker="localhost:9092", topic="test.scores", batch_size=100)
+        with caplog.at_level(logging.INFO, logger="src.scoring_data_emitter.scoring_data_emitter"):
+            emitter.emit_all(sample_entities, sample_spaces)
+
+        messages = [r.getMessage() for r in caplog.records]
+        assert not any("Emit progress" in m for m in messages)
 
 
 class TestDeliveryCallback:

--- a/scoring-service/cronjob/tests/test_scoring_data_emitter.py
+++ b/scoring-service/cronjob/tests/test_scoring_data_emitter.py
@@ -137,67 +137,6 @@ class TestUuidConversion:
         assert result == bytes.fromhex("22222222222222222222222222222222")
 
 
-class TestPrepareScores:
-    """Tests for score preparation methods."""
-
-    def test_prepare_entity_scores(self, emitter, sample_entities):
-        """Test EntityScore preparation."""
-        updated_at = 1704067200
-        scores = emitter._prepare_entity_scores(sample_entities, updated_at)
-
-        assert len(scores) == 2
-
-        # First entity
-        assert scores[0].entity_id == bytes.fromhex("11111111111111111111111111111111")
-        assert scores[0].score == 0.85
-        assert scores[0].updated_at == updated_at
-
-        # Second entity
-        assert scores[1].entity_id == bytes.fromhex("33333333333333333333333333333333")
-        assert scores[1].score == 0.65
-
-    def test_prepare_perspective_scores(self, emitter, sample_entities):
-        """Test PerspectiveScore preparation."""
-        updated_at = 1704067200
-        scores = emitter._prepare_perspective_scores(sample_entities, updated_at)
-
-        # 1 perspective from entity1 + 2 perspectives from entity2
-        assert len(scores) == 3
-
-        # First perspective
-        assert scores[0].entity_id == bytes.fromhex("11111111111111111111111111111111")
-        assert scores[0].space_id == bytes.fromhex("22222222222222222222222222222222")
-        assert scores[0].score == 0.9
-
-        # Second perspective (from entity2)
-        assert scores[1].entity_id == bytes.fromhex("33333333333333333333333333333333")
-        assert scores[1].space_id == bytes.fromhex("22222222222222222222222222222222")
-        assert scores[1].score == 0.7
-
-    def test_prepare_space_scores(self, emitter, sample_spaces):
-        """Test SpaceScore preparation."""
-        updated_at = 1704067200
-        scores = emitter._prepare_space_scores(sample_spaces, updated_at)
-
-        assert len(scores) == 2
-
-        assert scores[0].space_id == bytes.fromhex("22222222222222222222222222222222")
-        assert scores[0].score == 0.8
-
-        assert scores[1].space_id == bytes.fromhex("44444444444444444444444444444444")
-        assert scores[1].score == 0.64
-
-    def test_prepare_empty_entities(self, emitter):
-        """Test preparation with empty entity list."""
-        scores = emitter._prepare_entity_scores([], 1704067200)
-        assert scores == []
-
-    def test_prepare_empty_spaces(self, emitter):
-        """Test preparation with empty space list."""
-        scores = emitter._prepare_space_scores([], 1704067200)
-        assert scores == []
-
-
 class TestEmitAll:
     """Tests for emit_all method."""
 
@@ -281,6 +220,123 @@ class TestEmitAll:
         first_batch = HermesScoresBatch()
         first_batch.ParseFromString(first_message)
         assert first_batch.is_final is False
+
+class TestEmittedContent:
+    """Verify the bytes we produce to Kafka via the public emit_all interface.
+
+    These tests deserialize the serialized protobuf payloads and assert the
+    field values — the same coverage TestPrepareScores used to provide, but
+    through the public interface so the tests survive internal refactors.
+    """
+
+    def _deserialize_batches(self, mock_producer):
+        from src.pb import HermesScoresBatch
+
+        batches = []
+        for call_args in mock_producer.produce.call_args_list:
+            batch = HermesScoresBatch()
+            batch.ParseFromString(call_args.kwargs["value"])
+            batches.append(batch)
+        return batches
+
+    def test_emit_all_encodes_entity_scores(self, emitter, mock_producer, sample_entities, sample_spaces):
+        emitter.emit_all(sample_entities, sample_spaces)
+        batches = self._deserialize_batches(mock_producer)
+
+        entity_scores = [s for b in batches for s in b.entity_scores]
+        assert len(entity_scores) == 2
+
+        assert entity_scores[0].entity_id == bytes.fromhex("11111111111111111111111111111111")
+        assert entity_scores[0].score == pytest.approx(0.85)
+        assert entity_scores[0].updated_at > 0
+
+        assert entity_scores[1].entity_id == bytes.fromhex("33333333333333333333333333333333")
+        assert entity_scores[1].score == pytest.approx(0.65)
+
+    def test_emit_all_encodes_perspective_scores(self, emitter, mock_producer, sample_entities, sample_spaces):
+        emitter.emit_all(sample_entities, sample_spaces)
+        batches = self._deserialize_batches(mock_producer)
+
+        persp_scores = [s for b in batches for s in b.perspective_scores]
+        assert len(persp_scores) == 3
+
+        assert persp_scores[0].entity_id == bytes.fromhex("11111111111111111111111111111111")
+        assert persp_scores[0].space_id == bytes.fromhex("22222222222222222222222222222222")
+        assert persp_scores[0].score == pytest.approx(0.9)
+
+        assert persp_scores[1].entity_id == bytes.fromhex("33333333333333333333333333333333")
+        assert persp_scores[1].space_id == bytes.fromhex("22222222222222222222222222222222")
+        assert persp_scores[1].score == pytest.approx(0.7)
+
+        assert persp_scores[2].space_id == bytes.fromhex("44444444444444444444444444444444")
+        assert persp_scores[2].score == pytest.approx(0.6)
+
+    def test_emit_all_encodes_space_scores(self, emitter, mock_producer, sample_entities, sample_spaces):
+        emitter.emit_all(sample_entities, sample_spaces)
+        batches = self._deserialize_batches(mock_producer)
+
+        space_scores = [s for b in batches for s in b.space_scores]
+        assert len(space_scores) == 2
+
+        assert space_scores[0].space_id == bytes.fromhex("22222222222222222222222222222222")
+        assert space_scores[0].score == pytest.approx(0.8)
+
+        assert space_scores[1].space_id == bytes.fromhex("44444444444444444444444444444444")
+        assert space_scores[1].score == pytest.approx(0.64)
+
+    def test_emit_all_empty_inputs_produces_nothing(self, emitter, mock_producer):
+        emitter.emit_all([], [])
+        assert mock_producer.produce.call_count == 0
+
+    def test_emit_all_sequence_is_monotonic(self, mock_producer):
+        from src.pb import HermesScoresBatch
+
+        emitter = ScoringDataEmitter(broker="localhost:9092", topic="test.scores", batch_size=2)
+        now = datetime.now()
+        entities = [Entity(id=f"{i:032x}", created_at=now) for i in range(5)]
+        for e in entities:
+            e.normalized_score = 0.5
+            e.perspectives = []
+
+        emitter.emit_all(entities, [])
+
+        sequences = []
+        computed_ats = set()
+        for call_args in mock_producer.produce.call_args_list:
+            batch = HermesScoresBatch()
+            batch.ParseFromString(call_args.kwargs["value"])
+            sequences.append(batch.batch_sequence)
+            computed_ats.add(batch.computed_at)
+
+        assert sequences == list(range(len(sequences)))
+        assert len(computed_ats) == 1  # same computed_at across all batches
+
+    def test_emit_all_last_batch_exactly_full_is_final(self, mock_producer):
+        """Edge case: when the last item exactly fills a batch, that batch must be is_final=True."""
+        from src.pb import HermesScoresBatch
+
+        emitter = ScoringDataEmitter(broker="localhost:9092", topic="test.scores", batch_size=2)
+        now = datetime.now()
+        # Exactly 4 entities with batch_size=2 -> 2 batches, second exactly full
+        entities = [Entity(id=f"{i:032x}", created_at=now) for i in range(4)]
+        for e in entities:
+            e.normalized_score = 0.5
+            e.perspectives = []
+
+        emitter.emit_all(entities, [])
+
+        assert mock_producer.produce.call_count == 2
+        last_message = mock_producer.produce.call_args_list[-1].kwargs["value"]
+        last_batch = HermesScoresBatch()
+        last_batch.ParseFromString(last_message)
+        assert last_batch.is_final is True
+        assert len(last_batch.entity_scores) == 2  # exactly full
+
+        first_message = mock_producer.produce.call_args_list[0].kwargs["value"]
+        first_batch = HermesScoresBatch()
+        first_batch.ParseFromString(first_message)
+        assert first_batch.is_final is False
+
 
 class TestDeliveryCallback:
     """Tests for delivery callback handling."""

--- a/scoring-service/cronjob/tests/test_scoring_data_emitter.py
+++ b/scoring-service/cronjob/tests/test_scoring_data_emitter.py
@@ -119,6 +119,30 @@ class TestScoringDataEmitterInit:
             assert config["sasl.password"] == "secret"
             assert "-----BEGIN CERTIFICATE-----" in config["ssl.ca.pem"]
 
+    @pytest.mark.parametrize("bad_batch_size", [0, -1])
+    def test_init_rejects_non_positive_batch_size(self, bad_batch_size):
+        """batch_size <= 0 must raise ValueError, not silently produce empty batches."""
+        with patch("src.scoring_data_emitter.scoring_data_emitter.Producer"):
+            with pytest.raises(ValueError, match="batch_size must be >= 1"):
+                ScoringDataEmitter(
+                    broker="localhost:9092",
+                    topic="test.scores",
+                    batch_size=bad_batch_size,
+                )
+
+    @pytest.mark.parametrize("bad_interval", [0, -1])
+    def test_init_rejects_non_positive_emit_progress_every(self, bad_interval):
+        """emit_progress_every <= 0 must raise ValueError to avoid ZeroDivisionError in emit_all."""
+        with patch("src.scoring_data_emitter.scoring_data_emitter.Producer"):
+            with pytest.raises(ValueError, match="emit_progress_every must be >= 1"):
+                ScoringDataEmitter(
+                    broker="localhost:9092",
+                    topic="test.scores",
+                    batch_size=100,
+                    emit_progress_every=bad_interval,
+                )
+
+
 class TestUuidConversion:
     """Tests for UUID string to bytes conversion."""
 


### PR DESCRIPTION
## Summary
- Stream entities, perspectives, and spaces directly into `HermesScoresBatch` in `ScoringDataEmitter.emit_all` instead of materializing three full lists of per-item protobuf messages upfront (~4.8M `EntityScore` + ~288K `PerspectiveScore` objects). Peak Python-heap allocation in the emit phase drops from ~800MB–1GB to one in-flight batch plus one "pending" batch — enough to fit the cron job under the existing 4Gi limit.
- Preserves wire behavior: same within-batch ordering (entities → perspectives → spaces), `batch_size`, `batch_sequence` monotonicity, single `computed_at` per run, and `is_final=True` on the last batch (with a one-batch "pending" buffer to correctly handle the exactly-full-final-batch edge case).
- Adds transition markers between item kinds (`Finished emitting entity scores: N items`) and a periodic `Emit progress:` log every 500 non-final flushes — previously there were zero logs between `Emitting scores to Kafka` and the success line, making it impossible to localize where the OOM was happening.

## Context
The cron was hitting the 4Gi memory ceiling during the Kafka emit phase and getting OOMKilled; Kubernetes silently retried via \`restartPolicy: OnFailure\` ~6–7 times per trigger (~7 hours of wasted compute per day) for multiple days. Postgres writes were completing fine — only Kafka was broken. Evidence in Sentry: 6+ back-to-back \`Starting scoring pipeline\` runs in 24h, \`Emitting scores to Kafka\` logged 6 times, \`Scores emitted to Kafka successfully\` logged **zero** times, and a memory-monitor alert at 92% (3754MB / 4096MB) right after emit began.

Epic: [GEO-508](https://linear.app/defi-wonderland/issue/GEO-508/scoring-algorithm-running-out-of-memory) — sub-issues [GEO-533](https://linear.app/defi-wonderland/issue/GEO-533) (refactor) and [GEO-534](https://linear.app/defi-wonderland/issue/GEO-534) (progress logging) are addressed in this PR.

## Test plan
- [x] \`just test\` passes in \`scoring-service/cronjob/\` (80/80 tests, 100% coverage on the emitter)
- [ ] Staging deploy (auto-triggered on merge to \`dev\`): trigger manually and verify:
  - [ ] Pod exits 0, no \`OOMKilled\` in \`kubectl describe pod\`
  - [ ] Logs show \`Scores emitted to Kafka successfully: <N> messages, 0 errors\` (line never seen in broken runs)
  - [ ] New transition + \`Emit progress:\` logs appear
  - [ ] Peak RSS under ~85% of 4Gi (check \`kubectl top pod\`)
  - [ ] No \`BackoffLimitExceeded\` restart chain
  - [ ] No Sentry \`Memory usage critical\` alerts
- [ ] Downstream spot-check: search-indexer picks up the scores batch and updates OpenSearch for a known entity

Once staging is green this gets promoted to \`main\` for production rollout (tracked in [GEO-536](https://linear.app/defi-wonderland/issue/GEO-536)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)