### PR TITLE
fix(api): handle entity typeIds overlaps, contains filters

### DIFF
--- a/api/src/kg/__tests__/entitySpaceFilterPlugin.test.ts
+++ b/api/src/kg/__tests__/entitySpaceFilterPlugin.test.ts
@@ -15,6 +15,26 @@ async function executeGraphQL(query: string, variables?: Record<string, unknown>
 	return response.json()
 }
 
+/**
+ * Read the cumulative count of sequential scans Postgres has run against
+ * a table since startup. Compare before/after a query to detect whether
+ * the query forced a full scan — a useful assertion for filter plugins
+ * that must route through an indexed path.
+ *
+ * Note: the counter is per-table and increments once per executed Seq
+ * Scan node. If the test DB has concurrent background activity that
+ * happens to scan `entities`, the delta could be >0 for reasons outside
+ * the query under test — in that case, loosen to `<= 1` (the bug
+ * increments by exactly 1 per offending call).
+ */
+async function getSeqScanCount(pool: Pool, table: string): Promise<number> {
+	const r = await pool.query(
+		"SELECT seq_scan FROM pg_stat_user_tables WHERE schemaname = 'public' AND relname = $1",
+		[table],
+	)
+	return Number(r.rows[0]?.seq_scan ?? 0)
+}
+
 describe("EntitySpaceFilterPlugin", () => {
 	let pool: Pool
 	let testSpaceId: string | null = null
@@ -447,6 +467,128 @@ describe("EntitySpaceFilterPlugin", () => {
 			for (const entity of result.data.entities) {
 				expect(entity.typeIds).toEqual([])
 			}
+		})
+
+		// --------------------------------------------------------------------
+		// `overlaps` and `contains` — array-set operators on the typeIds
+		// computed column. Without the custom plugin handler, PostGraphile
+		// falls back to `entities_type_ids(e) && $1` (or `@> $1`), which
+		// forces a seq scan over the entities table and calls the computed
+		// function per row — observed as nginx 504 in prod (PR #635).
+		// These tests verify both:
+		//   (1) correctness — overlaps is equivalent to `in`, contains is AND
+		//   (2) plan shape — no new seq_scan on entities (plugin routes
+		//       through the indexed EXISTS path on relations_to_entity_id_idx)
+		// --------------------------------------------------------------------
+
+		it("should filter with 'overlaps' operator (equivalent to 'in' for type arrays)", async () => {
+			if (!testTypeId) {
+				console.log("Skipping test: no type with entities found")
+				return
+			}
+
+			const result = await executeGraphQL(
+				`
+				query TestTypeFilter($typeIds: [UUID!]!) {
+					entities(typeIds: { overlaps: $typeIds }, first: 5) {
+						id
+						typeIds
+					}
+				}
+			`,
+				{typeIds: [testTypeId]},
+			)
+
+			expect(result.errors).toBeUndefined()
+			expect(result.data.entities).toBeDefined()
+
+			for (const entity of result.data.entities) {
+				expect(entity.typeIds).toContain(testTypeId)
+			}
+		})
+
+		it("should filter with 'contains' operator (requires all specified types)", async () => {
+			if (!testTypeId) {
+				console.log("Skipping test: no type with entities found")
+				return
+			}
+
+			// Single-type `contains` — every returned entity must have that type.
+			const result = await executeGraphQL(
+				`
+				query TestTypeFilter($typeIds: [UUID!]!) {
+					entities(typeIds: { contains: $typeIds }, first: 5) {
+						id
+						typeIds
+					}
+				}
+			`,
+				{typeIds: [testTypeId]},
+			)
+
+			expect(result.errors).toBeUndefined()
+			expect(result.data.entities).toBeDefined()
+
+			for (const entity of result.data.entities) {
+				expect(entity.typeIds).toContain(testTypeId)
+			}
+		})
+
+		it("'overlaps' filter does not trigger a sequential scan on entities", async () => {
+			// The bug we're fixing: without the custom plugin case, the generated
+			// SQL is `entities_type_ids(e) && $1`, which forces `Seq Scan on
+			// entities`. pg_stat_user_tables.seq_scan increments by 1 per full
+			// sequential scan executed against the table. If the fix is working,
+			// the counter should not move for this query.
+			if (!testTypeId) {
+				console.log("Skipping test: no type with entities found")
+				return
+			}
+
+			const before = await getSeqScanCount(pool, "entities")
+			const result = await executeGraphQL(
+				`
+				query TestTypeFilter($typeIds: [UUID!]!) {
+					entities(typeIds: { overlaps: $typeIds }, first: 5) {
+						id
+						typeIds
+					}
+				}
+			`,
+				{typeIds: [testTypeId]},
+			)
+			const after = await getSeqScanCount(pool, "entities")
+
+			expect(result.errors).toBeUndefined()
+			// Tightest assertion: no seq_scan at all. If this ever gets flaky
+			// because of an unrelated concurrent workload, loosen to
+			// `expect(after - before).toBeLessThanOrEqual(1)` — still catches
+			// the bug, which increments by at least 1 per test call.
+			expect(after - before).toBe(0)
+		})
+
+		it("'contains' filter does not trigger a sequential scan on entities", async () => {
+			if (!testTypeId) {
+				console.log("Skipping test: no type with entities found")
+				return
+			}
+
+			const before = await getSeqScanCount(pool, "entities")
+			const result = await executeGraphQL(
+				`
+				query TestTypeFilter($typeIds: [UUID!]!) {
+					entities(typeIds: { contains: $typeIds }, first: 5) {
+						id
+						typeIds
+					}
+				}
+			`,
+				{typeIds: [testTypeId]},
+			)
+			const after = await getSeqScanCount(pool, "entities")
+
+			expect(result.errors).toBeUndefined()
+			expect(after - before).toBe(0)
 		})
 	})
 

--- a/api/src/kg/entitySpaceFilterPlugin.ts
+++ b/api/src/kg/entitySpaceFilterPlugin.ts
@@ -237,20 +237,14 @@ export const EntitySpaceFilterPlugin = (builder: any) => {
 					if (typeIds.notIn && typeIds.notIn.length > 0) {
 						queryBuilder.where(sql.fragment`NOT ${buildMultiTypeCondition(sql, tableAlias, typeIds.notIn)}`)
 					}
-					// `overlaps` on a uuid[] column is the array-overlap operator (`&&`).
-					// Semantically equivalent to `in` for entity types: "entity has at
-					// least one of these types". Without this case, PostGraphile falls
-					// back to the computed-column filter `entities_type_ids(e) && $1`,
-					// which forces a seq scan over all entities and calls the function
-					// per row — catastrophic (seen ≥60 s, 504 at nginx). Use the same
-					// EXISTS pattern as `in` so PostgreSQL uses `relations_to_entity_id_idx`.
+					// `overlaps`: semantically equivalent to `in` for type arrays
+					// ("entity has at least one of these"). Custom-handled so we
+					// don't fall back to the seq-scanning computed-column filter.
 					if (typeIds.overlaps && typeIds.overlaps.length > 0) {
 						queryBuilder.where(buildMultiTypeCondition(sql, tableAlias, typeIds.overlaps))
 					}
-					// `contains` on a uuid[] column is `@>` — "entity's type array
-					// contains ALL of these". For entity types, that's AND-semantics
-					// across the list: each supplied type must be present via its own
-					// EXISTS. Same per-row-seq-scan risk without a custom handler.
+					// `contains`: "entity has ALL of these types" — AND of per-type
+					// EXISTS predicates, same indexed path as `is`.
 					if (typeIds.contains && typeIds.contains.length > 0) {
 						for (const t of typeIds.contains) {
 							queryBuilder.where(buildSingleTypeCondition(sql, tableAlias, t))

--- a/api/src/kg/entitySpaceFilterPlugin.ts
+++ b/api/src/kg/entitySpaceFilterPlugin.ts
@@ -237,6 +237,25 @@ export const EntitySpaceFilterPlugin = (builder: any) => {
 					if (typeIds.notIn && typeIds.notIn.length > 0) {
 						queryBuilder.where(sql.fragment`NOT ${buildMultiTypeCondition(sql, tableAlias, typeIds.notIn)}`)
 					}
+					// `overlaps` on a uuid[] column is the array-overlap operator (`&&`).
+					// Semantically equivalent to `in` for entity types: "entity has at
+					// least one of these types". Without this case, PostGraphile falls
+					// back to the computed-column filter `entities_type_ids(e) && $1`,
+					// which forces a seq scan over all entities and calls the function
+					// per row — catastrophic (seen ≥60 s, 504 at nginx). Use the same
+					// EXISTS pattern as `in` so PostgreSQL uses `relations_to_entity_id_idx`.
+					if (typeIds.overlaps && typeIds.overlaps.length > 0) {
+						queryBuilder.where(buildMultiTypeCondition(sql, tableAlias, typeIds.overlaps))
+					}
+					// `contains` on a uuid[] column is `@>` — "entity's type array
+					// contains ALL of these". For entity types, that's AND-semantics
+					// across the list: each supplied type must be present via its own
+					// EXISTS. Same per-row-seq-scan risk without a custom handler.
+					if (typeIds.contains && typeIds.contains.length > 0) {
+						for (const t of typeIds.contains) {
+							queryBuilder.where(buildSingleTypeCondition(sql, tableAlias, t))
+						}
+					}
 					if (typeIds.isNull === true) {
 						queryBuilder.where(sql.fragment`NOT ${buildHasAnyTypeCondition(sql, tableAlias)}`)
 					}


### PR DESCRIPTION
Mirrors geobrowser/gaia#635.

## Summary
`entitiesConnection(filter: {typeIds: {overlaps: [...]}})` has been producing nginx 504 Gateway Timeouts in prod. The custom `entitySpaceFilterPlugin` only intercepts `is`, `isNot`, `in`, `notIn`, `isNull` — `overlaps` and `contains` fall through to PostGraphile's default filter on the computed column `entities_type_ids(e)`, which triggers a full table scan.

This PR adds `overlaps` (same semantics as `in` for type arrays) and `contains` (AND of single-type predicates), both routing through the existing EXISTS helpers that use `relations_to_entity_id_idx`.

## Repro

```graphql
query {
  entitiesConnection(
    filter: {typeIds: {overlaps: ["3b22262d7919441db1a839eee9c2b3e9"]}}
    first: 25
  ) {
    nodes { name description types { name } }
    pageInfo { endCursor hasNextPage }
  }
}
```

Client gets:
```
{ "errors": [{ "message": "Unexpected response: 504 Gateway Time-out", ... }] }
```

## Root cause (verified via `EXPLAIN`)

```
Seq Scan on public.entities e  (cost=0.00..1430355.00 rows=25994 width=16)
  Filter: (entities_type_ids(e.*) && '{3b22262d-…}'::uuid[])
```

~2M entity rows scanned; `entities_type_ids(e)` evaluated per row (itself joining `relations × entities`). Query exceeds the 60s `statement_timeout` → nginx 504.

## Fix

Added two cases in `entitySpaceFilterPlugin.ts`:

```ts
if (typeIds.overlaps && typeIds.overlaps.length > 0) {
  queryBuilder.where(buildMultiTypeCondition(sql, tableAlias, typeIds.overlaps))
}
if (typeIds.contains && typeIds.contains.length > 0) {
  for (const t of typeIds.contains) {
    queryBuilder.where(buildSingleTypeCondition(sql, tableAlias, t))
  }
}
```

- **`overlaps`** → `buildMultiTypeCondition` (same EXISTS + `ANY(uuid[])` as `in`). Semantically identical for entity types: "has at least one of these".
- **`contains`** → AND of single-type EXISTS predicates. "Entity has ALL of these types".

Both use `relations_to_entity_id_idx` via the existing helpers. Expected post-fix plan: Index Scan, sub-ms execution.

## Short-term workaround for affected clients
Swap `overlaps` → `in`. Identical results for type-array filtering, and the `in` path has always been fast.

## Test plan
- [x] tsc passes
- [x] New integration tests added:
  - Correctness: `overlaps` returns entities with at least one matching type; `contains` returns entities with all specified types
  - **Plan-shape regression guard**: `pg_stat_user_tables.seq_scan` on `entities` must not increment while the filter runs. Catches any future change that falls back to the generic computed-column filter.
- [ ] After deploy: re-run the client's `overlaps` query, verify sub-second execution