### PR TITLE
fix(hermes-pipeline): emit VOTING_SETTINGS_UPDATED events to Kafka

### DIFF
--- a/hermes-pipeline/src/emit.rs
+++ b/hermes-pipeline/src/emit.rs
@@ -18,7 +18,7 @@ use hermes_schema::pb::{
     blockchain_metadata::BlockchainMetadata,
     governance::{
         HermesProposalCreated, HermesProposalExecuted, HermesProposalSettingsUpdated,
-        HermesProposalUpdated, HermesProposalVoted,
+        HermesProposalUpdated, HermesProposalVoted, HermesVotingSettingsUpdated,
     },
     knowledge::HermesEdit,
     membership::{HermesRoleGranted, HermesRoleRevoked, HermesSpaceLeft, MembershipRole},
@@ -294,6 +294,27 @@ impl KafkaEvent for HermesProposalSettingsUpdated {
 }
 
 impl HasMeta for HermesProposalSettingsUpdated {
+    fn meta(&self) -> Option<&BlockchainMetadata> {
+        self.meta.as_ref()
+    }
+}
+
+impl KafkaEvent for HermesVotingSettingsUpdated {
+    const TOPIC: &'static str = topics::GOVERNANCE;
+
+    fn key(&self) -> Vec<u8> {
+        self.space_id.clone()
+    }
+
+    fn headers(&self) -> OwnedHeaders {
+        OwnedHeaders::new().insert(Header {
+            key: "event-type",
+            value: Some("VOTING_SETTINGS_UPDATED"),
+        })
+    }
+}
+
+impl HasMeta for HermesVotingSettingsUpdated {
     fn meta(&self) -> Option<&BlockchainMetadata> {
         self.meta.as_ref()
     }
@@ -756,6 +777,24 @@ mod tests {
         assert_eq!(HermesProposalCreated::TOPIC, "space.governance");
         assert_eq!(HermesProposalVoted::TOPIC, "space.governance");
         assert_eq!(HermesProposalExecuted::TOPIC, "space.governance");
+        assert_eq!(HermesProposalSettingsUpdated::TOPIC, "space.governance");
+        assert_eq!(HermesVotingSettingsUpdated::TOPIC, "space.governance");
+    }
+
+    #[test]
+    fn test_voting_settings_updated_key() {
+        let event = HermesVotingSettingsUpdated {
+            space_id: vec![0xAB; 16],
+            partial_percentage_support_threshold: 0,
+            universal_percentage_support_threshold: 0,
+            flat_support_threshold: 0,
+            quorum: 0,
+            duration: 0,
+            disable_fast_path_access_for_new_members: false,
+            execution_grace_period: 0,
+            meta: None,
+        };
+        assert_eq!(event.key(), vec![0xAB; 16]);
     }
 
     #[test]

--- a/hermes-pipeline/src/main.rs
+++ b/hermes-pipeline/src/main.rs
@@ -292,6 +292,7 @@ impl Pipeline {
                 max_sequence(&governance.proposals_voted),
                 max_sequence(&governance.proposals_executed),
                 max_sequence(&governance.proposals_settings_updated),
+                max_sequence(&governance.voting_settings_updated),
                 max_sequence(&voting.votes),
                 max_sequence(&edits.events),
             ]
@@ -315,6 +316,7 @@ impl Pipeline {
                 || mark_sequence_as_last(&mut governance.proposals_voted, max_seq)
                 || mark_sequence_as_last(&mut governance.proposals_executed, max_seq)
                 || mark_sequence_as_last(&mut governance.proposals_settings_updated, max_seq)
+                || mark_sequence_as_last(&mut governance.voting_settings_updated, max_seq)
                 || mark_sequence_as_last(&mut voting.votes, max_seq)
                 || mark_sequence_as_last(&mut edits.events, max_seq);
         }
@@ -426,6 +428,10 @@ impl Pipeline {
         counts_by_event_type.insert(
             "PROPOSAL_SETTINGS_UPDATED".to_string(),
             governance.proposals_settings_updated.len() as u64,
+        );
+        counts_by_event_type.insert(
+            "VOTING_SETTINGS_UPDATED".to_string(),
+            governance.voting_settings_updated.len() as u64,
         );
         counts_by_event_type.insert("VOTE_CAST".to_string(), voting.votes.len() as u64);
 
@@ -590,6 +596,13 @@ impl Pipeline {
                         space_id = %hex::encode(&event.space_id),
                         proposal_id = %hex::encode(&event.proposal_id),
                         "Proposal settings updated"
+                    );
+                }
+                for event in &governance.voting_settings_updated {
+                    self.emitter.emit(event).await?;
+                    debug!(
+                        space_id = %hex::encode(&event.space_id),
+                        "Voting settings updated"
                     );
                 }
             }

--- a/hermes-pipeline/src/pipelines/mod.rs
+++ b/hermes-pipeline/src/pipelines/mod.rs
@@ -23,7 +23,7 @@ pub mod voting;
 use hermes_schema::pb::blockchain_metadata::BlockchainMetadata;
 use hermes_schema::pb::governance::{
     HermesProposalCreated, HermesProposalExecuted, HermesProposalSettingsUpdated,
-    HermesProposalUpdated, HermesProposalVoted,
+    HermesProposalUpdated, HermesProposalVoted, HermesVotingSettingsUpdated,
 };
 use hermes_schema::pb::knowledge::HermesEdit;
 use hermes_schema::pb::membership::{HermesRoleGranted, HermesRoleRevoked, HermesSpaceLeft};
@@ -71,6 +71,7 @@ impl_has_meta!(
     HermesProposalVoted,
     HermesProposalExecuted,
     HermesProposalSettingsUpdated,
+    HermesVotingSettingsUpdated,
     HermesVoteCast,
     HermesEdit,
 );


### PR DESCRIPTION
Closes [GEO-567](https://linear.app/defi-wonderland/issue/GEO-567).

## Summary

`HermesVotingSettingsUpdated` events were being decoded by the governance pipeline but never published to Kafka, so `space_voting_settings` was never written.

## Changes

- **`hermes-pipeline/src/main.rs`** — emit `governance.voting_settings_updated` after `proposals_settings_updated`; include in `max_sequence` / `mark_sequence_as_last` so `is_last_in_block` is correct; add `VOTING_SETTINGS_UPDATED` to `counts_by_event_type`.
- **`hermes-pipeline/src/pipelines/mod.rs`** — `impl HasMeta for HermesVotingSettingsUpdated`.
- **`hermes-pipeline/src/emit.rs`** — `KafkaEvent` (topic `space.governance`, key `space_id`, header `event-type=VOTING_SETTINGS_UPDATED`) and `HasMeta` impls + tests.

## Test plan

- [x] `cargo test -p hermes-pipeline` (108 tests pass)
- [x] `cargo test -p kg-indexer --lib --bins` (82 tests pass)
- [ ] Manual e2e: trigger `VOTING_SETTINGS_UPDATED` onchain, verify message on `space.governance` and a row in `space_voting_settings`.