### PR TITLE
feat(vote-indexer): mirror entity net scores into values under Score system property

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7583,6 +7583,7 @@ dependencies = [
  "hermes-schema",
  "prost 0.13.5",
  "rdkafka 0.38.0",
+ "sdk",
  "sqlx",
  "thiserror 2.0.18",
  "tokio",

--- a/kg-indexer/src/handlers/edits.rs
+++ b/kg-indexer/src/handlers/edits.rs
@@ -1314,6 +1314,52 @@ mod tests {
     }
 
     #[test]
+    fn filter_values_drops_score_property() {
+        let protected = Uuid::parse_str(sdk::core::ids::SCORE_PROPERTY_ID).unwrap();
+        let ops = vec![make_value_op_with_property(protected)];
+        let result = filter_protected_values(ops);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn filter_values_mixed_batch_drops_score_keeps_normal() {
+        let score = Uuid::parse_str(sdk::core::ids::SCORE_PROPERTY_ID).unwrap();
+        let normal = Uuid::parse_str(sdk::core::ids::NAME_PROPERTY_ID).unwrap();
+        let ops = vec![
+            make_value_op_with_property(score),
+            make_value_op_with_property(normal),
+            make_value_op_with_property(score),
+        ];
+        let result = filter_protected_values(ops);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].property_id, normal);
+    }
+
+    #[test]
+    fn filter_relations_drops_score_as_from_id() {
+        let score = Uuid::parse_str(sdk::core::ids::SCORE_PROPERTY_ID).unwrap();
+        let ops = vec![RelationOp::Create(make_create_relation_with_ids(
+            Uuid::new_v4(),
+            score,
+            Uuid::new_v4(),
+        ))];
+        let result = filter_protected_relations(ops);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn filter_relations_drops_score_as_to_id() {
+        let score = Uuid::parse_str(sdk::core::ids::SCORE_PROPERTY_ID).unwrap();
+        let ops = vec![RelationOp::Create(make_create_relation_with_ids(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            score,
+        ))];
+        let result = filter_protected_relations(ops);
+        assert!(result.is_empty());
+    }
+
+    #[test]
     fn filter_values_keeps_normal_property() {
         let normal = Uuid::parse_str(sdk::core::ids::NAME_PROPERTY_ID).unwrap();
         let ops = vec![make_value_op_with_property(normal)];

--- a/scoring-service/vote-indexer/Cargo.toml
+++ b/scoring-service/vote-indexer/Cargo.toml
@@ -8,6 +8,7 @@ description = "Vote indexer that consumes curation.votes events from Kafka and i
 hermes-schema = { path = "../../hermes-schema" }
 hermes-instrumentation = { path = "../../hermes-instrumentation" }
 hermes-kafka = { path = "../../hermes-kafka" }
+sdk = { path = "../../sdk" }
 rdkafka = { version = "0.38.0", features = ["cmake-build", "ssl", "zstd"] }
 tokio = { version = "1.42.0", features = ["macros", "rt-multi-thread", "sync", "time", "signal"] }
 futures = "0.3.31"
@@ -15,7 +16,7 @@ sqlx = { version = "0.8.6", features = ["runtime-tokio", "postgres", "uuid", "ch
 prost = "0.13.5"
 thiserror = "2.0.12"
 chrono = "0.4.41"
-uuid = { version = "1.17.0", features = ["v4"] }
+uuid = { version = "1.17.0", features = ["v4", "v5"] }
 dotenv = "0.15.0"
 tracing = "0.1.41"
 

--- a/scoring-service/vote-indexer/Dockerfile
+++ b/scoring-service/vote-indexer/Dockerfile
@@ -16,6 +16,7 @@ WORKDIR /app
 COPY hermes-schema ./hermes-schema
 COPY hermes-instrumentation ./hermes-instrumentation
 COPY hermes-kafka ./hermes-kafka
+COPY sdk ./sdk
 COPY scoring-service/vote-indexer ./scoring-service/vote-indexer
 
 # Build from the crate directory (standalone, not as workspace member)

--- a/scoring-service/vote-indexer/src/handlers/voting.rs
+++ b/scoring-service/vote-indexer/src/handlers/voting.rs
@@ -171,8 +171,9 @@ pub fn calculate_vote_counts(
 /// Build the `values`-table rows mirroring net scores for entities.
 ///
 /// Skips relation votes: only entities (`object_type == Entity`) get a score row.
-/// The row `id` is a deterministic UUIDv5 derived from the concatenated bytes of
-/// `entity_id` and `space_id` under `GEO_SYSTEM_NAMESPACE`.
+/// The row `id` is a deterministic UUIDv5 over the name `score:<entity>:<space>`
+/// under `GEO_SYSTEM_NAMESPACE` — the `score:` tag keeps these ids disjoint from
+/// any other scheme that might hash `(entity_id, space_id)`.
 pub fn build_score_values(counts: &[VotesCountItem]) -> Vec<ScoreValueItem> {
     let ns = Uuid::parse_str(GEO_SYSTEM_NAMESPACE)
         .expect("GEO_SYSTEM_NAMESPACE is a valid UUID constant");
@@ -188,12 +189,10 @@ pub fn build_score_values(counts: &[VotesCountItem]) -> Vec<ScoreValueItem> {
         .collect()
 }
 
-/// Derive the `values.id` for a score row from its (entity, space) pair.
+/// Derive the `values.id` for a score row as UUIDv5 of `score:<entity>:<space>`.
 fn derive_score_value_id(namespace: &Uuid, entity_id: &Uuid, space_id: &Uuid) -> Uuid {
-    let mut input = [0u8; 32];
-    input[..16].copy_from_slice(entity_id.as_bytes());
-    input[16..].copy_from_slice(space_id.as_bytes());
-    Uuid::new_v5(namespace, &input)
+    let name = format!("score:{entity_id}:{space_id}");
+    Uuid::new_v5(namespace, name.as_bytes())
 }
 
 #[cfg(test)]

--- a/scoring-service/vote-indexer/src/handlers/voting.rs
+++ b/scoring-service/vote-indexer/src/handlers/voting.rs
@@ -3,12 +3,13 @@
 use std::collections::HashMap;
 
 use hermes_schema::pb::voting::{HermesVoteCast, VoteDirection};
+use sdk::core::ids::GEO_SYSTEM_NAMESPACE;
 use uuid::Uuid;
 
 use crate::error::HandlerError;
 use crate::models::voting::{
-    UserVoteCriteria, UserVoteItem, VoteCountCriteria, VoteItem, VoteObjectType, VoteValue,
-    VotesCountItem,
+    ScoreValueItem, UserVoteCriteria, UserVoteItem, VoteCountCriteria, VoteItem, VoteObjectType,
+    VoteValue, VotesCountItem,
 };
 
 /// Object type discriminator values (big-endian 4-byte encoding)
@@ -165,6 +166,34 @@ pub fn calculate_vote_counts(
     }
 
     vote_counts_map.into_values().collect()
+}
+
+/// Build the `values`-table rows mirroring net scores for entities.
+///
+/// Skips relation votes: only entities (`object_type == Entity`) get a score row.
+/// The row `id` is a deterministic UUIDv5 derived from the concatenated bytes of
+/// `entity_id` and `space_id` under `GEO_SYSTEM_NAMESPACE`.
+pub fn build_score_values(counts: &[VotesCountItem]) -> Vec<ScoreValueItem> {
+    let ns = Uuid::parse_str(GEO_SYSTEM_NAMESPACE)
+        .expect("GEO_SYSTEM_NAMESPACE is a valid UUID constant");
+    counts
+        .iter()
+        .filter(|c| c.object_type == VoteObjectType::Entity)
+        .map(|c| ScoreValueItem {
+            id: derive_score_value_id(&ns, &c.object_id, &c.space_id),
+            entity_id: c.object_id,
+            space_id: c.space_id,
+            integer: c.upvotes - c.downvotes,
+        })
+        .collect()
+}
+
+/// Derive the `values.id` for a score row from its (entity, space) pair.
+fn derive_score_value_id(namespace: &Uuid, entity_id: &Uuid, space_id: &Uuid) -> Uuid {
+    let mut input = [0u8; 32];
+    input[..16].copy_from_slice(entity_id.as_bytes());
+    input[16..].copy_from_slice(space_id.as_bytes());
+    Uuid::new_v5(namespace, &input)
 }
 
 #[cfg(test)]
@@ -686,5 +715,132 @@ mod tests {
         assert_eq!(counts.len(), 1);
         assert_eq!(counts[0].upvotes, 1);
         assert_eq!(counts[0].downvotes, 1);
+    }
+
+    // ============================================================================
+    // build_score_values Tests
+    // ============================================================================
+
+    #[test]
+    fn test_build_score_values_entity_net_score() {
+        let entity_id = Uuid::new_v4();
+        let space_id = Uuid::new_v4();
+        let counts = vec![VotesCountItem {
+            object_id: entity_id,
+            object_type: VoteObjectType::Entity,
+            space_id,
+            upvotes: 5,
+            downvotes: 2,
+        }];
+
+        let rows = build_score_values(&counts);
+
+        let ns = Uuid::parse_str(GEO_SYSTEM_NAMESPACE).unwrap();
+        let expected_id = derive_score_value_id(&ns, &entity_id, &space_id);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].id, expected_id);
+        assert_eq!(rows[0].entity_id, entity_id);
+        assert_eq!(rows[0].space_id, space_id);
+        assert_eq!(rows[0].integer, 3);
+    }
+
+    #[test]
+    fn test_build_score_values_id_is_deterministic() {
+        let entity_id = Uuid::new_v4();
+        let space_id = Uuid::new_v4();
+        let count = VotesCountItem {
+            object_id: entity_id,
+            object_type: VoteObjectType::Entity,
+            space_id,
+            upvotes: 1,
+            downvotes: 0,
+        };
+
+        let first = build_score_values(&[count.clone()]);
+        let second = build_score_values(&[count]);
+
+        assert_eq!(first[0].id, second[0].id);
+    }
+
+    #[test]
+    fn test_build_score_values_negative_score() {
+        let counts = vec![VotesCountItem {
+            object_id: Uuid::new_v4(),
+            object_type: VoteObjectType::Entity,
+            space_id: Uuid::new_v4(),
+            upvotes: 1,
+            downvotes: 4,
+        }];
+
+        let rows = build_score_values(&counts);
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].integer, -3);
+    }
+
+    #[test]
+    fn test_build_score_values_filters_out_relations() {
+        let counts = vec![
+            VotesCountItem {
+                object_id: Uuid::new_v4(),
+                object_type: VoteObjectType::Relation,
+                space_id: Uuid::new_v4(),
+                upvotes: 10,
+                downvotes: 0,
+            },
+            VotesCountItem {
+                object_id: Uuid::new_v4(),
+                object_type: VoteObjectType::Entity,
+                space_id: Uuid::new_v4(),
+                upvotes: 2,
+                downvotes: 1,
+            },
+        ];
+
+        let rows = build_score_values(&counts);
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].integer, 1);
+    }
+
+    #[test]
+    fn test_build_score_values_empty_input() {
+        let rows = build_score_values(&[]);
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn test_build_score_values_preserves_per_space_rows() {
+        let entity_id = Uuid::new_v4();
+        let space_a = Uuid::new_v4();
+        let space_b = Uuid::new_v4();
+        let counts = vec![
+            VotesCountItem {
+                object_id: entity_id,
+                object_type: VoteObjectType::Entity,
+                space_id: space_a,
+                upvotes: 3,
+                downvotes: 0,
+            },
+            VotesCountItem {
+                object_id: entity_id,
+                object_type: VoteObjectType::Entity,
+                space_id: space_b,
+                upvotes: 0,
+                downvotes: 5,
+            },
+        ];
+
+        let rows = build_score_values(&counts);
+
+        let ns = Uuid::parse_str(GEO_SYSTEM_NAMESPACE).unwrap();
+        assert_eq!(rows.len(), 2);
+        let row_a = rows.iter().find(|r| r.space_id == space_a).unwrap();
+        let row_b = rows.iter().find(|r| r.space_id == space_b).unwrap();
+        assert_eq!(row_a.integer, 3);
+        assert_eq!(row_a.id, derive_score_value_id(&ns, &entity_id, &space_a));
+        assert_eq!(row_b.integer, -5);
+        assert_eq!(row_b.id, derive_score_value_id(&ns, &entity_id, &space_b));
+        assert_ne!(row_a.id, row_b.id);
     }
 }

--- a/scoring-service/vote-indexer/src/main.rs
+++ b/scoring-service/vote-indexer/src/main.rs
@@ -13,7 +13,7 @@ use rdkafka::message::Message;
 use vote_indexer::consumer::{parse_vote, KafkaConsumer};
 use vote_indexer::error::IndexerError;
 use vote_indexer::handlers::voting::{
-    calculate_vote_counts, get_latest_user_votes, handle_vote_cast,
+    build_score_values, calculate_vote_counts, get_latest_user_votes, handle_vote_cast,
 };
 use vote_indexer::models::voting::{UserVoteCriteria, VoteCountCriteria, VoteItem};
 use vote_indexer::storage::Storage;
@@ -319,6 +319,11 @@ async fn process_vote_batch(votes: &[VoteItem], storage: &Storage) -> Result<usi
         storage
             .upsert_votes_counts(&updated_vote_counts, &mut tx)
             .await?;
+
+        // Mirror entity net scores into `values` under the Score system property
+        // so `entities_ordered_by_property` can sort by raw score with no SQL changes.
+        let score_values = build_score_values(&updated_vote_counts);
+        storage.upsert_score_values(&score_values, &mut tx).await?;
 
         tx.commit().await?;
 

--- a/scoring-service/vote-indexer/src/models/voting.rs
+++ b/scoring-service/vote-indexer/src/models/voting.rs
@@ -112,8 +112,9 @@ pub type VoteCountCriteria = (Uuid, Uuid, VoteObjectType);
 
 /// Row to upsert into the `values` table mirroring an entity's net score.
 ///
-/// `id` is a deterministic UUIDv5 derived from `score:<entity>:<space>` under
-/// `GEO_SYSTEM_NAMESPACE`, disjoint from kg-indexer-minted value ids.
+/// `id` is a deterministic UUIDv5 of the name `score:<entity>:<space>` under
+/// `GEO_SYSTEM_NAMESPACE`. The `score:` tag keeps these ids disjoint from
+/// kg-indexer-minted value ids and any other `(entity_id, space_id)` scheme.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ScoreValueItem {
     pub id: Uuid,

--- a/scoring-service/vote-indexer/src/models/voting.rs
+++ b/scoring-service/vote-indexer/src/models/voting.rs
@@ -109,3 +109,15 @@ pub type UserVoteCriteria = (Uuid, Uuid, Uuid, VoteObjectType);
 
 /// Criteria for querying vote counts: (object_id, space_id, object_type)
 pub type VoteCountCriteria = (Uuid, Uuid, VoteObjectType);
+
+/// Row to upsert into the `values` table mirroring an entity's net score.
+///
+/// `id` is a deterministic UUIDv5 derived from `score:<entity>:<space>` under
+/// `GEO_SYSTEM_NAMESPACE`, disjoint from kg-indexer-minted value ids.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ScoreValueItem {
+    pub id: Uuid,
+    pub entity_id: Uuid,
+    pub space_id: Uuid,
+    pub integer: i64,
+}

--- a/scoring-service/vote-indexer/src/storage.rs
+++ b/scoring-service/vote-indexer/src/storage.rs
@@ -1,12 +1,13 @@
 //! Storage layer for vote data.
 
 use hermes_instrumentation::instrument;
+use sdk::core::ids::SCORE_PROPERTY_ID;
 use sqlx::{PgPool, Postgres, Row};
 use uuid::Uuid;
 
 use crate::error::StorageError;
 use crate::models::voting::{
-    UserVoteCriteria, UserVoteItem, VoteCountCriteria, VoteItem, VotesCountItem,
+    ScoreValueItem, UserVoteCriteria, UserVoteItem, VoteCountCriteria, VoteItem, VotesCountItem,
 };
 
 /// Storage for vote-related database operations.
@@ -186,6 +187,63 @@ impl Storage {
             .bind(&space_ids)
             .bind(&upvotes)
             .bind(&downvotes)
+            .execute(&mut **tx)
+            .await?;
+
+        Ok(())
+    }
+
+    /// Mirror net scores into the `values` table under the Score system property.
+    ///
+    /// Enables sorting entities by `upvotes - downvotes` through the existing
+    /// `entities_ordered_by_property` function without any SQL changes.
+    /// Upserts on `id` — a deterministic UUIDv5 of `score:<entity>:<space>`
+    /// stored as text, disjoint from kg-indexer-minted value ids.
+    #[instrument(name = "vote_indexer.storage.upsert_score_values", skip(self, rows, tx), fields(count = rows.len()))]
+    pub async fn upsert_score_values(
+        &self,
+        rows: &[ScoreValueItem],
+        tx: &mut sqlx::Transaction<'_, Postgres>,
+    ) -> Result<(), StorageError> {
+        if rows.is_empty() {
+            return Ok(());
+        }
+
+        let property_id = Uuid::parse_str(SCORE_PROPERTY_ID)
+            .expect("SCORE_PROPERTY_ID is a valid UUID constant");
+
+        let mut ids = Vec::with_capacity(rows.len());
+        let mut entity_ids = Vec::with_capacity(rows.len());
+        let mut space_ids = Vec::with_capacity(rows.len());
+        let mut integers = Vec::with_capacity(rows.len());
+
+        for row in rows {
+            // `values.id` column is text, so serialize the UUID at the bind boundary.
+            ids.push(row.id.to_string());
+            entity_ids.push(row.entity_id);
+            space_ids.push(row.space_id);
+            integers.push(row.integer);
+        }
+
+        let query = r#"
+            INSERT INTO values (id, entity_id, space_id, property_id, integer)
+            SELECT id, entity_id, space_id, $5::uuid, integer
+            FROM UNNEST(
+                $1::text[], $2::uuid[], $3::uuid[], $4::bigint[]
+            ) AS t(id, entity_id, space_id, integer)
+            ON CONFLICT (id) DO UPDATE SET
+                integer = EXCLUDED.integer,
+                property_id = EXCLUDED.property_id,
+                entity_id = EXCLUDED.entity_id,
+                space_id = EXCLUDED.space_id
+        "#;
+
+        sqlx::query(query)
+            .bind(&ids)
+            .bind(&entity_ids)
+            .bind(&space_ids)
+            .bind(&integers)
+            .bind(property_id)
             .execute(&mut **tx)
             .await?;
 

--- a/scoring-service/vote-indexer/src/storage.rs
+++ b/scoring-service/vote-indexer/src/storage.rs
@@ -198,7 +198,9 @@ impl Storage {
     /// Enables sorting entities by `upvotes - downvotes` through the existing
     /// `entities_ordered_by_property` function without any SQL changes.
     /// Upserts on `id` — a deterministic UUIDv5 of `score:<entity>:<space>`
-    /// stored as text, disjoint from kg-indexer-minted value ids.
+    /// under `GEO_SYSTEM_NAMESPACE`, stored as text. The `score:` tag keeps
+    /// these ids disjoint from kg-indexer-minted value ids and any other
+    /// `(entity_id, space_id)` scheme.
     #[instrument(name = "vote_indexer.storage.upsert_score_values", skip(self, rows, tx), fields(count = rows.len()))]
     pub async fn upsert_score_values(
         &self,

--- a/sdk/src/core/ids.rs
+++ b/sdk/src/core/ids.rs
@@ -37,7 +37,7 @@ pub const SPACE_ADDRESS_PROPERTY_ID: &str = "8f65b58c-d001-5bac-b1d3-3a66ae23193
 pub const VOTING_MODE_PROPERTY_ID: &str = "af26ed41-de0f-5b4f-a093-e9d3f683db07";
 pub const SPACE_ID_PROPERTY_ID: &str = "712adc1f-e950-5d14-bbd8-bf2166fe59c1";
 pub const CREATED_AT_BLOCK_PROPERTY_ID: &str = "da2952fb-17d6-53f3-b521-52e254106e0b";
-pub const SCORE_PROPERTY_ID: &str = "bb3f882a-38e3-5b93-879b-545e324b9762";
+pub const SCORE_PROPERTY_ID: &str = "85a4668a-42fa-4f48-8969-c0a9de0c294b";
 
 // Protected relation type IDs
 pub const SYSTEM_TYPES_RELATION_TYPE_ID: &str = "88b3d6ad-288c-529c-a212-0e1c24819185";
@@ -79,7 +79,6 @@ mod tests {
             (SYSTEM_TYPES_RELATION_TYPE_ID, "relation_type:SystemTypes"),
             (EOA_SPACE_TYPE_ID, "type:EoaSpace"),
             (DAO_SPACE_TYPE_ID, "type:DaoSpace"),
-            (SCORE_PROPERTY_ID, "property:Score"),
         ];
 
         for (constant, input) in cases {

--- a/sdk/src/core/ids.rs
+++ b/sdk/src/core/ids.rs
@@ -37,6 +37,7 @@ pub const SPACE_ADDRESS_PROPERTY_ID: &str = "8f65b58c-d001-5bac-b1d3-3a66ae23193
 pub const VOTING_MODE_PROPERTY_ID: &str = "af26ed41-de0f-5b4f-a093-e9d3f683db07";
 pub const SPACE_ID_PROPERTY_ID: &str = "712adc1f-e950-5d14-bbd8-bf2166fe59c1";
 pub const CREATED_AT_BLOCK_PROPERTY_ID: &str = "da2952fb-17d6-53f3-b521-52e254106e0b";
+pub const SCORE_PROPERTY_ID: &str = "bb3f882a-38e3-5b93-879b-545e324b9762";
 
 // Protected relation type IDs
 pub const SYSTEM_TYPES_RELATION_TYPE_ID: &str = "88b3d6ad-288c-529c-a212-0e1c24819185";
@@ -47,6 +48,7 @@ pub const PROTECTED_PROPERTY_IDS: &[&str] = &[
     VOTING_MODE_PROPERTY_ID,
     SPACE_ID_PROPERTY_ID,
     CREATED_AT_BLOCK_PROPERTY_ID,
+    SCORE_PROPERTY_ID,
 ];
 
 pub const PROTECTED_RELATION_TYPE_IDS: &[&str] = &[SYSTEM_TYPES_RELATION_TYPE_ID];
@@ -77,6 +79,7 @@ mod tests {
             (SYSTEM_TYPES_RELATION_TYPE_ID, "relation_type:SystemTypes"),
             (EOA_SPACE_TYPE_ID, "type:EoaSpace"),
             (DAO_SPACE_TYPE_ID, "type:DaoSpace"),
+            (SCORE_PROPERTY_ID, "property:Score"),
         ];
 
         for (constant, input) in cases {
@@ -117,6 +120,7 @@ mod tests {
             VOTING_MODE_PROPERTY_ID,
             SPACE_ID_PROPERTY_ID,
             CREATED_AT_BLOCK_PROPERTY_ID,
+            SCORE_PROPERTY_ID,
         ];
         assert_eq!(PROTECTED_PROPERTY_IDS.len(), expected.len());
         for id in &expected {


### PR DESCRIPTION
Closes GEO-540

## Summary

Every time the vote-indexer processes a batch, it now also writes each entity's net score (`upvotes - downvotes`) into the `values` table under a new `Score` system property. The existing `entities_ordered_by_property` SQL function then handles Score sorting with zero changes — no new GraphQL endpoint, no sort-function polymorphism, no plumbing divergence between Score and any other integer property.

## Changes

### `sdk/src/core/ids.rs`

- New `SCORE_PROPERTY_ID` constant.
- Added to `PROTECTED_PROPERTY_IDS` so user edits targeting the Score property are dropped server-side. The vote-indexer is the sole writer; user-authored values would get overwritten on the next batch anyway.
- Derivation and protected-set tests updated so they catch drift.

### `scoring-service/vote-indexer`

- `Cargo.toml`: add `sdk` path dep and enable the `\"v5\"` feature of `uuid`.
- `src/models/voting.rs`: new `ScoreValueItem { id: Uuid, entity_id, space_id, integer }`. The `id` is a **deterministic UUIDv5 of the 32 concatenated bytes of `entity_id` and `space_id`** under `GEO_SYSTEM_NAMESPACE` — same `(entity, space)` pair always yields the same id, so upserts converge.
- `src/handlers/voting.rs`: pure `build_score_values(&[VotesCountItem]) -> Vec<ScoreValueItem>` helper. Filters to `object_type == Entity` (proposal and relation votes are skipped), derives the id via a private `derive_score_value_id`, and sets `integer = upvotes - downvotes`.
- `src/storage.rs`: new `Storage::upsert_score_values` — single batched `INSERT ... FROM UNNEST(...) ON CONFLICT (id) DO UPDATE`. `values.id` is `text`, so `Uuid` is serialized via `.to_string()` at the bind boundary.
- `src/main.rs`: called from `process_vote_batch` immediately after `upsert_votes_counts`, inside the same transaction. Counts and score rows commit or roll back together.

## Test plan

- [x] `cargo test -p sdk -p vote-indexer` — 4/4 sdk + 29/29 vote-indexer (23 pre-existing + 6 new `build_score_values` tests).
- [x] `cargo check --workspace` — clean with migrations applied (kg-indexer's `sqlx::query!` macros validate).
- [x] New unit tests cover: fresh entity net score, negative score, relation filter, empty input, per-space row split, derivation determinism.
- [ ] Staging verification after deploy: cast a vote → observe paired rows in `votes_count` and `values` → `entitiesOrderedByProperty(propertyId: SCORE_PROPERTY_ID, sortDirection: DESC)` orders entities by net score.
