### PR TITLE
feat(api): add only_canonical search flag

### DIFF
--- a/api/src/search/index.test.ts
+++ b/api/src/search/index.test.ts
@@ -499,6 +499,77 @@ describe("Search Router - Integration Tests", () => {
 		})
 	})
 
+	describe("only_canonical / include_non_canonical", () => {
+		it("does not pass include_non_canonical to the search client by default", async () => {
+			const request = new Request("http://localhost/search?query=test")
+			const response = await app.fetch(request)
+
+			expect(response.status).toBe(200)
+			const callArg = (mockSearchClient.search as ReturnType<typeof vi.fn>).mock.calls[0]![0]
+			expect(callArg).not.toHaveProperty("include_non_canonical")
+		})
+
+		it("only_canonical=true restricts results to the canonical graph", async () => {
+			const request = new Request("http://localhost/search?query=test&only_canonical=true")
+			const response = await app.fetch(request)
+
+			expect(response.status).toBe(200)
+			expect(mockSearchClient.search).toHaveBeenCalledWith(
+				expect.objectContaining({
+					include_non_canonical: false,
+				}),
+			)
+		})
+
+		it("only_canonical=false leaves the default (include all spaces) behavior", async () => {
+			const request = new Request("http://localhost/search?query=test&only_canonical=false")
+			const response = await app.fetch(request)
+
+			expect(response.status).toBe(200)
+			const callArg = (mockSearchClient.search as ReturnType<typeof vi.fn>).mock.calls[0]![0]
+			expect(callArg).not.toHaveProperty("include_non_canonical")
+		})
+
+		it("include_non_canonical=false (legacy spelling) still restricts results", async () => {
+			const request = new Request("http://localhost/search?query=test&include_non_canonical=false")
+			const response = await app.fetch(request)
+
+			expect(response.status).toBe(200)
+			expect(mockSearchClient.search).toHaveBeenCalledWith(
+				expect.objectContaining({
+					include_non_canonical: false,
+				}),
+			)
+		})
+
+		it("returns 400 when both include_non_canonical and only_canonical are set", async () => {
+			const request = new Request(
+				"http://localhost/search?query=test&include_non_canonical=true&only_canonical=true",
+			)
+			const response = await app.fetch(request)
+			const result = await response.json()
+
+			expect(response.status).toBe(400)
+			expect(result.error).toBe("Invalid parameter")
+			expect(result.message).toContain("mutually exclusive")
+			expect(mockSearchClient.search).not.toHaveBeenCalled()
+		})
+
+		it("returns 400 when both flags are set, even with conceptually-consistent values", async () => {
+			// include_non_canonical=false and only_canonical=true mean the same thing,
+			// but allowing both still creates ambiguity for callers — disallow.
+			const request = new Request(
+				"http://localhost/search?query=test&include_non_canonical=false&only_canonical=true",
+			)
+			const response = await app.fetch(request)
+			const result = await response.json()
+
+			expect(response.status).toBe(400)
+			expect(result.message).toContain("mutually exclusive")
+			expect(mockSearchClient.search).not.toHaveBeenCalled()
+		})
+	})
+
 	describe("inCanonicalGraph field", () => {
 		it("returns inCanonicalGraph: true when set", async () => {
 			const response: SearchResponse = {

--- a/api/src/search/index.ts
+++ b/api/src/search/index.ts
@@ -108,6 +108,7 @@ const VALID_PARAMS: Set<string> = new Set([
 	"offset",
 	"include_deleted",
 	"include_non_canonical",
+	"only_canonical",
 	...BOOST_PARAMS,
 ])
 
@@ -217,9 +218,17 @@ export function createSearchRouter(searchClient: SearchClient, runtime: AppRunti
 					name: "include_non_canonical",
 					in: "query",
 					description:
-						"Whether to include entities from spaces outside the canonical graph. Defaults to true (all entities returned). Set to false to restrict results to canonical spaces only. The canonical graph is the trust-based subset of spaces rooted at the configured root space, connected by verified/related/editor/member edges.",
+						"Whether to include entities from spaces outside the canonical graph. Defaults to true (all entities returned). Set to false to restrict results to canonical spaces only. The canonical graph is the trust-based subset of spaces rooted at the configured root space, connected by verified/related/editor/member edges. Mutually exclusive with `only_canonical`.",
 					required: false,
 					schema: {type: "boolean", default: true},
+				},
+				{
+					name: "only_canonical",
+					in: "query",
+					description:
+						"When `true`, restricts results to entities from spaces in the canonical graph. Equivalent to `include_non_canonical=false`. Mutually exclusive with `include_non_canonical` — passing both query parameters returns 400.",
+					required: false,
+					schema: {type: "boolean", default: false},
 				},
 			],
 			responses: {
@@ -353,6 +362,20 @@ export function createSearchRouter(searchClient: SearchClient, runtime: AppRunti
 				const offsetParam = c.req.query("offset")
 				const includeDeletedParam = c.req.query("include_deleted")
 				const includeNonCanonicalParam = c.req.query("include_non_canonical")
+				const onlyCanonicalParam = c.req.query("only_canonical")
+
+				// `include_non_canonical` and `only_canonical` are mutually exclusive —
+				// they're inverse spellings of the same toggle, so allowing both invites
+				// confusion (e.g. include_non_canonical=true & only_canonical=true).
+				if (includeNonCanonicalParam !== undefined && onlyCanonicalParam !== undefined) {
+					return yield* Effect.fail(
+						new SearchValidationError({
+							message:
+								"include_non_canonical and only_canonical cannot both be set — they are mutually exclusive. Use one or the other.",
+							status: 400,
+						}),
+					)
+				}
 
 				// Validate query length
 				const trimmedQuery = query?.trim() ?? ""
@@ -536,8 +559,13 @@ export function createSearchRouter(searchClient: SearchClient, runtime: AppRunti
 				// Parse include_deleted flag (default: false)
 				const includeDeleted = includeDeletedParam === "true"
 
-				// Parse include_non_canonical flag (default: true)
-				const includeNonCanonical = includeNonCanonicalParam !== "false"
+				// Parse canonicality toggle. Two equivalent spellings, only one allowed:
+				//   include_non_canonical=false  ↔  only_canonical=true
+				// Mutual exclusion is enforced above.
+				const includeNonCanonical =
+					onlyCanonicalParam !== undefined
+						? onlyCanonicalParam !== "true"
+						: includeNonCanonicalParam !== "false"
 
 				// Parse optional boost overrides (undocumented — for internal testing)
 				const boosts: BoostOverrides = {}

--- a/api/src/search/index.ts
+++ b/api/src/search/index.ts
@@ -145,7 +145,8 @@ export function createSearchRouter(searchClient: SearchClient, runtime: AppRunti
 		describeRoute({
 			tags: ["Search"],
 			summary: "Search for entities",
-			description: "Search for entities across the Knowledge Graph with optional filters",
+			description:
+				"Search for entities across the Knowledge Graph with optional filters. By default, results include entities from **all** spaces — both inside and outside the canonical graph. To restrict results to the canonical graph only, set `only_canonical=true` (or equivalently, `include_non_canonical=false`).",
 			parameters: [
 				{
 					name: "query",
@@ -218,7 +219,7 @@ export function createSearchRouter(searchClient: SearchClient, runtime: AppRunti
 					name: "include_non_canonical",
 					in: "query",
 					description:
-						"Whether to include entities from spaces outside the canonical graph. Defaults to true (all entities returned). Set to false to restrict results to canonical spaces only. The canonical graph is the trust-based subset of spaces rooted at the configured root space, connected by verified/related/editor/member edges. Mutually exclusive with `only_canonical`.",
+						"Whether to include entities from spaces outside the canonical graph. **Defaults to `true`** — non-canonical results are returned by default. Set to `false` to restrict results to canonical spaces only. The canonical graph is the trust-based subset of spaces rooted at the configured root space, connected by verified/related/editor/member edges. Mutually exclusive with `only_canonical`; passing both query parameters returns 400.",
 					required: false,
 					schema: {type: "boolean", default: true},
 				},
@@ -226,7 +227,7 @@ export function createSearchRouter(searchClient: SearchClient, runtime: AppRunti
 					name: "only_canonical",
 					in: "query",
 					description:
-						"When `true`, restricts results to entities from spaces in the canonical graph. Equivalent to `include_non_canonical=false`. Mutually exclusive with `include_non_canonical` — passing both query parameters returns 400.",
+						"When `true`, restricts results to entities from spaces in the canonical graph. Equivalent to `include_non_canonical=false`. **Defaults to `false`** — non-canonical results are returned by default. Mutually exclusive with `include_non_canonical`; passing both query parameters returns 400.",
 					required: false,
 					schema: {type: "boolean", default: false},
 				},


### PR DESCRIPTION
## Summary

- Adds a positive-direction spelling for restricting search results to the canonical graph: `only_canonical=true` is equivalent to the existing `include_non_canonical=false`
- Returns **400** if a caller passes both `include_non_canonical` and `only_canonical` query parameters — they are inverse spellings of the same toggle, and allowing both invites confusion (e.g. `include_non_canonical=true&only_canonical=true` is contradictory). Mutual exclusion is enforced regardless of values
- OpenAPI spec updated to document the new flag and the mutual-exclusion rule on both flags
- 6 new tests covering: default behavior, each spelling working alone, the legacy spelling still working, and the 400 in both contradictory and consistent-but-redundant double-set cases

## Behavior matrix

| query | result |
|-------|--------|
| neither flag | default — return all spaces |
| \`include_non_canonical=false\` | canonical only |
| \`only_canonical=true\` | canonical only |
| \`only_canonical=false\` | default — return all spaces |
| both flags present (any values) | 400 |

## Test plan

- [ ] \`bun vitest run src/search/index.test.ts\` passes (46 tests)
- [ ] \`bun run ci\` clean