### PR TITLE
feat(api): improve GraphQL query cost telemetry

### DIFF
--- a/api/src/kg/__tests__/costLoggerPlugin.test.ts
+++ b/api/src/kg/__tests__/costLoggerPlugin.test.ts
@@ -336,6 +336,11 @@ describe("computeQueryCost — operation selection, directives, and SQL-risk sig
 		expect(rawCost(`{ entities(first: 25, offset: 100) { id } }`)).toBe(378n)
 	})
 
+	it("treats offset zero as a valid no-skip value", () => {
+		expect(rawCost(`{ entities(first: 25) { id } }`)).toBe(26n)
+		expect(rawCost(`{ entities(first: 25, offset: 0) { id } }`)).toBe(26n)
+	})
+
 	it("charges totalCount as an extra connection-wide count", () => {
 		expect(rawCost(`{ entitiesConnection(first: 1) { totalCount } }`)).toBe(10_001n)
 		expect(cost(`{ entitiesConnection(first: 1) { totalCount } }`)).toBe(40)

--- a/api/src/kg/__tests__/costLoggerPlugin.test.ts
+++ b/api/src/kg/__tests__/costLoggerPlugin.test.ts
@@ -1,10 +1,22 @@
 import {parse} from "graphql"
-import {beforeEach, describe, expect, it} from "vitest"
+import {beforeEach, describe, expect, it, vi} from "vitest"
+
+// Mock Sentry so we can assert on the new metric emission without a real
+// Sentry init. Order matters: this mock must precede the import of the
+// module under test.
+vi.mock("@sentry/node", () => ({
+	metrics: {
+		distribution: vi.fn(),
+	},
+}))
+
+import * as Sentry from "@sentry/node"
 import {
 	__resetQueryCostHistogramForTests,
 	compressCost,
 	computeQueryCost,
 	computeQueryCostRaw,
+	GRAPHQL_QUERY_COST_CONTEXT_KEY,
 	renderQueryCostHistogram,
 	useCostLogger,
 } from "../costLoggerPlugin"
@@ -396,6 +408,90 @@ describe("query cost histogram", () => {
 			},
 		})
 		expect(renderQueryCostHistogram()).toContain("gaia_api_graphql_query_cost_count 0")
+	})
+})
+
+// --------------------------------------------------------------------------
+// Sentry metric emission + cross-plugin cost sharing via contextValue
+// --------------------------------------------------------------------------
+
+describe("useCostLogger — Sentry metric + context cost-sharing", () => {
+	beforeEach(() => {
+		__resetQueryCostHistogramForTests()
+		vi.clearAllMocks()
+	})
+
+	it("emits a Sentry distribution metric on every (non-introspection) query", () => {
+		const plugin = useCostLogger()
+		const onExecute = (plugin as {onExecute: (args: unknown) => void}).onExecute
+		onExecute({
+			args: {
+				document: parse(`{ entity(id: "...") { id name } }`),
+				variableValues: {},
+				operationName: null,
+				contextValue: {},
+			},
+		})
+
+		expect(Sentry.metrics.distribution).toHaveBeenCalledTimes(1)
+		expect(Sentry.metrics.distribution).toHaveBeenCalledWith(
+			"graphql.query_cost",
+			expect.any(Number),
+			expect.objectContaining({attributes: expect.objectContaining({operation: "query entity"})}),
+		)
+	})
+
+	it("does not emit a Sentry metric for introspection queries", () => {
+		const plugin = useCostLogger()
+		const onExecute = (plugin as {onExecute: (args: unknown) => void}).onExecute
+		onExecute({
+			args: {
+				document: parse(`{ __typename }`),
+				variableValues: {},
+				operationName: "IntrospectionQuery",
+				contextValue: {},
+			},
+		})
+
+		expect(Sentry.metrics.distribution).not.toHaveBeenCalled()
+	})
+
+	it("stashes cost on contextValue for downstream plugins to read", () => {
+		const plugin = useCostLogger()
+		const onExecute = (plugin as {onExecute: (args: unknown) => void}).onExecute
+		const ctx: Record<string, unknown> = {}
+
+		onExecute({
+			args: {
+				document: parse(`{ entity(id: "...") { id name } }`),
+				variableValues: {},
+				operationName: null,
+				contextValue: ctx,
+			},
+		})
+
+		// Same compressed score the histogram bucketing test asserts (33 for
+		// a simple entity lookup).
+		expect(ctx[GRAPHQL_QUERY_COST_CONTEXT_KEY]).toBe(33)
+	})
+
+	it("does not stash cost when computation fails (shadow-mode safety)", () => {
+		const plugin = useCostLogger()
+		const onExecute = (plugin as {onExecute: (args: unknown) => void}).onExecute
+		const ctx: Record<string, unknown> = {}
+
+		onExecute({
+			args: {
+				// biome-ignore lint/suspicious/noExplicitAny: deliberately malformed
+				document: null as any,
+				variableValues: {},
+				operationName: null,
+				contextValue: ctx,
+			},
+		})
+
+		expect(ctx[GRAPHQL_QUERY_COST_CONTEXT_KEY]).toBeUndefined()
+		expect(Sentry.metrics.distribution).not.toHaveBeenCalled()
 	})
 })
 

--- a/api/src/kg/__tests__/costLoggerPlugin.test.ts
+++ b/api/src/kg/__tests__/costLoggerPlugin.test.ts
@@ -20,13 +20,14 @@ import {
 	renderQueryCostHistogram,
 	useCostLogger,
 } from "../costLoggerPlugin"
-import {MAX_PAGINATION_LIMIT} from "../paginationCapPlugin"
 
 /** Compressed-score helper (what gets recorded and logged). */
-const cost = (query: string, variables: Record<string, unknown> = {}) => computeQueryCost(parse(query), variables)
+const cost = (query: string, variables: Record<string, unknown> = {}, operationName?: string) =>
+	computeQueryCost(parse(query), variables, operationName)
 
 /** Raw BigInt-cost helper — for tests that care about the exact multiplier math. */
-const rawCost = (query: string, variables: Record<string, unknown> = {}) => computeQueryCostRaw(parse(query), variables)
+const rawCost = (query: string, variables: Record<string, unknown> = {}, operationName?: string) =>
+	computeQueryCostRaw(parse(query), variables, operationName)
 
 // --------------------------------------------------------------------------
 // compressCost — log₁₀×10 compression primitive
@@ -76,8 +77,8 @@ describe("computeQueryCost — compressed scores", () => {
 	})
 
 	it("simple single-entity lookup → ~30", () => {
-		// raw = 1000 × 2 + 1 = 2001, log10 ≈ 3.301 → 33
-		expect(cost(`{ entity(id: "...") { id name } }`)).toBe(33)
+		// raw = 1000 × (id=1 + name=2) + 1 = 3001, log10 ≈ 3.477 → 35
+		expect(cost(`{ entity(id: "...") { id name } }`)).toBe(35)
 	})
 
 	it("first:50 single scalar → 17", () => {
@@ -90,10 +91,11 @@ describe("computeQueryCost — compressed scores", () => {
 		expect(cost(`{ entities(last: 25) { id } }`)).toBe(14)
 	})
 
-	it("nested-list with explicit pagination → 24", () => {
+	it("nested-list with explicit pagination → 30", () => {
 		// inner relations(first:10){id} = 11
-		// outer entities(first:20){id + inner} = 20 × (1 + 11) + 1 = 241
-		// log10(241) ≈ 2.382 → 24
+		// relations payload factor = ×4, so inner = 44
+		// outer entities(first:20){id + inner} = 20 × (1 + 44) + 1 = 901
+		// log10(901) ≈ 2.955 → 30
 		expect(
 			cost(`{
 				entities(first: 20) {
@@ -101,7 +103,7 @@ describe("computeQueryCost — compressed scores", () => {
 					relations(first: 10) { id }
 				}
 			}`),
-		).toBe(24)
+		).toBe(30)
 	})
 })
 
@@ -110,7 +112,7 @@ describe("computeQueryCost — compressed scores", () => {
 // --------------------------------------------------------------------------
 
 describe("computeQueryCostRaw — multiplier math", () => {
-	it("explicit-pagination nested: `entities(first:20) { id, relations(first:10){id} }` → 241n", () => {
+	it("explicit-pagination nested: `entities(first:20) { id, relations(first:10){id} }` → 901n", () => {
 		expect(
 			rawCost(`{
 				entities(first: 20) {
@@ -118,14 +120,15 @@ describe("computeQueryCostRaw — multiplier math", () => {
 					relations(first: 10) { id }
 				}
 			}`),
-		).toBe(241n)
+		).toBe(901n)
 	})
 
 	it("implicit-default heavy query: three unpaginated levels compound at 1000×", () => {
-		// valuesList { 2 scalars }             = 1000 × 2 + 1   = 2001
-		// toEntity { valuesList }              = 1000 × 2001 + 1 = 2_001_001
-		// relationsList { toEntity }           = 1000 × 2_001_001 + 1 = 2_001_001_001
-		// entities { id, relationsList }       = 1000 × 2_001_001_002 + 1 = 2_001_001_002_001
+		// Payload-size risk now matters too:
+		// - text scalar is heavier than id-like fields
+		// - valuesList / relationsList have response-size factors
+		// - nested toEntity is a duplication path
+		// - broad cap-sized root entities gets root SQL + payload factors
 		expect(
 			rawCost(`{
 				entities {
@@ -135,7 +138,7 @@ describe("computeQueryCostRaw — multiplier math", () => {
 					}
 				}
 			}`),
-		).toBe(2_001_001_002_001n)
+		).toBe(46_801_800_360_150_030n)
 	})
 
 	it("real prod shape: `entitiesConnection` with 3-level nested relations", () => {
@@ -186,13 +189,13 @@ describe("computeQueryCostRaw — multiplier math", () => {
 			}
 		`
 		const raw = rawCost(query, {type: ["7ed45f2bc48b419e8e4664d5ff680b0d"], first: 1000, after: null})
-		// Raw is a 22-digit BigInt. Exact value is stable across runs since
-		// the walker is deterministic.
-		expect(raw.toString().length).toBeGreaterThanOrEqual(22)
-		expect(raw.toString().length).toBeLessThanOrEqual(23)
-		// Compressed score of the prod cap-hitter: ~220 (≈10²² raw cost).
-		expect(compressCost(raw)).toBeGreaterThanOrEqual(215)
-		expect(compressCost(raw)).toBeLessThanOrEqual(225)
+		// Raw now includes SQL-risk and payload-size factors: broad root
+		// collection, relation filter, cursor pagination, values/relations
+		// fan-out, entity duplication, and cap-sized root page.
+		expect(raw.toString().length).toBeGreaterThanOrEqual(28)
+		expect(raw.toString().length).toBeLessThanOrEqual(29)
+		expect(compressCost(raw)).toBeGreaterThanOrEqual(270)
+		expect(compressCost(raw)).toBeLessThanOrEqual(280)
 	})
 })
 
@@ -202,56 +205,54 @@ describe("computeQueryCostRaw — multiplier math", () => {
 // --------------------------------------------------------------------------
 
 describe("computeQueryCost — adversarial inputs", () => {
-	it("50-level deeply nested `entities(first:1000)` → score ~1500, no throw", () => {
-		// raw = 1000^50 ≈ 10^150 → compressed = 1500.
+	it("50-level deeply nested `entities(first:1000)` → score ~1515, no throw", () => {
+		// raw is still dominated by 1000^50; root payload factors add about 15 points.
 		let q = "{ id }"
 		for (let i = 0; i < 50; i++) q = `{ entities(first: 1000) ${q} }`
 		const c = cost(q)
 		expect(Number.isFinite(c)).toBe(true)
-		expect(c).toBeGreaterThanOrEqual(1500)
-		expect(c).toBeLessThanOrEqual(1510)
+		expect(c).toBeGreaterThanOrEqual(1510)
+		expect(c).toBeLessThanOrEqual(1520)
 	})
 
 	it("100-level nesting — BigInt walker handles it, score scales linearly with depth", () => {
-		// raw = 1000^100 = 10^300 → compressed = 3000.
+		// raw is still dominated by 1000^100; root payload factors add about 15 points.
 		let q = "{ id }"
 		for (let i = 0; i < 100; i++) q = `{ entities(first: 1000) ${q} }`
 		const c = cost(q)
-		expect(c).toBeGreaterThanOrEqual(3000)
-		expect(c).toBeLessThanOrEqual(3010)
+		expect(c).toBeGreaterThanOrEqual(3010)
+		expect(c).toBeLessThanOrEqual(3020)
 	})
 
 	it("wide fan-out: 100 sibling aliased collections → modest score, linear in width", () => {
-		// Each sibling: entities(first:1000){id} = 1001 → 100 siblings sum = ~100_100.
-		// log10(100_100) ≈ 5.0 → compressed ≈ 50.
+		// Each sibling is root cap-sized and gets root page factors; still
+		// linear in width rather than multiplicative across aliases.
 		const aliases = Array.from({length: 100}, (_, i) => `a${i}: entities(first: 1000) { id }`).join(" ")
 		const c = cost(`{ ${aliases} }`)
-		expect(c).toBeGreaterThanOrEqual(45)
-		expect(c).toBeLessThanOrEqual(55)
+		expect(c).toBeGreaterThanOrEqual(60)
+		expect(c).toBeLessThanOrEqual(70)
 	})
 
 	it("attacker attempts `first: 0` to sneak nested work past the estimator", () => {
 		// first:0 is non-positive → fallback to MAX_PAGINATION_LIMIT. Nested
 		// relations(first:50){id} still charged.
-		// inner = 51, outer = 1000 × (1 + 51) + 1 = 52001 → compressed ~47.
+		// relations payload factor and root cap-sized payload factor both apply.
 		const raw = rawCost(`{
 			entities(first: 0) {
 				id
 				relations(first: 50) { id }
 			}
 		}`)
-		expect(raw).toBe(BigInt(MAX_PAGINATION_LIMIT) * 52n + 1n)
-		expect(compressCost(raw)).toBe(47)
+		expect(raw).toBe(6_150_030n)
+		expect(compressCost(raw)).toBe(68)
 	})
 
 	it("attacker attempts negative `first`", () => {
-		expect(rawCost(`{ entities(first: -100) { id } }`)).toBe(BigInt(MAX_PAGINATION_LIMIT) + 1n)
+		expect(rawCost(`{ entities(first: -100) { id } }`)).toBe(30_030n)
 	})
 
 	it("unresolved variable in `first:` falls back to MAX_PAGINATION_LIMIT", () => {
-		expect(rawCost(`query Q($first: Int) { entities(first: $first) { id } }`, {})).toBe(
-			BigInt(MAX_PAGINATION_LIMIT) + 1n,
-		)
+		expect(rawCost(`query Q($first: Int) { entities(first: $first) { id } }`, {})).toBe(30_030n)
 	})
 
 	it("fragment cycle terminates cleanly (defence-in-depth vs skipped validation)", () => {
@@ -286,12 +287,13 @@ describe("computeQueryCost — adversarial inputs", () => {
 
 describe("computeQueryCost — pagination + variables", () => {
 	it("resolves pagination args supplied via variables", () => {
-		expect(rawCost(`query Q($first: Int!) { entities(first: $first) { id } }`, {first: 100})).toBe(101n)
+		expect(rawCost(`query Q($first: Int!) { entities(first: $first) { id } }`, {first: 100})).toBe(303n)
 	})
 
 	it("sibling with negative outer still charges for valid nested first", () => {
 		// Inner relations(first:50){id} = 51.
-		// Outer entities(first:-5) → MAX_PAGINATION_LIMIT × (1 + 51) + 1 = 52_001
+		// Outer invalid first falls back to cap; relation payload and root page
+		// factors both apply.
 		expect(
 			rawCost(`{
 				entities(first: -5) {
@@ -299,7 +301,109 @@ describe("computeQueryCost — pagination + variables", () => {
 					relations(first: 50) { id }
 				}
 			}`),
-		).toBe(BigInt(MAX_PAGINATION_LIMIT) * 52n + 1n)
+		).toBe(6_150_030n)
+	})
+})
+
+// --------------------------------------------------------------------------
+// Operation selection, directives, and SQL-risk signals
+// --------------------------------------------------------------------------
+
+describe("computeQueryCost — operation selection, directives, and SQL-risk signals", () => {
+	it("uses the selected operationName instead of always walking the first operation", () => {
+		const query = `
+			query Cheap { entities(first: 1) { id } }
+			query Expensive { entities(first: 1000) { id } }
+		`
+		expect(rawCost(query, {}, "Cheap")).toBe(2n)
+		expect(rawCost(query, {}, "Expensive")).toBe(30_030n)
+	})
+
+	it("honors @skip and @include when variable values are available", () => {
+		const query = `
+			query Q($includeRelations: Boolean!) {
+				entities(first: 10) {
+					id
+					relations(first: 50) @include(if: $includeRelations) { id }
+				}
+			}
+		`
+		expect(rawCost(query, {includeRelations: false})).toBe(11n)
+		expect(rawCost(query, {includeRelations: true})).toBe(2_051n)
+	})
+
+	it("charges offset as skipped rows plus returned rows", () => {
+		expect(rawCost(`{ entities(first: 25, offset: 100) { id } }`)).toBe(378n)
+	})
+
+	it("charges totalCount as an extra connection-wide count", () => {
+		expect(rawCost(`{ entitiesConnection(first: 1) { totalCount } }`)).toBe(10_001n)
+		expect(cost(`{ entitiesConnection(first: 1) { totalCount } }`)).toBe(40)
+	})
+
+	it("adds SQL-risk factor for expensive string filter operators", () => {
+		const cheap = rawCost(`{ entitiesConnection(first: 20) { nodes { id } } }`)
+		const expensive = rawCost(`{
+			entitiesConnection(first: 20, filter: { name: { includesInsensitive: "geo" } }) {
+				nodes { id }
+			}
+		}`)
+		expect(expensive).toBeGreaterThan(cheap * 1_000n)
+		expect(compressCost(expensive)).toBeGreaterThan(compressCost(cheap) + 25)
+	})
+
+	it("adds SQL-risk factor for overlaps filters", () => {
+		const cheap = rawCost(`{ entitiesConnection(first: 20) { nodes { id } } }`)
+		const expensive = rawCost(`{
+			entitiesConnection(first: 20, filter: { spaceIds: { overlaps: ["00000000000000000000000000000000"] } }) {
+				nodes { id }
+			}
+		}`)
+		expect(expensive).toBeGreaterThan(cheap * 500n)
+	})
+
+	it("adds field/argument weights for known expensive GraphQL fields and orderings", () => {
+		expect(cost(`{ search(query: "geo", first: 10) { id } }`)).toBeGreaterThan(20)
+		expect(
+			cost(`{ entitiesOrderedByProperty(propertyId: "00000000000000000000000000000000", first: 10) { id } }`),
+		).toBeGreaterThan(25)
+		expect(cost(`{ valuesConnection(orderBy: RAW_SCORE_DESC, first: 5) { nodes { id } } }`)).toBeGreaterThan(60)
+	})
+
+	it("adds payload-size cost for large entity pages with heavy scalar fields", () => {
+		const leanPage = cost(`{ entitiesConnection(first: 1000) { nodes { id } } }`)
+		const payloadHeavyPage = cost(`{
+			entitiesConnection(first: 1000) {
+				nodes {
+					id
+					name
+					description
+					values(first: 50) {
+						nodes { text schedule embedding bytes }
+					}
+					relations(first: 100) {
+						nodes {
+							toEntity {
+								id
+								name
+								description
+								values(first: 5) { nodes { text } }
+							}
+						}
+					}
+				}
+			}
+		}`)
+
+		expect(leanPage).toBe(75)
+		expect(payloadHeavyPage).toBeGreaterThanOrEqual(220)
+		expect(payloadHeavyPage).toBeGreaterThan(leanPage + 100)
+	})
+
+	it("adds a step-up payload factor for large root entitiesConnection pages", () => {
+		expect(rawCost(`{ entitiesConnection(first: 99) { nodes { id } } }`)).toBe(99_100n)
+		expect(rawCost(`{ entitiesConnection(first: 100) { nodes { id } } }`)).toBe(300_303n)
+		expect(rawCost(`{ entitiesConnection(first: 500) { nodes { id } } }`)).toBe(15_015_030n)
 	})
 })
 
@@ -310,8 +414,8 @@ describe("computeQueryCost — pagination + variables", () => {
 describe("computeQueryCost — fragments", () => {
 	it("inline fragments contribute to parent's childComplexity", () => {
 		// entities(first:10) { ... on Entity { id name } }
-		// inline frag = 2 → 10 × 2 + 1 = 21
-		expect(rawCost(`{ entities(first: 10) { ... on Entity { id name } } }`)).toBe(21n)
+		// inline frag = id(1) + name(2) → 10 × 3 + 1 = 31
+		expect(rawCost(`{ entities(first: 10) { ... on Entity { id name } } }`)).toBe(31n)
 	})
 
 	it("fragment spreads follow the definition", () => {
@@ -320,7 +424,7 @@ describe("computeQueryCost — fragments", () => {
 				query { entities(first: 10) { ...F } }
 				fragment F on Entity { id name }
 			`),
-		).toBe(21n)
+		).toBe(31n)
 	})
 
 	it("allows a fragment to be used multiple times at sibling positions (not a cycle)", () => {
@@ -370,13 +474,13 @@ describe("query cost histogram", () => {
 
 		// Score 0 — trivial.
 		runQuery(`{ __typename }`)
-		// Score 33 — simple entity.
+		// Score 35 — simple entity with `name` weighted as a larger scalar.
 		runQuery(`{ entity(id: "...") { id name } }`)
 
 		const out = renderQueryCostHistogram()
 		expect(out).toContain("gaia_api_graphql_query_cost_count 2")
-		expect(out).toContain(`gaia_api_graphql_query_cost_sum ${0 + 33}`)
-		// le=30: only the trivial observation (33 > 30)
+		expect(out).toContain(`gaia_api_graphql_query_cost_sum ${0 + 35}`)
+		// le=30: only the trivial observation (35 > 30)
 		expect(out).toMatch(/gaia_api_graphql_query_cost_bucket\{le="30"} 1$/m)
 		// le=60: both
 		expect(out).toMatch(/gaia_api_graphql_query_cost_bucket\{le="60"} 2$/m)
@@ -402,12 +506,25 @@ describe("query cost histogram", () => {
 		const onExecute = (plugin as {onExecute: (args: unknown) => void}).onExecute
 		onExecute({
 			args: {
-				document: parse(`{ __typename }`),
+				document: parse(`query IntrospectionQuery { __schema { queryType { name } } }`),
 				variableValues: {},
 				operationName: "IntrospectionQuery",
 			},
 		})
 		expect(renderQueryCostHistogram()).toContain("gaia_api_graphql_query_cost_count 0")
+	})
+
+	it("does not skip a normal query just because it is named IntrospectionQuery", () => {
+		const plugin = useCostLogger()
+		const onExecute = (plugin as {onExecute: (args: unknown) => void}).onExecute
+		onExecute({
+			args: {
+				document: parse(`query IntrospectionQuery { entity(id: "...") { id name } }`),
+				variableValues: {},
+				operationName: "IntrospectionQuery",
+			},
+		})
+		expect(renderQueryCostHistogram()).toContain("gaia_api_graphql_query_cost_count 1")
 	})
 })
 
@@ -446,7 +563,7 @@ describe("useCostLogger — Sentry metric + context cost-sharing", () => {
 		const onExecute = (plugin as {onExecute: (args: unknown) => void}).onExecute
 		onExecute({
 			args: {
-				document: parse(`{ __typename }`),
+				document: parse(`query IntrospectionQuery { __schema { queryType { name } } }`),
 				variableValues: {},
 				operationName: "IntrospectionQuery",
 				contextValue: {},
@@ -470,9 +587,9 @@ describe("useCostLogger — Sentry metric + context cost-sharing", () => {
 			},
 		})
 
-		// Same compressed score the histogram bucketing test asserts (33 for
+		// Same compressed score the histogram bucketing test asserts (35 for
 		// a simple entity lookup).
-		expect(ctx[GRAPHQL_QUERY_COST_CONTEXT_KEY]).toBe(33)
+		expect(ctx[GRAPHQL_QUERY_COST_CONTEXT_KEY]).toBe(35)
 	})
 
 	it("does not stash cost when computation fails (shadow-mode safety)", () => {

--- a/api/src/kg/__tests__/instrumentationPlugin.test.ts
+++ b/api/src/kg/__tests__/instrumentationPlugin.test.ts
@@ -1,6 +1,27 @@
-import {type ASTNode, GraphQLError, Kind} from "graphql"
-import {describe, expect, it} from "vitest"
-import {isClientError} from "../instrumentationPlugin"
+import {type ASTNode, GraphQLError, Kind, parse} from "graphql"
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest"
+
+// Mock telemetry so we can assert what gets logged. Must precede the import
+// of the plugin. `log` is destructured at call-time by the plugin, so this
+// stub reaches into the same module.
+vi.mock("../../services/telemetry", () => ({
+	log: {
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	},
+}))
+
+// Mock Sentry to prevent real network calls + so we can ignore captureException.
+vi.mock("@sentry/node", () => ({
+	captureException: vi.fn(),
+	metrics: {distribution: vi.fn()},
+}))
+
+import {log} from "../../services/telemetry"
+import {GRAPHQL_QUERY_COST_CONTEXT_KEY} from "../costLoggerPlugin"
+import {isClientError, useGraphQLInstrumentation} from "../instrumentationPlugin"
 
 // Minimal AST-node factory — isClientError only reads `kind`, so the rest of
 // the shape doesn't matter. Cast through `unknown` to avoid TS insisting on a
@@ -137,5 +158,76 @@ describe("isClientError", () => {
 	it("does not flag null or undefined", () => {
 		expect(isClientError(null)).toBe(false)
 		expect(isClientError(undefined)).toBe(false)
+	})
+})
+
+// --------------------------------------------------------------------------
+// Slow-query / large-response logs include cost when stashed by useCostLogger
+// --------------------------------------------------------------------------
+
+describe("useGraphQLInstrumentation — query cost in slow / large logs", () => {
+	const SLOW_QUERY_THRESHOLD_MS = 3000
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		vi.useFakeTimers()
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+	})
+
+	function runRequest(opts: {durationMs: number; cost?: number; responseData?: unknown}) {
+		const plugin = useGraphQLInstrumentation()
+		const onExecute = (plugin as {onExecute: (args: unknown) => {onExecuteDone: (r: unknown) => void}}).onExecute
+
+		const ctx: Record<string, unknown> = {}
+		if (opts.cost !== undefined) {
+			ctx[GRAPHQL_QUERY_COST_CONTEXT_KEY] = opts.cost
+		}
+
+		const startTime = Date.now()
+		vi.setSystemTime(startTime)
+
+		const args = {
+			document: parse(`{ entity(id: "...") { id name } }`),
+			variableValues: {},
+			operationName: null,
+			contextValue: ctx,
+		}
+
+		const handle = onExecute({args})
+		vi.setSystemTime(startTime + opts.durationMs)
+		handle.onExecuteDone({result: {data: opts.responseData ?? {ok: true}}})
+	}
+
+	it("Slow GraphQL query log includes the cost field when context has it", () => {
+		runRequest({durationMs: SLOW_QUERY_THRESHOLD_MS + 1, cost: 235})
+
+		expect(log.warn).toHaveBeenCalledWith("Slow GraphQL query", expect.objectContaining({queryCost: 235}))
+	})
+
+	it("Slow GraphQL query log omits cost when context has none", () => {
+		runRequest({durationMs: SLOW_QUERY_THRESHOLD_MS + 1})
+
+		const slowCalls = (log.warn as ReturnType<typeof vi.fn>).mock.calls.filter((c) => c[0] === "Slow GraphQL query")
+		expect(slowCalls).toHaveLength(1)
+		const fields = slowCalls[0]?.[1]
+		expect(fields).not.toHaveProperty("queryCost")
+	})
+
+	it("Large GraphQL response log includes the cost field when context has it", () => {
+		// Build a response that stringifies to >1MB so the large-response branch fires.
+		const big = {data: "x".repeat(1_100_000)}
+		runRequest({durationMs: 1500, cost: 250, responseData: big})
+
+		expect(log.warn).toHaveBeenCalledWith("Large GraphQL response", expect.objectContaining({queryCost: 250}))
+	})
+
+	it("does not fire slow log under threshold", () => {
+		runRequest({durationMs: SLOW_QUERY_THRESHOLD_MS - 1, cost: 235})
+
+		const slowCalls = (log.warn as ReturnType<typeof vi.fn>).mock.calls.filter((c) => c[0] === "Slow GraphQL query")
+		expect(slowCalls).toHaveLength(0)
 	})
 })

--- a/api/src/kg/costLoggerPlugin.ts
+++ b/api/src/kg/costLoggerPlugin.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/node"
 import {
 	type ArgumentNode,
 	type DocumentNode,
@@ -13,6 +14,19 @@ import type {Plugin} from "graphql-yoga"
 import {graphqlQueryFingerprint} from "../services/queryFingerprint"
 import {log} from "../services/telemetry"
 import {MAX_PAGINATION_LIMIT} from "./paginationCapPlugin"
+
+/**
+ * Context-key used to share the per-request compressed cost score between
+ * `useCostLogger` (where it's computed) and `useGraphQLInstrumentation`
+ * (where it's attached to slow-query / large-response warnings so a 30s+
+ * report carries cost as context). Stashing on the yoga `contextValue`
+ * avoids recomputing in two plugins.
+ */
+export const GRAPHQL_QUERY_COST_CONTEXT_KEY = "graphqlQueryCost" as const
+
+export type GraphqlCostContext = {
+	[GRAPHQL_QUERY_COST_CONTEXT_KEY]?: number
+}
 
 // Parse a positive-integer env var, falling back to `fallback` on anything
 // non-finite or non-positive. Guards against deploy-time misconfiguration
@@ -256,14 +270,21 @@ function resolveValue(value: ValueNode, vars: Record<string, unknown>): unknown 
 }
 
 /**
- * Yoga plugin that computes query cost on every request. Two observability
- * channels, no alerts:
+ * Yoga plugin that computes query cost on every request. Three observability
+ * channels:
  *   - Prometheus histogram `gaia_api_graphql_query_cost` — records every
  *     query's compressed score; charted in Grafana for distribution.
+ *   - Sentry metric `graphql.query_cost` (distribution) — same value, tagged
+ *     by operation, lets Sentry surface cost percentiles next to its own
+ *     duration / error metrics. Sentry only — no issue is created here.
  *   - `log.warn("High GraphQL query cost", ...)` when score ≥
  *     `COST_LOG_THRESHOLD`. `log.warn` always writes to stdout (visible in
  *     kubectl + Axiom) *and* drops a Sentry breadcrumb, but does NOT create
  *     a Sentry issue.
+ *
+ * The cost is also stashed on the yoga `contextValue` under
+ * `GRAPHQL_QUERY_COST_CONTEXT_KEY` so `useGraphQLInstrumentation` can attach
+ * it to the slow-query / large-response warnings without recomputing.
  *
  * Phase 1 is strictly observational. The outer try/catch is a shadow-mode
  * safety invariant: a failure inside the plugin must never break the
@@ -288,12 +309,30 @@ export function useCostLogger(): Plugin {
 
 				recordQueryCost(cost)
 
+				const operationLabel = getOperationLabel(args)
+
+				// Sentry distribution metric — operation-tagged so dashboards can
+				// surface p50 / p95 / p99 cost per operation alongside duration.
+				// Cost is the compressed log10×10 score (dimensionless), so no unit.
+				Sentry.metrics.distribution("graphql.query_cost", cost, {
+					attributes: {operation: operationLabel},
+				})
+
+				// Stash on the request context so the instrumentation plugin can
+				// include cost in slow-query / large-response warnings without
+				// having to walk the AST again. `contextValue` is the same object
+				// passed through both plugins for a single request.
+				const ctx = args.contextValue as GraphqlCostContext | undefined
+				if (ctx && typeof ctx === "object") {
+					ctx[GRAPHQL_QUERY_COST_CONTEXT_KEY] = cost
+				}
+
 				if (cost >= COST_LOG_THRESHOLD) {
 					const fullQuery = print(args.document)
 					log.warn("High GraphQL query cost", {
 						cost,
 						threshold: COST_LOG_THRESHOLD,
-						operationName: getOperationLabel(args),
+						operationName: operationLabel,
 						queryFingerprint: graphqlQueryFingerprint(fullQuery),
 						query: fullQuery.slice(0, 2000),
 						variables: args.variableValues,

--- a/api/src/kg/costLoggerPlugin.ts
+++ b/api/src/kg/costLoggerPlugin.ts
@@ -436,7 +436,7 @@ function effectiveLimit(args: Record<string, unknown>, hasPagination: boolean, h
 	if (!hasOffset) return limit
 
 	const rawOffset = args.offset
-	const validOffset = typeof rawOffset === "number" && Number.isFinite(rawOffset) && rawOffset > 0
+	const validOffset = typeof rawOffset === "number" && Number.isFinite(rawOffset) && rawOffset >= 0
 	return limit + (validOffset ? BigInt(rawOffset) : DEFAULT_LIMIT)
 }
 

--- a/api/src/kg/costLoggerPlugin.ts
+++ b/api/src/kg/costLoggerPlugin.ts
@@ -7,6 +7,7 @@ import {
 	Kind,
 	type OperationDefinitionNode,
 	print,
+	type SelectionNode,
 	type SelectionSetNode,
 	type ValueNode,
 } from "graphql"
@@ -76,7 +77,9 @@ const COST_LOG_THRESHOLD = parsePositiveIntEnv("GRAPHQL_COST_LOG_THRESHOLD", 200
 // Bucket edges now use the compressed (log₁₀×10) scale. Each 10-point step
 // is a 10× jump in raw cost, so one linear scale captures everything from
 // trivial scalars (score 0) to adversarial fractal nesting (score 1000+).
-const COST_BUCKET_EDGES: readonly number[] = [30, 60, 90, 120, 150, 180, 200, 220, 240, 260, 280, 300, 500, 1000]
+const COST_BUCKET_EDGES: readonly number[] = [
+	30, 60, 90, 120, 150, 180, 200, 220, 240, 260, 280, 300, 320, 350, 400, 500, 1000,
+]
 
 const bucketCounts = new Map<number, number>()
 let totalCount = 0
@@ -133,10 +136,14 @@ export function __resetQueryCostHistogramForTests(): void {
  * call sites should use `computeQueryCost` instead and work with the
  * compressed Number score.
  */
-export function computeQueryCostRaw(doc: DocumentNode, variables: Record<string, unknown> = {}): bigint {
-	const op = doc.definitions.find((d): d is OperationDefinitionNode => d.kind === Kind.OPERATION_DEFINITION)
+export function computeQueryCostRaw(
+	doc: DocumentNode,
+	variables: Record<string, unknown> = {},
+	operationName?: string | null,
+): bigint {
+	const op = getOperationDefinition(doc, operationName)
 	if (!op) return 0n
-	return sumSelections(op.selectionSet, variables, doc, new Set())
+	return sumSelections(op.selectionSet, variables, doc, new Set(), 0)
 }
 
 /**
@@ -146,8 +153,12 @@ export function computeQueryCostRaw(doc: DocumentNode, variables: Record<string,
  * Returns 0 for trivial queries; typical heavy prod queries land 150–250;
  * structurally-unbounded shapes exceed 240.
  */
-export function computeQueryCost(doc: DocumentNode, variables: Record<string, unknown> = {}): number {
-	return compressCost(computeQueryCostRaw(doc, variables))
+export function computeQueryCost(
+	doc: DocumentNode,
+	variables: Record<string, unknown> = {},
+	operationName?: string | null,
+): number {
+	return compressCost(computeQueryCostRaw(doc, variables, operationName))
 }
 
 /** `round(log₁₀(n) × 10)` with BigInt-safe log10. Returns 0 for n ≤ 1. */
@@ -162,18 +173,86 @@ export function compressCost(n: bigint): number {
 	return Math.round(log10 * 10)
 }
 
+function getOperationDefinition(doc: DocumentNode, operationName?: string | null): OperationDefinitionNode | undefined {
+	if (!isDocumentLike(doc)) throw new TypeError("Invalid GraphQL document")
+	const operations = doc.definitions.filter((d): d is OperationDefinitionNode => d.kind === Kind.OPERATION_DEFINITION)
+	if (operationName) {
+		return operations.find((op) => op.name?.value === operationName) ?? operations[0]
+	}
+	return operations[0]
+}
+
+function isDocumentLike(doc: unknown): doc is DocumentNode {
+	return !!doc && typeof doc === "object" && Array.isArray((doc as {definitions?: unknown}).definitions)
+}
+
+function isIntrospectionOnlyOperation(doc: DocumentNode, operationName?: string | null): boolean {
+	if (!isDocumentLike(doc)) return false
+	const op = getOperationDefinition(doc, operationName)
+	if (!op) return false
+
+	const rootFields = collectRootFieldNames(op.selectionSet, doc, new Set())
+	return (
+		rootFields.length > 0 &&
+		rootFields.every((name) => name.startsWith("__")) &&
+		rootFields.some((name) => name === "__schema" || name === "__type")
+	)
+}
+
+function collectRootFieldNames(
+	selectionSet: SelectionSetNode,
+	doc: DocumentNode,
+	visitedFragments: Set<string>,
+): string[] {
+	const names: string[] = []
+	for (const sel of selectionSet.selections) {
+		if (sel.kind === Kind.FIELD) {
+			names.push(sel.name.value)
+		} else if (sel.kind === Kind.INLINE_FRAGMENT) {
+			names.push(...collectRootFieldNames(sel.selectionSet, doc, visitedFragments))
+		} else if (sel.kind === Kind.FRAGMENT_SPREAD) {
+			const name = sel.name.value
+			if (visitedFragments.has(name)) continue
+			const frag = doc.definitions.find(
+				(d): d is FragmentDefinitionNode => d.kind === Kind.FRAGMENT_DEFINITION && d.name.value === name,
+			)
+			if (frag) {
+				visitedFragments.add(name)
+				names.push(...collectRootFieldNames(frag.selectionSet, doc, visitedFragments))
+				visitedFragments.delete(name)
+			}
+		}
+	}
+	return names
+}
+
+function shouldIncludeSelection(selection: SelectionNode, vars: Record<string, unknown>): boolean {
+	for (const directive of selection.directives ?? []) {
+		if (directive.name.value !== "skip" && directive.name.value !== "include") continue
+		const ifArg = directive.arguments?.find((arg) => arg.name.value === "if")
+		if (!ifArg) continue
+		const value = resolveValue(ifArg.value, vars)
+		if (typeof value !== "boolean") continue
+		if (directive.name.value === "skip" && value) return false
+		if (directive.name.value === "include" && !value) return false
+	}
+	return true
+}
+
 function sumSelections(
 	selectionSet: SelectionSetNode,
 	vars: Record<string, unknown>,
 	doc: DocumentNode,
 	visitedFragments: Set<string>,
+	depth: number,
 ): bigint {
 	let total = 0n
 	for (const sel of selectionSet.selections) {
+		if (!shouldIncludeSelection(sel, vars)) continue
 		if (sel.kind === Kind.FIELD) {
-			total += fieldCost(sel, vars, doc, visitedFragments)
+			total += fieldCost(sel, vars, doc, visitedFragments, depth)
 		} else if (sel.kind === Kind.INLINE_FRAGMENT) {
-			total += sumSelections(sel.selectionSet, vars, doc, visitedFragments)
+			total += sumSelections(sel.selectionSet, vars, doc, visitedFragments, depth)
 		} else if (sel.kind === Kind.FRAGMENT_SPREAD) {
 			// Fragment cycles (A spreads B spreads A) are normally blocked by
 			// the NoFragmentCycles validation rule, but if something in the
@@ -187,7 +266,7 @@ function sumSelections(
 			)
 			if (frag) {
 				visitedFragments.add(name)
-				total += sumSelections(frag.selectionSet, vars, doc, visitedFragments)
+				total += sumSelections(frag.selectionSet, vars, doc, visitedFragments, depth)
 				visitedFragments.delete(name)
 			}
 		}
@@ -198,6 +277,8 @@ function sumSelections(
 /**
  * Cost model per field:
  *   - Explicit `first` / `last` arg with a valid positive value → `child × limit + 1`.
+ *     `offset` contributes to the effective limit because the DB may still
+ *     need to skip those rows before returning the page.
  *   - Pagination arg present but value unresolved / non-positive → fall back
  *     to MAX_PAGINATION_LIMIT (1000) — matches the effective cap at SQL build.
  *   - No pagination arg, has selections → `child × MAX_PAGINATION_LIMIT + 1`.
@@ -205,33 +286,251 @@ function sumSelections(
  *     collection field at SQL build, so modeling the default at 1000 matches
  *     the real fan-out ceiling. BigInt arithmetic means this doesn't overflow.
  *   - No pagination arg, no selections → 1 (scalar leaf).
+ *   - Known SQL-heavy fields / args multiply the raw cost by conservative
+ *     factors. On the compressed score, ×10 is roughly +10 points.
  */
 const DEFAULT_LIMIT = BigInt(MAX_PAGINATION_LIMIT)
+const TOTAL_COUNT_RAW_COST = 10_000n
+const MAX_FILTER_FACTOR = 1_000n
+const LARGE_ROOT_PAGE_LIMIT = 100n
+const VERY_LARGE_ROOT_PAGE_LIMIT = 500n
+
+const SEARCH_FIELD_NAMES: ReadonlySet<string> = new Set(["search", "searchConnection"])
+const ENTITIES_ORDERED_BY_PROPERTY_FIELD_NAMES: ReadonlySet<string> = new Set([
+	"entitiesOrderedByProperty",
+	"entitiesOrderedByPropertyConnection",
+])
+const SCORE_ORDERED_FIELD_NAMES: ReadonlySet<string> = new Set(["values", "valuesConnection"])
+const ENTITY_ROOT_COLLECTION_FIELD_NAMES: ReadonlySet<string> = new Set(["entities", "entitiesConnection"])
+const BROAD_ROOT_COLLECTION_FIELD_NAMES: ReadonlySet<string> = new Set([
+	"entities",
+	"entitiesConnection",
+	"values",
+	"valuesConnection",
+	"relations",
+	"relationsConnection",
+	"spaces",
+	"spacesConnection",
+])
+const SELECTIVE_ROOT_ARGS: ReadonlySet<string> = new Set([
+	"id",
+	"nodeId",
+	"spaceId",
+	"spaceIds",
+	"typeId",
+	"typeIds",
+	"condition",
+	"filter",
+])
+
+const STRING_SCAN_FILTER_FACTORS: Readonly<Record<string, bigint>> = {
+	includes: 20n,
+	includesInsensitive: 30n,
+	like: 20n,
+	likeInsensitive: 30n,
+	notIncludes: 30n,
+	notIncludesInsensitive: 40n,
+	notLike: 30n,
+	notLikeInsensitive: 40n,
+}
+
+const STRUCTURAL_FILTER_FACTORS: Readonly<Record<string, bigint>> = {
+	overlaps: 15n,
+	contains: 8n,
+	containedBy: 8n,
+	containsKey: 5n,
+	containsAnyKeys: 8n,
+	containsAllKeys: 8n,
+	isNot: 5n,
+	notIn: 5n,
+	not: 5n,
+}
+
+const RELATION_FILTER_KEYS: ReadonlySet<string> = new Set(["some", "every", "none"])
+const COMPUTED_FILTER_FIELD_NAMES: ReadonlySet<string> = new Set([
+	"name",
+	"description",
+	"spaceIds",
+	"typeIds",
+	"types",
+	"spaces",
+	"dataType",
+	"properties",
+	"property",
+	"type",
+])
+
+const LARGE_PAYLOAD_SCALAR_COSTS: Readonly<Record<string, bigint>> = {
+	name: 2n,
+	description: 50n,
+	text: 25n,
+	string: 25n,
+	value: 25n,
+	schedule: 100n,
+	embedding: 100n,
+	bytes: 100n,
+	metadata: 50n,
+	data: 100n,
+}
+
+const PAYLOAD_COLLECTION_FACTORS: Readonly<Record<string, bigint>> = {
+	values: 5n,
+	valuesList: 5n,
+	valuesConnection: 5n,
+	relations: 4n,
+	relationsList: 4n,
+	relationsConnection: 4n,
+	backlinks: 4n,
+	backlinksList: 4n,
+	backlinksConnection: 4n,
+	relationsWhereEntity: 4n,
+	relationsWhereEntityList: 4n,
+	relationsWhereEntityConnection: 4n,
+}
+
+const ENTITY_REFERENCE_FIELD_NAMES: ReadonlySet<string> = new Set([
+	"entity",
+	"fromEntity",
+	"toEntity",
+	"relationEntity",
+	"typeEntity",
+	"propertyEntity",
+])
 
 function fieldCost(
 	field: FieldNode,
 	vars: Record<string, unknown>,
 	doc: DocumentNode,
 	visitedFragments: Set<string>,
+	depth: number,
 ): bigint {
 	// Check for the *syntactic* presence of first/last. `entities(first: $n)`
 	// with `$n` unresolved still means the caller intended pagination — treat
 	// it as a list (and fall back to MAX_PAGINATION_LIMIT since the effective
 	// limit is undefined).
+	const fieldName = field.name.value
 	const argNames = new Set((field.arguments ?? []).map((a) => a.name.value))
 	const hasPagination = argNames.has("first") || argNames.has("last")
+	const args = resolveArgs(field.arguments, vars)
 
-	const child = field.selectionSet ? sumSelections(field.selectionSet, vars, doc, visitedFragments) : 0n
+	const child = field.selectionSet ? sumSelections(field.selectionSet, vars, doc, visitedFragments, depth + 1) : 0n
 
-	if (hasPagination) {
-		const args = resolveArgs(field.arguments, vars)
-		const raw = args.first ?? args.last
-		const validExplicit = typeof raw === "number" && Number.isFinite(raw) && raw > 0
-		const limit = validExplicit ? BigInt(raw as number) : DEFAULT_LIMIT
-		return child * limit + 1n
+	if (!field.selectionSet) {
+		return scalarFieldCost(fieldName) * sqlRiskFactor(fieldName, args, argNames, depth, 0n)
 	}
 
-	return child * DEFAULT_LIMIT + 1n
+	const limit = effectiveLimit(args, hasPagination, argNames.has("offset"))
+	const base = child * limit + 1n
+	return base * sqlRiskFactor(fieldName, args, argNames, depth, limit)
+}
+
+function scalarFieldCost(fieldName: string): bigint {
+	if (fieldName === "totalCount") return TOTAL_COUNT_RAW_COST
+	return LARGE_PAYLOAD_SCALAR_COSTS[fieldName] ?? 1n
+}
+
+function effectiveLimit(args: Record<string, unknown>, hasPagination: boolean, hasOffset: boolean): bigint {
+	const rawLimit = args.first ?? args.last
+	const validLimit = typeof rawLimit === "number" && Number.isFinite(rawLimit) && rawLimit > 0
+	const limit = hasPagination ? (validLimit ? BigInt(rawLimit) : DEFAULT_LIMIT) : DEFAULT_LIMIT
+	if (!hasOffset) return limit
+
+	const rawOffset = args.offset
+	const validOffset = typeof rawOffset === "number" && Number.isFinite(rawOffset) && rawOffset > 0
+	return limit + (validOffset ? BigInt(rawOffset) : DEFAULT_LIMIT)
+}
+
+function sqlRiskFactor(
+	fieldName: string,
+	args: Record<string, unknown>,
+	argNames: ReadonlySet<string>,
+	depth: number,
+	limit: bigint,
+): bigint {
+	let factor = 1n
+
+	if (SEARCH_FIELD_NAMES.has(fieldName)) factor *= 20n
+	if (ENTITIES_ORDERED_BY_PROPERTY_FIELD_NAMES.has(fieldName)) factor *= 50n
+	if (SCORE_ORDERED_FIELD_NAMES.has(fieldName) && usesScoreOrderBy(args.orderBy)) factor *= 20n
+	if (isBroadRootCollection(fieldName, argNames, depth, limit)) factor *= 3n
+	if (ENTITY_ROOT_COLLECTION_FIELD_NAMES.has(fieldName) && depth === 0) factor *= rootEntityPagePayloadFactor(limit)
+	factor *= PAYLOAD_COLLECTION_FACTORS[fieldName] ?? 1n
+	if (ENTITY_REFERENCE_FIELD_NAMES.has(fieldName) && depth >= 2) factor *= 3n
+
+	if (argNames.has("filter")) factor *= 5n * filterRiskFactor(args.filter)
+	if (argNames.has("condition")) factor *= 2n
+	if (argNames.has("orderBy")) factor *= orderByRiskFactor(args.orderBy)
+	if (argNames.has("after") || argNames.has("before")) factor *= 2n
+
+	return factor
+}
+
+function rootEntityPagePayloadFactor(limit: bigint): bigint {
+	if (limit >= VERY_LARGE_ROOT_PAGE_LIMIT) return 10n
+	if (limit >= LARGE_ROOT_PAGE_LIMIT) return 3n
+	return 1n
+}
+
+function isBroadRootCollection(
+	fieldName: string,
+	argNames: ReadonlySet<string>,
+	depth: number,
+	limit: bigint,
+): boolean {
+	if (depth !== 0 || !BROAD_ROOT_COLLECTION_FIELD_NAMES.has(fieldName)) return false
+	if (limit < DEFAULT_LIMIT / 2n) return false
+	for (const argName of SELECTIVE_ROOT_ARGS) {
+		if (argNames.has(argName)) return false
+	}
+	return true
+}
+
+function orderByRiskFactor(value: unknown): bigint {
+	if (usesScoreOrderBy(value)) return 20n
+	return value === undefined || value === null ? 1n : 3n
+}
+
+function usesScoreOrderBy(value: unknown): boolean {
+	if (typeof value === "string") return value.includes("SCORE")
+	if (Array.isArray(value)) return value.some(usesScoreOrderBy)
+	return false
+}
+
+function filterRiskFactor(value: unknown): bigint {
+	return capFilterFactor(filterRiskFactorInner(value))
+}
+
+function filterRiskFactorInner(value: unknown): bigint {
+	if (Array.isArray(value)) {
+		if (value.length === 0) return 1n
+		return value.reduce((factor, item) => capFilterFactor(factor * filterRiskFactorInner(item)), 1n)
+	}
+	if (!value || typeof value !== "object") return 1n
+
+	let factor = 1n
+	for (const [key, childValue] of Object.entries(value as Record<string, unknown>)) {
+		const stringScanFactor = STRING_SCAN_FILTER_FACTORS[key]
+		if (stringScanFactor !== undefined) factor = capFilterFactor(factor * stringScanFactor)
+
+		const structuralFactor = STRUCTURAL_FILTER_FACTORS[key]
+		if (structuralFactor !== undefined) factor = capFilterFactor(factor * structuralFactor)
+
+		if (key === "or" && Array.isArray(childValue) && childValue.length > 1) {
+			factor = capFilterFactor(factor * BigInt(Math.min(childValue.length, 10)))
+		}
+		if ((key === "in" || key === "notIn") && Array.isArray(childValue) && childValue.length > 10) {
+			factor = capFilterFactor(factor * BigInt(Math.min(Math.ceil(childValue.length / 10), 10)))
+		}
+		if (RELATION_FILTER_KEYS.has(key)) factor = capFilterFactor(factor * 10n)
+		if (COMPUTED_FILTER_FIELD_NAMES.has(key)) factor = capFilterFactor(factor * 10n)
+
+		factor = capFilterFactor(factor * filterRiskFactorInner(childValue))
+	}
+	return factor
+}
+
+function capFilterFactor(value: bigint): bigint {
+	return value > MAX_FILTER_FACTOR ? MAX_FILTER_FACTOR : value
 }
 
 function resolveArgs(
@@ -294,11 +593,11 @@ export function useCostLogger(): Plugin {
 	return {
 		onExecute({args}) {
 			try {
-				if (args.operationName === "IntrospectionQuery") return
+				if (isIntrospectionOnlyOperation(args.document, args.operationName)) return
 
 				let cost: number
 				try {
-					cost = computeQueryCost(args.document, args.variableValues ?? {})
+					cost = computeQueryCost(args.document, args.variableValues ?? {}, args.operationName)
 				} catch (error) {
 					log.warn("[cost] complexity calculation failed", {
 						error: error instanceof Error ? error.message : String(error),
@@ -355,6 +654,7 @@ export function useCostLogger(): Plugin {
 
 function getOperationLabel(args: {operationName?: string | null; document: {definitions: readonly unknown[]}}): string {
 	if (args.operationName) return args.operationName
+	if (!args.document || !Array.isArray(args.document.definitions)) return "anonymous"
 
 	const operationDef = args.document.definitions.find(
 		(def): def is OperationDefinitionNode =>

--- a/api/src/kg/instrumentationPlugin.ts
+++ b/api/src/kg/instrumentationPlugin.ts
@@ -13,6 +13,7 @@ import {
 import type {Plugin} from "graphql-yoga"
 import {graphqlQueryFingerprint} from "../services/queryFingerprint"
 import {log} from "../services/telemetry"
+import {GRAPHQL_QUERY_COST_CONTEXT_KEY, type GraphqlCostContext} from "./costLoggerPlugin"
 
 // GraphQL error codes that always indicate a client-side problem (bad input,
 // syntax/validation errors). These are the expected consequence of a
@@ -200,6 +201,15 @@ export function useGraphQLInstrumentation(): Plugin {
 					const errors = "errors" in result ? result.errors : undefined
 					const hasErrors = errors && errors.length > 0
 
+					// Read cost from context (set by useCostLogger). Treat as
+					// optional: if cost computation failed or the cost plugin
+					// ran out-of-order, we still emit the warning, just without
+					// the cost field. Helpful when triaging a 30s/60s timeout —
+					// a high cost score (≥200) plus the duration tells you it
+					// was an expensive query, not a stalled DB connection.
+					const ctx = args.contextValue as GraphqlCostContext | undefined
+					const queryCost = ctx?.[GRAPHQL_QUERY_COST_CONTEXT_KEY]
+
 					// Measure serialized response size for large payload detection.
 					// Only stringify data (not errors) since that's the memory-heavy part.
 					// Guard behind a 1s duration check to avoid the stringify cost on fast queries.
@@ -220,6 +230,7 @@ export function useGraphQLInstrumentation(): Plugin {
 							responseSizeBytes,
 							responseSizeMB: Math.round((responseSizeBytes / 1_000_000) * 100) / 100,
 							durationMs,
+							...(queryCost !== undefined && {queryCost}),
 							query: query.slice(0, 5000),
 							variables: args.variableValues,
 							requestId,
@@ -232,6 +243,7 @@ export function useGraphQLInstrumentation(): Plugin {
 							queryFingerprint,
 							durationMs,
 							responseSizeBytes,
+							...(queryCost !== undefined && {queryCost}),
 							query: query.slice(0, 5000),
 							variables: args.variableValues,
 							requestId,
@@ -258,6 +270,7 @@ export function useGraphQLInstrumentation(): Plugin {
 									variables: args.variableValues,
 									path: error.path,
 									requestId,
+									...(queryCost !== undefined && {queryCost}),
 								},
 							})
 						}
@@ -266,6 +279,9 @@ export function useGraphQLInstrumentation(): Plugin {
 					span.setAttribute("graphql.duration_ms", durationMs)
 					if (responseSizeBytes !== undefined) {
 						span.setAttribute("graphql.response_size_bytes", responseSizeBytes)
+					}
+					if (queryCost !== undefined) {
+						span.setAttribute("graphql.query_cost", queryCost)
 					}
 
 					// Sentry metrics for dashboards and alerting


### PR DESCRIPTION
## Summary
- Emit GraphQL query cost to Sentry and share the computed score with slow/large response instrumentation.
- Expand the GraphQL cost model for selected operations, directives, SQL-risk arguments, expensive filters, and known heavy fields.
- Raise cost scores for payload-heavy entity queries by weighting large scalar fields, root entity page size, nested values/relations fanout, and entity duplication paths.

## Test plan
- bun test src/kg/__tests__/costLoggerPlugin.test.ts
- bunx biome check src/kg/costLoggerPlugin.ts src/kg/__tests__/costLoggerPlugin.test.ts
- bun run check


Made with [Cursor](https://cursor.com)