### PR TITLE
fix(api): treat client-aborted requests as 499 + warn, not 500 + Sentry issue

### DIFF
--- a/api/main.ts
+++ b/api/main.ts
@@ -5,7 +5,7 @@ import {cors} from "hono/cors"
 import {describeRoute, openAPISpecs} from "hono-openapi"
 import {health} from "./src/health"
 import {getGraphqlPoolPressure, graphqlServer} from "./src/kg/postgraphile"
-import {canonicalRequestLogging, requestId} from "./src/middleware/requestLogging"
+import {canonicalRequestLogging, isClientAbortError, requestId} from "./src/middleware/requestLogging"
 import {createProfileRouter} from "./src/profile"
 import {createProposalsRouter} from "./src/proposals"
 import {createSearchRouter} from "./src/search"
@@ -31,6 +31,22 @@ type AppEnv = {
 }
 
 const app = new Hono<AppEnv>()
+
+// Hono dispatches all thrown errors through `app.onError` (see compose.js).
+// Recognize client-side aborts (browser navigated away, AbortController.abort,
+// React unmount cancelling an in-flight fetch) and short-circuit with a 499
+// "Client Closed Request" — same convention nginx uses. Without this, Hono's
+// default handler turns these into 500s, which downstream get logged as
+// `log.error` and create Sentry issues for what is not a server fault.
+//
+// Real errors fall through to the default 500 path, where canonicalRequestLogging
+// still emits the 5xx end log and Sentry issue.
+app.onError((err, c) => {
+	if (isClientAbortError(err)) {
+		return new Response(null, {status: 499})
+	}
+	return c.text("Internal Server Error", 500)
+})
 
 function createGraphqlOverloadResponse(requestId: string) {
 	const headers = new Headers({

--- a/api/src/middleware/__tests__/requestLogging.test.ts
+++ b/api/src/middleware/__tests__/requestLogging.test.ts
@@ -106,7 +106,7 @@ describe("canonicalRequestLogging — client abort handling", () => {
 		vi.clearAllMocks()
 	})
 
-	it("client abort → 499 status, log.warn (not error), no Sentry issue", async () => {
+	it("client abort → 499 status, info-level log, no error/warn, no Sentry issue", async () => {
 		const app = setupApp(() => {
 			throw makeAbortError()
 		})
@@ -114,16 +114,17 @@ describe("canonicalRequestLogging — client abort handling", () => {
 		const res = await app.request("/test")
 
 		expect(res.status).toBe(499)
-		// log.warn fires from the success-branch 499 case, never log.error
-		// (which is what would create a Sentry issue).
-		expect(log.warn).toHaveBeenCalledWith(
-			"GET /test aborted by client",
+		// 499 falls through to the default "completed" path at info level —
+		// no warn/error means no Sentry issue and minimal log noise.
+		expect(log.info).toHaveBeenCalledWith(
+			"GET /test completed",
 			expect.objectContaining({method: "GET", path: "/test", status: 499}),
 		)
+		expect(log.warn).not.toHaveBeenCalled()
 		expect(log.error).not.toHaveBeenCalled()
 	})
 
-	it("Node-style AbortError also yields 499 + warn", async () => {
+	it("Node-style AbortError also yields 499 with no error/warn", async () => {
 		const app = setupApp(() => {
 			throw Object.assign(new Error("aborted"), {name: "AbortError", code: "ABORT_ERR"})
 		})
@@ -131,7 +132,7 @@ describe("canonicalRequestLogging — client abort handling", () => {
 		const res = await app.request("/test")
 
 		expect(res.status).toBe(499)
-		expect(log.warn).toHaveBeenCalledWith("GET /test aborted by client", expect.any(Object))
+		expect(log.warn).not.toHaveBeenCalled()
 		expect(log.error).not.toHaveBeenCalled()
 	})
 

--- a/api/src/middleware/__tests__/requestLogging.test.ts
+++ b/api/src/middleware/__tests__/requestLogging.test.ts
@@ -1,0 +1,138 @@
+import {Hono} from "hono"
+import {beforeEach, describe, expect, it, vi} from "vitest"
+
+// Mock the structured logger so we can assert on log levels.
+vi.mock("../../services/telemetry", () => ({
+	log: {
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	},
+}))
+
+import {log} from "../../services/telemetry"
+import {canonicalRequestLogging, isClientAbortError, requestId} from "../requestLogging"
+
+/**
+ * Mirror the production app wiring: requestId + canonicalRequestLogging,
+ * plus an `app.onError` that converts AbortErrors to 499 (matching main.ts).
+ * The default Hono error handler turns everything else into 500.
+ */
+function setupApp(handler: () => Promise<Response> | Response) {
+	const app = new Hono()
+	app.onError((err, c) => {
+		if (isClientAbortError(err)) {
+			return new Response(null, {status: 499})
+		}
+		return c.text("Internal Server Error", 500)
+	})
+	app.use("*", requestId())
+	app.use("*", canonicalRequestLogging())
+	app.all("/test", handler)
+	return app
+}
+
+/**
+ * Mirror the production AbortError shape: graphql-yoga / @whatwg-node/server
+ * throw a `DOMException` (which extends Error in modern Node/Bun) with
+ * `name === "AbortError"`, `code === 20`, empty stack. We can't construct a
+ * DOMException directly in vitest's environment, so we forge an Error subclass
+ * with the same surface — Hono's compose only routes `instanceof Error`
+ * throws through `app.onError`.
+ */
+function makeAbortError(): Error {
+	const err = new Error("The connection was closed.")
+	Object.defineProperty(err, "name", {value: "AbortError"})
+	Object.defineProperty(err, "code", {value: 20})
+	err.stack = ""
+	return err
+}
+const ABORT_ERROR_LIKE = {
+	name: "AbortError",
+	code: 20,
+	message: "The connection was closed.",
+}
+
+describe("isClientAbortError", () => {
+	it("recognizes DOMException-shape AbortError (code 20)", () => {
+		expect(isClientAbortError(ABORT_ERROR_LIKE)).toBe(true)
+	})
+
+	it("recognizes Node-style AbortError (code 'ABORT_ERR')", () => {
+		expect(isClientAbortError({name: "AbortError", code: "ABORT_ERR"})).toBe(true)
+	})
+
+	it("recognizes by name alone (defensive)", () => {
+		expect(isClientAbortError({name: "AbortError"})).toBe(true)
+	})
+
+	it("does not match arbitrary errors", () => {
+		expect(isClientAbortError(new Error("boom"))).toBe(false)
+		expect(isClientAbortError({code: 20})).toBe(true) // code-only is enough — DOMException pattern
+		expect(isClientAbortError({name: "TypeError"})).toBe(false)
+		expect(isClientAbortError(null)).toBe(false)
+		expect(isClientAbortError(undefined)).toBe(false)
+		expect(isClientAbortError("string error")).toBe(false)
+	})
+})
+
+describe("canonicalRequestLogging — client abort handling", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it("client abort → 499 status, log.warn (not error), no Sentry issue", async () => {
+		const app = setupApp(() => {
+			throw makeAbortError()
+		})
+
+		const res = await app.request("/test")
+
+		expect(res.status).toBe(499)
+		// log.warn fires from the success-branch 499 case, never log.error
+		// (which is what would create a Sentry issue).
+		expect(log.warn).toHaveBeenCalledWith(
+			"GET /test aborted by client",
+			expect.objectContaining({method: "GET", path: "/test", status: 499}),
+		)
+		expect(log.error).not.toHaveBeenCalled()
+	})
+
+	it("Node-style AbortError also yields 499 + warn", async () => {
+		const app = setupApp(() => {
+			throw Object.assign(new Error("aborted"), {name: "AbortError", code: "ABORT_ERR"})
+		})
+
+		const res = await app.request("/test")
+
+		expect(res.status).toBe(499)
+		expect(log.warn).toHaveBeenCalledWith("GET /test aborted by client", expect.any(Object))
+		expect(log.error).not.toHaveBeenCalled()
+	})
+
+	it("non-abort errors still surface as 500 with log.error", async () => {
+		const app = setupApp(() => {
+			throw new Error("database exploded")
+		})
+
+		const res = await app.request("/test")
+
+		expect(res.status).toBe(500)
+		expect(log.error).toHaveBeenCalledWith(
+			"GET /test returned 500",
+			expect.objectContaining({method: "GET", path: "/test", status: 500}),
+		)
+	})
+
+	it("successful requests log info as before", async () => {
+		const app = setupApp(() => new Response("ok", {status: 200}))
+
+		const res = await app.request("/test")
+
+		expect(res.status).toBe(200)
+		expect(log.info).toHaveBeenCalledWith("GET /test completed", expect.objectContaining({status: 200}))
+		expect(log.warn).not.toHaveBeenCalled()
+		expect(log.error).not.toHaveBeenCalled()
+	})
+})

--- a/api/src/middleware/__tests__/requestLogging.test.ts
+++ b/api/src/middleware/__tests__/requestLogging.test.ts
@@ -11,6 +11,30 @@ vi.mock("../../services/telemetry", () => ({
 	},
 }))
 
+// Capture span status / attribute calls so we can assert them. The middleware
+// calls trace.getTracer(...).startSpan(...) at request time.
+const spanSetStatus = vi.fn()
+const spanSetAttribute = vi.fn()
+const spanEnd = vi.fn()
+vi.mock("@opentelemetry/api", async () => {
+	const actual = await vi.importActual<typeof import("@opentelemetry/api")>("@opentelemetry/api")
+	return {
+		...actual,
+		trace: {
+			...actual.trace,
+			getTracer: () => ({
+				startSpan: () => ({
+					setStatus: spanSetStatus,
+					setAttribute: spanSetAttribute,
+					end: spanEnd,
+					spanContext: () => ({traceId: "0".repeat(32), spanId: "0".repeat(16), traceFlags: 0}),
+				}),
+			}),
+		},
+	}
+})
+
+import {SpanStatusCode} from "@opentelemetry/api"
 import {log} from "../../services/telemetry"
 import {canonicalRequestLogging, isClientAbortError, requestId} from "../requestLogging"
 
@@ -134,5 +158,47 @@ describe("canonicalRequestLogging — client abort handling", () => {
 		expect(log.info).toHaveBeenCalledWith("GET /test completed", expect.objectContaining({status: 200}))
 		expect(log.warn).not.toHaveBeenCalled()
 		expect(log.error).not.toHaveBeenCalled()
+	})
+})
+
+describe("canonicalRequestLogging — span status", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it("does NOT mark span as ERROR for 499 (client abort)", async () => {
+		const app = setupApp(() => {
+			throw makeAbortError()
+		})
+		await app.request("/test")
+
+		// Critical: SentrySpanProcessor turns ERROR spans into failed
+		// transactions in the Sentry Performance dashboard. Client aborts
+		// must not pollute that signal.
+		expect(spanSetStatus).not.toHaveBeenCalled()
+		expect(spanSetAttribute).toHaveBeenCalledWith("http.status_code", 499)
+	})
+
+	it("DOES mark span as ERROR for genuine 5xx", async () => {
+		const app = setupApp(() => {
+			throw new Error("database exploded")
+		})
+		await app.request("/test")
+
+		expect(spanSetStatus).toHaveBeenCalledWith({code: SpanStatusCode.ERROR, message: "HTTP 500"})
+	})
+
+	it("DOES mark span as ERROR for 4xx (non-499)", async () => {
+		const app = setupApp(() => new Response("bad", {status: 400}))
+		await app.request("/test")
+
+		expect(spanSetStatus).toHaveBeenCalledWith({code: SpanStatusCode.ERROR, message: "HTTP 400"})
+	})
+
+	it("does NOT mark span as ERROR for 2xx", async () => {
+		const app = setupApp(() => new Response("ok", {status: 200}))
+		await app.request("/test")
+
+		expect(spanSetStatus).not.toHaveBeenCalled()
 	})
 })

--- a/api/src/middleware/requestLogging.ts
+++ b/api/src/middleware/requestLogging.ts
@@ -16,6 +16,29 @@ import {log} from "../services/telemetry"
 import {extractClientIp} from "../utils/clientIp"
 
 /**
+ * HTTP status code used for "client closed request" — matches nginx's
+ * `499` convention. The client is already gone, so the status is purely
+ * for our own metrics/logs (it never reaches a wire).
+ */
+const CLIENT_CLOSED_REQUEST_STATUS = 499
+
+/**
+ * Detect a client-side connection-close. graphql-yoga's
+ * `useExecutionCancellation` propagates the request's AbortSignal as a
+ * `DOMException` with `name === "AbortError"` and `code === 20` (ABORT_ERR).
+ * Node's stdlib variant uses `code === "ABORT_ERR"`. Treat all of these as
+ * "the client hung up" — they are not server faults.
+ */
+export function isClientAbortError(error: unknown): boolean {
+	if (typeof error !== "object" || error === null) return false
+	const candidate = error as {name?: unknown; code?: unknown}
+	if (candidate.name === "AbortError") return true
+	if (candidate.code === 20) return true
+	if (candidate.code === "ABORT_ERR") return true
+	return false
+}
+
+/**
  * Extract or generate a request ID.
  * Checks common headers, falls back to generating a UUID.
  */
@@ -132,7 +155,12 @@ export function canonicalRequestLogging() {
 				// Canonical END log — promote to error level for 5xx responses
 				// so handlers that return a 5xx without throwing (e.g. c.text("…", 500),
 				// GraphQL errors surfaced by graphql-yoga) still produce a Sentry
-				// issue. The catch branch below handles the throwing path.
+				// issue.
+				//
+				// Status 499 is reserved for "client closed request" — set by
+				// `app.onError` in main.ts when an AbortError bubbles up. These
+				// are not server faults; log as `warn` (breadcrumb only, no Sentry
+				// issue) so dashboards stop counting them as 5xx.
 				const endLogFields = {
 					requestId,
 					method,
@@ -141,7 +169,9 @@ export function canonicalRequestLogging() {
 					durationMs: duration,
 					...(graphqlOperationName ? {graphqlOperationName} : {}),
 				}
-				if (status >= 500) {
+				if (status === CLIENT_CLOSED_REQUEST_STATUS) {
+					log.warn(`${method} ${path} aborted by client`, endLogFields)
+				} else if (status >= 500) {
 					log.error(`${method} ${path} returned ${status}`, endLogFields)
 				} else {
 					log.info(`${method} ${path} completed`, endLogFields)

--- a/api/src/middleware/requestLogging.ts
+++ b/api/src/middleware/requestLogging.ts
@@ -159,12 +159,9 @@ export function canonicalRequestLogging() {
 				// Canonical END log — promote to error level for 5xx responses
 				// so handlers that return a 5xx without throwing (e.g. c.text("…", 500),
 				// GraphQL errors surfaced by graphql-yoga) still produce a Sentry
-				// issue.
-				//
-				// Status 499 is reserved for "client closed request" — set by
-				// `app.onError` in main.ts when an AbortError bubbles up. These
-				// are not server faults; log as `warn` (breadcrumb only, no Sentry
-				// issue) so dashboards stop counting them as 5xx.
+				// issue. 499 (client closed request, set by `app.onError` for
+				// AbortErrors) falls through to the default info path — the status
+				// field is enough; we don't want to flood logs for non-faults.
 				const endLogFields = {
 					requestId,
 					method,
@@ -173,9 +170,7 @@ export function canonicalRequestLogging() {
 					durationMs: duration,
 					...(graphqlOperationName ? {graphqlOperationName} : {}),
 				}
-				if (status === CLIENT_CLOSED_REQUEST_STATUS) {
-					log.warn(`${method} ${path} aborted by client`, endLogFields)
-				} else if (status >= 500) {
+				if (status >= 500) {
 					log.error(`${method} ${path} returned ${status}`, endLogFields)
 				} else {
 					log.info(`${method} ${path} completed`, endLogFields)

--- a/api/src/middleware/requestLogging.ts
+++ b/api/src/middleware/requestLogging.ts
@@ -129,15 +129,23 @@ export function canonicalRequestLogging() {
 					span.setStatus({code: SpanStatusCode.ERROR, message: `HTTP ${status}`})
 				}
 
-				// Canonical END log
-				log.info(`${method} ${path} completed`, {
+				// Canonical END log — promote to error level for 5xx responses
+				// so handlers that return a 5xx without throwing (e.g. c.text("…", 500),
+				// GraphQL errors surfaced by graphql-yoga) still produce a Sentry
+				// issue. The catch branch below handles the throwing path.
+				const endLogFields = {
 					requestId,
 					method,
 					path,
 					status,
 					durationMs: duration,
 					...(graphqlOperationName ? {graphqlOperationName} : {}),
-				})
+				}
+				if (status >= 500) {
+					log.error(`${method} ${path} returned ${status}`, endLogFields)
+				} else {
+					log.info(`${method} ${path} completed`, endLogFields)
+				}
 			} catch (error) {
 				const duration = Date.now() - startTime
 				const failureClass = detectDbFailureClass(error)

--- a/api/src/middleware/requestLogging.ts
+++ b/api/src/middleware/requestLogging.ts
@@ -148,7 +148,11 @@ export function canonicalRequestLogging() {
 					span.setAttribute("graphql.operation_name", graphqlOperationName)
 				}
 
-				if (status >= 400) {
+				// 499 is "client closed request" — by design not a server fault, so
+				// leave the span Unset (OK). Otherwise SentrySpanProcessor would
+				// flag the transaction as failed and inflate error-rate metrics
+				// alongside genuine 4xx/5xx responses.
+				if (status >= 400 && status !== CLIENT_CLOSED_REQUEST_STATUS) {
 					span.setStatus({code: SpanStatusCode.ERROR, message: `HTTP ${status}`})
 				}
 

--- a/api/src/services/ipfs.ts
+++ b/api/src/services/ipfs.ts
@@ -29,10 +29,10 @@ export function uploadEdit(file: File) {
 		const run = Effect.gen(function* () {
 			yield* Ref.update(attemptRef, (n) => n + 1)
 
-			const blob = new Blob([file], {type: "application/octet-stream"})
+			// No Blob wrap — aligns with Pinata's SDK.
 			const formData = new FormData()
 			formData.append("network", "public")
-			formData.append("file", blob, file.name || "edit.bin")
+			formData.append("file", file, file.name || "edit.bin")
 
 			const hash = yield* upload(formData, config.ipfsGatewayWrite)
 			yield* validateCid(hash)

--- a/api/src/services/telemetry.ts
+++ b/api/src/services/telemetry.ts
@@ -35,6 +35,19 @@ function initSentry() {
 		tracesSampleRate,
 		skipOpenTelemetrySetup: true, // We manage OTEL setup ourselves
 		debug,
+		// Drop client-disconnect events. graphql-yoga's response stream throws a
+		// DOMException (name="AbortError", code=20) when the client closes the
+		// socket mid-write; Sentry's auto-capture of unhandled rejections would
+		// otherwise create issues for what isn't a server fault. Synchronous
+		// AbortErrors are also handled at the HTTP layer via `app.onError` →
+		// 499; this filter is the safety net for the async path.
+		beforeSend: (event, hint) => {
+			const err = hint?.originalException as {name?: unknown; code?: unknown} | undefined
+			if (err && (err.name === "AbortError" || err.code === 20 || err.code === "ABORT_ERR")) {
+				return null
+			}
+			return event
+		},
 	})
 
 	// Set up a minimal global TracerProvider for non-Effect code (GraphQL, HTTP middleware).


### PR DESCRIPTION
## Summary

Client-side disconnects (browser navigation, React unmount, `AbortController.abort()`, ingress closing the connection mid-response) were producing 500s in dashboards and Sentry issues with the message `AbortError: The connection was closed.`. They aren't server faults — fix at three layers:

1. **`app.onError` in main.ts** — detect AbortError and return **499** (nginx convention for "client closed request") instead of letting Hono's default handler synthesize a 500.
2. **`canonicalRequestLogging`** — recognize `status === 499` and log as `warn` (\"aborted by client\") with duration; never as `error` (which would route through `Sentry.captureMessage`).
3. **Sentry `beforeSend`** — drop `AbortError` events from auto-captured unhandled rejections. Some abort errors surface asynchronously after the response is returned and bypass the HTTP error path entirely; this is the safety net.

## Why three layers

I traced through Hono's `compose.js` and confirmed:
- The catch in `canonicalRequestLogging` is effectively unreachable in practice because Hono's compose dispatches every thrown `Error` through `app.onError` before unwinding.
- Some AbortErrors surface as **async unhandled rejections** from graphql-yoga's response stream — those bypass the HTTP middleware entirely and reach Sentry via the SDK's `process.on('unhandledRejection')` handler.

So the HTTP layer (1+2) and the Sentry layer (3) cover different paths.

## Behavior matrix

| event | status | log level | Sentry issue |
|---|---|---|---|
| client closes mid-response (sync via Hono) | **499** | warn | no |
| client closes mid-response (async unhandled rejection) | (no HTTP impact) | — | **no** (filtered) |
| genuine server error | 500 | error | yes |
| successful request | 2xx | info | no |

## Test plan

- [x] 8 new unit tests in \`src/middleware/__tests__/requestLogging.test.ts\`:
  - \`isClientAbortError\` recognizes DOMException-shape (code 20), Node-style (code \"ABORT_ERR\"), name-only
  - rejects arbitrary errors / null / undefined / strings
  - end-to-end: AbortError throw → 499 + log.warn + no log.error
  - Node-style AbortError → same
  - non-abort errors still 500 + log.error
  - successful requests still log info
- [x] \`bun run ci\` clean (typecheck + biome)