### PR TITLE
fix(api): route typeIds/spaceIds filtering through the indexed path — fixes nginx 504

### DIFF
--- a/api/src/kg/__tests__/entitySpaceFilterPlugin.test.ts
+++ b/api/src/kg/__tests__/entitySpaceFilterPlugin.test.ts
@@ -589,5 +589,62 @@ describe("EntitySpaceFilterPlugin", () => {
 			expect(typeIdsArg).toBeDefined()
 			expect(typeIdsArg.type.name).toBe("UUIDFilter")
 		})
+
+		// --------------------------------------------------------------------
+		// EntityFilter stripping — typeIds / spaceIds are removed from the
+		// auto-generated `filter:` input because they'd otherwise route
+		// through the per-row computed-column filter and force a seq scan
+		// on `entities`. See the plugin's long-form comment for details.
+		// --------------------------------------------------------------------
+
+		it("EntityFilter does NOT expose `typeIds` (forces use of indexed top-level arg)", async () => {
+			const result = await executeGraphQL(`
+				query IntrospectEntityFilter {
+					__type(name: "EntityFilter") { inputFields { name } }
+				}
+			`)
+			expect(result.errors).toBeUndefined()
+			const fieldNames = (result.data.__type.inputFields as Array<{name: string}>).map((f) => f.name)
+			expect(fieldNames).not.toContain("typeIds")
+		})
+
+		it("EntityFilter does NOT expose `spaceIds` (forces use of indexed top-level arg)", async () => {
+			const result = await executeGraphQL(`
+				query IntrospectEntityFilter {
+					__type(name: "EntityFilter") { inputFields { name } }
+				}
+			`)
+			expect(result.errors).toBeUndefined()
+			const fieldNames = (result.data.__type.inputFields as Array<{name: string}>).map((f) => f.name)
+			expect(fieldNames).not.toContain("spaceIds")
+		})
+
+		it("other EntityFilter fields (e.g. `id`, `and`, `or`) remain", async () => {
+			// Sanity check: the strip is surgical. Generic combinators and
+			// non-computed-column filters should still work.
+			const result = await executeGraphQL(`
+				query IntrospectEntityFilter {
+					__type(name: "EntityFilter") { inputFields { name } }
+				}
+			`)
+			expect(result.errors).toBeUndefined()
+			const fieldNames = (result.data.__type.inputFields as Array<{name: string}>).map((f) => f.name)
+			expect(fieldNames).toContain("id")
+			expect(fieldNames).toContain("and")
+			expect(fieldNames).toContain("or")
+		})
+
+		it("rejects a query using the removed `filter.typeIds` path with a validation error", async () => {
+			// Regression guard: if a future change reintroduces `filter.typeIds`,
+			// this query would succeed (and seq-scan). Expect GraphQL to reject
+			// it at validation.
+			const result = await executeGraphQL(`
+				query WouldSeqScan {
+					entities(filter: {typeIds: {overlaps: ["00000000000000000000000000000000"]}}, first: 1) { id }
+				}
+			`)
+			expect(result.errors).toBeDefined()
+			expect(result.errors?.[0]?.message).toMatch(/typeIds|EntityFilter/i)
+		})
 	})
 })

--- a/api/src/kg/entitySpaceFilterPlugin.ts
+++ b/api/src/kg/entitySpaceFilterPlugin.ts
@@ -270,6 +270,35 @@ export const EntitySpaceFilterPlugin = (builder: any) => {
 			},
 		})
 	})
+
+	// ========================================================================
+	// Remove `typeIds` / `spaceIds` from the auto-generated `filter:` input.
+	// ========================================================================
+	//
+	// PostGraphile's connection-filter plugin exposes these computed-column
+	// fields on `EntityFilter` (nested under the `filter:` arg). Every
+	// operator used there evaluates `entities_type_ids(e)` /
+	// `entities_space_ids(e)` per row — a function that itself joins
+	// relations × entities. On a 2M-row table that's a full sequential scan
+	// with a per-row function call — it exceeds the 60 s statement_timeout
+	// and produces nginx 504 (reported with `filter: {typeIds: {overlaps: [...]}}`).
+	//
+	// The custom top-level `typeIds:` and `spaceIds:` arguments (added above)
+	// rewrite to indexed EXISTS predicates on `relations_to_entity_id_idx`
+	// and run sub-millisecond at full prod scale (measured: 1.0 ms end-to-end
+	// for the offending query shape). This hook removes the slow `filter.*`
+	// path to force callers onto the fast top-level args.
+	//
+	// Breaking for any caller using `filter: {typeIds: …}` or
+	// `filter: {spaceIds: …}`. Migration:
+	//   `entities(filter: {typeIds: {in: $ids}})`        → `entities(typeIds: {in: $ids})`
+	//   `entities(filter: {typeIds: {overlaps: $ids}})`  → `entities(typeIds: {in: $ids})`  (same semantics)
+	//   `entities(filter: {typeIds: {anyEqualTo: $id}})` → `entities(typeId: $id)`
+	builder.hook("GraphQLInputObjectType:fields", (fields: any, _build: any, context: any) => {
+		if (context.Self?.name !== "EntityFilter") return fields
+		const {typeIds: _typeIds, spaceIds: _spaceIds, ...rest} = fields
+		return rest
+	})
 }
 
 export default EntitySpaceFilterPlugin


### PR DESCRIPTION
Supersedes #164 — that PR targeted the wrong code path and wouldn't have fixed the reported 504. See the \`Context\` section below.

## Summary
- Remove `typeIds` and `spaceIds` from the auto-generated `EntityFilter` input type (the `filter:` arg).
- All type/space filtering is now routed through the top-level `typeIds:` / `spaceIds:` arguments which the custom plugin already intercepts with indexed EXISTS predicates.
- Breaking change for clients using `filter: {typeIds: …}` or `filter: {spaceIds: …}`.  Migration paths are documented inline; the common ones are one-line swaps.

## Repro

```graphql
query MyQuery {
  entitiesConnection(
    filter: {typeIds: {overlaps: ["3b22262d7919441db1a839eee9c2b3e9"]}}
    first: 25
  ) {
    nodes { name description types { name } }
    pageInfo { endCursor hasNextPage }
  }
}
```

Before: nginx 504 Gateway Timeout after ~60 s.

## Context — why not just add `overlaps` handling?

My earlier PR (#164) added `overlaps` / `contains` handlers to the existing `addArgDataGenerator`. But that only runs for the **top-level `typeIds:` argument** (`UUIDFilter`, scalar operators: `is`/`isNot`/`in`/`notIn`/`isNull`). The user's query uses the nested **`filter.typeIds`** path, which is a **`UUIDListFilter`** — exposed separately by PostGraphile's connection-filter plugin on top of the computed column `entities_type_ids(e)`.

Confirmed via introspection:

```
EntityFilter.typeIds → UUIDListFilter
  isNull, is, isNot, distinctFrom, notDistinctFrom,
  lessThan, lessThanOrEqualTo, greaterThan, greaterThanOrEqualTo,
  in, containedBy, overlaps,
  anyEqualTo, anyNotEqualTo, anyLessThan, anyLessThanOrEqualTo,
  anyGreaterThan, anyGreaterThanOrEqualTo
```

**Every single operator on `UUIDListFilter` routes through the per-row computed-column filter** (`entities_type_ids(e) && $1`, `@> $1`, etc.), which forces a `Seq Scan on entities` with the function called per row. #164 added handlers for an argument path the user's query doesn't traverse — dead code.

## Root cause (verified)

```
Seq Scan on public.entities e  (cost=0.00..1430355.00 rows=25994 width=16)
  Filter: (entities_type_ids(e.*) && '{3b22262d-…}'::uuid[])
```

~2M entity rows scanned; `entities_type_ids(e)` evaluated per row (itself joining `relations × entities`). Exceeds the 60 s `statement_timeout` → nginx 504.

## Fix

Adds a `GraphQLInputObjectType:fields` build hook to `entitySpaceFilterPlugin.ts`:

```ts
builder.hook("GraphQLInputObjectType:fields", (fields, _build, context) => {
  if (context.Self?.name !== "EntityFilter") return fields
  const {typeIds: _typeIds, spaceIds: _spaceIds, ...rest} = fields
  return rest
})
```

Removes the two slow-path fields from `EntityFilter`. The existing top-level `typeIds:` / `spaceIds:` arguments (which rewrite to indexed EXISTS on `relations_to_entity_id_idx`) remain and are the intended fast path.

### Measured: the fast path handles this query in ~1 ms

EXPLAIN ANALYZE against live prod DB, same type-id filter, same selection set (`id`, `name`, `description`, `types { name }`):

```
Limit  (cost=46.74..50.84 rows=8 width=80) (actual time=0.247..0.661 rows=18 loops=1)
  → Sort (id) → Nested Loop
       → HashAggregate on relations (Index Scan: relations_to_entity_id_idx, 18 rows)
       → Index Scan on entities_pkey (18 loops)
SubPlan 1 (types per row): Index Only Scan on relations_type_from_to_idx, 18 loops
Execution Time: 1.009 ms
```

## Breaking change & migration

Any caller using `filter: {typeIds: …}` or `filter: {spaceIds: …}` will now get a GraphQL validation error (no such field). Migration:

| Before | After |
|---|---|
| `entities(filter: {typeIds: {in: $ids}})`        | `entities(typeIds: {in: $ids})` |
| `entities(filter: {typeIds: {overlaps: $ids}})`  | `entities(typeIds: {in: $ids})` (same semantics for type arrays) |
| `entities(filter: {typeIds: {anyEqualTo: $id}})` | `entities(typeId: $id)` |

Same story for `spaceIds`. The error message GraphQL produces points directly at the removed field, so affected clients will see a clear path forward.

## Test plan
- [x] lint / tsc pass
- [x] Integration tests added:
  - `EntityFilter` introspection confirms `typeIds` and `spaceIds` are absent
  - Non-computed-column fields (`id`, `and`, `or`) remain
  - A query that uses the removed `filter.typeIds` path returns a GraphQL validation error (regression guard against reintroduction)
- [ ] After deploy: re-run the client's `overlaps` query against `/graphql` via the migrated shape; confirm sub-second execution
- [ ] After deploy: confirm no new `Seq Scan on entities` entries in slow-query logs
- [ ] Grep client codebases (`geogenesis`, `curator-app`) for `filter: {typeIds` / `filter: {spaceIds` before merge; notify any affected team