### PR TITLE
fix(api): GET /versioned/proposals/:id/diff against V2 schema split

### DIFF
--- a/api/src/versioned/__tests__/integration.test.ts
+++ b/api/src/versioned/__tests__/integration.test.ts
@@ -1368,36 +1368,52 @@ async function setupTestData(pool: Pool): Promise<void> {
 			],
 		)
 
-		// 11. Create proposals
+		// 11. Create proposals (V2: identity row + version 1 row, joined via `proposals_current` view)
 		const now = Math.floor(Date.now() / 1000)
 
+		const insertProposalV2 = async (
+			proposalId: string,
+			startTime: number,
+			endTime: number,
+			executedAt: number | null,
+		) => {
+			if (executedAt !== null) {
+				await client.query(
+					`INSERT INTO proposals (id, space_id, proposed_by, executed_at, created_at, created_at_block, current_version)
+					 VALUES ($1, $2, $3, $4, '2024-01-01T00:00:00Z', '1000', 1) ON CONFLICT DO NOTHING`,
+					[proposalId, uuid.space1, uuid.entityAllTypes, executedAt],
+				)
+			} else {
+				await client.query(
+					`INSERT INTO proposals (id, space_id, proposed_by, created_at, created_at_block, current_version)
+					 VALUES ($1, $2, $3, '2024-01-01T00:00:00Z', '1000', 1) ON CONFLICT DO NOTHING`,
+					[proposalId, uuid.space1, uuid.entityAllTypes],
+				)
+			}
+			await client.query(
+				`INSERT INTO proposal_versions (
+					proposal_id, proposal_version, voting_mode, start_time, end_time,
+					quorum, threshold,
+					partial_percentage_support_threshold, universal_percentage_support_threshold,
+					flat_support_threshold,
+					version_created_at, version_created_at_block
+				 )
+				 VALUES ($1, 1, 'Fast', $2, $3, 1, 1, 0, 0, 1, '2024-01-01T00:00:00Z', '1000') ON CONFLICT DO NOTHING`,
+				[proposalId, startTime, endTime],
+			)
+		}
+
 		// Active proposal (end_time in future)
-		await client.query(
-			`INSERT INTO proposals (id, space_id, proposed_by, voting_mode, start_time, end_time, quorum, threshold, created_at, created_at_block)
-			 VALUES ($1, $2, $3, 'Fast', $4, $5, 1, 1, '2024-01-01T00:00:00Z', '1000') ON CONFLICT DO NOTHING`,
-			[uuid.proposalActive, uuid.space1, uuid.entityAllTypes, now - 1000, now + 86400],
-		)
+		await insertProposalV2(uuid.proposalActive, now - 1000, now + 86400, null)
 
 		// Closed proposal (end_time in past)
-		await client.query(
-			`INSERT INTO proposals (id, space_id, proposed_by, voting_mode, start_time, end_time, quorum, threshold, created_at, created_at_block)
-			 VALUES ($1, $2, $3, 'Fast', $4, $5, 1, 1, '2024-01-01T00:00:00Z', '1000') ON CONFLICT DO NOTHING`,
-			[uuid.proposalClosed, uuid.space1, uuid.entityAllTypes, now - 86400, now - 1000],
-		)
+		await insertProposalV2(uuid.proposalClosed, now - 86400, now - 1000, null)
 
 		// Executed proposal
-		await client.query(
-			`INSERT INTO proposals (id, space_id, proposed_by, voting_mode, start_time, end_time, quorum, threshold, executed_at, created_at, created_at_block)
-			 VALUES ($1, $2, $3, 'Fast', $4, $5, 1, 1, $6, '2024-01-01T00:00:00Z', '1000') ON CONFLICT DO NOTHING`,
-			[uuid.proposalExecuted, uuid.space1, uuid.entityAllTypes, now - 86400, now - 1000, now - 500],
-		)
+		await insertProposalV2(uuid.proposalExecuted, now - 86400, now - 1000, now - 500)
 
 		// Proposal without publish action
-		await client.query(
-			`INSERT INTO proposals (id, space_id, proposed_by, voting_mode, start_time, end_time, quorum, threshold, created_at, created_at_block)
-			 VALUES ($1, $2, $3, 'Fast', $4, $5, 1, 1, '2024-01-01T00:00:00Z', '1000') ON CONFLICT DO NOTHING`,
-			[uuid.proposalNoPublish, uuid.space1, uuid.entityAllTypes, now - 1000, now + 86400],
-		)
+		await insertProposalV2(uuid.proposalNoPublish, now - 1000, now + 86400, null)
 
 		await client.query("COMMIT")
 	} catch (error) {
@@ -1416,6 +1432,7 @@ async function cleanupTestData(pool: Pool): Promise<void> {
 
 		// Delete in reverse order of foreign key dependencies
 		await client.query(`DELETE FROM proposal_actions WHERE proposal_id::text LIKE '10000000-%'`)
+		await client.query(`DELETE FROM proposal_versions WHERE proposal_id::text LIKE '10000000-%'`)
 		await client.query(`DELETE FROM proposals WHERE id::text LIKE '10000000-%'`)
 		await client.query(`DELETE FROM relation_versions WHERE entity_id::text LIKE '10000000-%'`)
 		await client.query(`DELETE FROM value_versions WHERE entity_id::text LIKE '10000000-%'`)

--- a/api/src/versioned/__tests__/proposal-diff-edit-flow.test.ts
+++ b/api/src/versioned/__tests__/proposal-diff-edit-flow.test.ts
@@ -101,6 +101,7 @@ const uuid = {
 
 	// Proposals (continued)
 	proposalDeleteBlock: "20000000-0008-4000-8000-000000000010",
+	proposalExecuted: "20000000-0008-4000-8000-000000000011",
 
 	// Proposal actions
 	actionCreateEntity: "20000000-000a-4000-8000-000000000001",
@@ -113,6 +114,7 @@ const uuid = {
 	actionDeleteRelation: "20000000-000a-4000-8000-000000000008",
 	actionUpdateRelation: "20000000-000a-4000-8000-000000000009",
 	actionDeleteBlock: "20000000-000a-4000-8000-000000000010",
+	actionExecuted: "20000000-000a-4000-8000-000000000011",
 
 	// Value IDs (for value_versions)
 	val: (n: number) => `20000000-0009-4000-8000-${n.toString().padStart(12, "0")}`,
@@ -440,11 +442,29 @@ describe.skipIf(SKIP_INTEGRATION)("Proposal Diff - Full GRC-20 Edit Flow", () =>
 	})
 
 	// ==========================================================================
-	// 8. Closed Proposal Tests
+	// 8. Proposal Status Branches
+	//
+	// `getProposalStatus()` (proposal-diff.ts) decides the base-state source:
+	//   - active            → live tables
+	//   - closed (not exec) → versioned tables at end_time
+	//   - executed          → versioned tables just before executed_at
+	//
+	// Most other tests in this suite exercise the `active` branch implicitly
+	// via end_time-in-the-future fixtures. These tests cover the remaining
+	// branches and assert the reported `proposalStatus`.
 	// ==========================================================================
 
-	describe("Closed Proposal", () => {
-		it("uses versioned base state for closed proposals", async () => {
+	describe("Proposal Status Branches", () => {
+		it("returns proposalStatus=active for an open proposal", async () => {
+			const res = await app.request(
+				`/versioned/proposals/${uuid.proposalCreateEntity}/diff?spaceId=${uuid.space1}`,
+			)
+			expect(res.status).toBe(200)
+			const body = await res.json()
+			expect(body.proposalStatus).toBe("active")
+		})
+
+		it("uses versioned base state for closed (not executed) proposals", async () => {
 			const res = await app.request(`/versioned/proposals/${uuid.proposalClosed}/diff?spaceId=${uuid.space1}`)
 			expect(res.status).toBe(200)
 
@@ -452,6 +472,15 @@ describe.skipIf(SKIP_INTEGRATION)("Proposal Diff - Full GRC-20 Edit Flow", () =>
 			// Closed proposals should still return entities
 			expect(body.entities).toBeDefined()
 			expect(body.proposalStatus).toBe("closed")
+		})
+
+		it("uses versioned base state just before executed_at for executed proposals", async () => {
+			const res = await app.request(`/versioned/proposals/${uuid.proposalExecuted}/diff?spaceId=${uuid.space1}`)
+			expect(res.status).toBe(200)
+
+			const body = await res.json()
+			expect(body.entities).toBeDefined()
+			expect(body.proposalStatus).toBe("executed")
 		})
 	})
 
@@ -866,6 +895,28 @@ async function setupTestData(pool: Pool): Promise<void> {
 			contentUri: generateTestUri("delete-block"),
 		})
 
+		// Proposal 11: Executed Proposal — `executedAt` is set, so getProposalStatus
+		// returns "executed" regardless of where now sits relative to endTime.
+		// The diff should be computed against versioned state just before executedAt.
+		await createProposalWithEdit(client, {
+			proposalId: uuid.proposalExecuted,
+			actionId: uuid.actionExecuted,
+			spaceId: uuid.space1,
+			startTime: now - 86400,
+			endTime: now - 1000,
+			executedAt: now - 500,
+			editBuilder: (editId) => {
+				const builder = new EditBuilder(editId)
+					.setName("Executed Proposal Edit")
+					.setCreatedNow()
+					.updateEntity(uuidToId(uuid.entityExisting1), (u) =>
+						u.setText(uuidToId(uuid.propText), "From executed proposal"),
+					)
+				return builder.build()
+			},
+			contentUri: generateTestUri("executed-proposal"),
+		})
+
 		await client.query("COMMIT")
 	} catch (error) {
 		await client.query("ROLLBACK")
@@ -905,26 +956,41 @@ async function createProposalWithEdit(client: any, options: CreateProposalOption
 		[contentUri, Buffer.from(encoded), spaceId, edit.name],
 	)
 
-	// Create proposal
+	// Create proposal (V2 identity row + version 1 row).
+	// `proposals_current` view joins these on current_version = proposal_version.
 	if (executedAt) {
 		await client.query(
-			`INSERT INTO proposals (id, space_id, proposed_by, voting_mode, start_time, end_time, quorum, threshold, executed_at, created_at, created_at_block)
-			 VALUES ($1, $2, $3, 'Fast', $4, $5, 1, 1, $6, '2024-01-01T00:00:00Z', '2000') ON CONFLICT DO NOTHING`,
-			[proposalId, spaceId, uuid.entityExisting1, startTime, endTime, executedAt],
+			`INSERT INTO proposals (id, space_id, proposed_by, executed_at, created_at, created_at_block, current_version)
+			 VALUES ($1, $2, $3, $4, '2024-01-01T00:00:00Z', '2000', 1) ON CONFLICT DO NOTHING`,
+			[proposalId, spaceId, uuid.entityExisting1, executedAt],
 		)
 	} else {
 		await client.query(
-			`INSERT INTO proposals (id, space_id, proposed_by, voting_mode, start_time, end_time, quorum, threshold, created_at, created_at_block)
-			 VALUES ($1, $2, $3, 'Fast', $4, $5, 1, 1, '2024-01-01T00:00:00Z', '2000') ON CONFLICT DO NOTHING`,
-			[proposalId, spaceId, uuid.entityExisting1, startTime, endTime],
+			`INSERT INTO proposals (id, space_id, proposed_by, created_at, created_at_block, current_version)
+			 VALUES ($1, $2, $3, '2024-01-01T00:00:00Z', '2000', 1) ON CONFLICT DO NOTHING`,
+			[proposalId, spaceId, uuid.entityExisting1],
 		)
 	}
 
-	// Create proposal action (Publish)
 	await client.query(
-		`INSERT INTO proposal_actions (id, proposal_id, action_type, content_uri)
-		 VALUES ($1, $2, 'Publish', $3) ON CONFLICT DO NOTHING`,
-		[actionId, proposalId, contentUri],
+		`INSERT INTO proposal_versions (
+			proposal_id, proposal_version, voting_mode, start_time, end_time,
+			quorum, threshold,
+			partial_percentage_support_threshold, universal_percentage_support_threshold,
+			flat_support_threshold,
+			version_created_at, version_created_at_block
+		 )
+		 VALUES ($1, 1, 'Fast', $2, $3, 1, 1, 0, 0, 1, '2024-01-01T00:00:00Z', '2000') ON CONFLICT DO NOTHING`,
+		[proposalId, startTime, endTime],
+	)
+
+	// Create proposal action (Publish) — version-scoped on (proposal_id, proposal_version, index).
+	// `actionId` is retained in the option signature for caller stability but is no longer a column.
+	void actionId
+	await client.query(
+		`INSERT INTO proposal_actions (proposal_id, proposal_version, index, action_type, content_uri)
+		 VALUES ($1, 1, 0, 'Publish', $2) ON CONFLICT DO NOTHING`,
+		[proposalId, contentUri],
 	)
 }
 
@@ -936,6 +1002,7 @@ async function cleanupTestData(pool: Pool): Promise<void> {
 
 		// Delete in reverse order of foreign key dependencies
 		await client.query(`DELETE FROM proposal_actions WHERE proposal_id::text LIKE '20000000-%'`)
+		await client.query(`DELETE FROM proposal_versions WHERE proposal_id::text LIKE '20000000-%'`)
 		await client.query(`DELETE FROM proposals WHERE id::text LIKE '20000000-%'`)
 		await client.query(`DELETE FROM relations WHERE from_entity_id::text LIKE '20000000-%'`)
 		await client.query(`DELETE FROM relation_versions WHERE from_entity_id::text LIKE '20000000-%'`)

--- a/api/src/versioned/proposal-diff.ts
+++ b/api/src/versioned/proposal-diff.ts
@@ -139,8 +139,11 @@ function getProposalWithPublishAction(
 					p.end_time,
 					p.executed_at,
 					pa.content_uri
-				FROM proposals p
-				LEFT JOIN proposal_actions pa ON pa.proposal_id = p.id AND pa.action_type = 'Publish'
+				FROM proposals_current p
+				LEFT JOIN proposal_actions pa
+					ON pa.proposal_id = p.id
+					AND pa.proposal_version = p.proposal_version
+					AND pa.action_type = 'Publish'
 				WHERE p.id = ${proposalId}
 				LIMIT 1
 			`)


### PR DESCRIPTION
## Summary

Fixes `GET /versioned/proposals/:id/diff`, which was failing in e2e against the V2 governance schema with:

```
Database error: operation=getProposalWithPublishAction, cause=error: column p.start_time does not exist
```

The GEO-481 "Shape B" migration split `proposals` into an identity table + a `proposal_versions` mutable table, exposed jointly via the `proposals_current` view. Sibling endpoints in `api/src/proposals/` were already migrated under GEO-484 (#156); the diff endpoint was missed and still selected `start_time`/`end_time`/`executed_at` directly from `proposals p`.

This PR migrates `getProposalWithPublishAction` to read from `proposals_current` and version-scopes the `proposal_actions` join, matching the canonical pattern in `api/src/proposals/queries.ts:235-263`.

Closes [GEO-588](https://linear.app/defi-wonderland/issue/GEO-588/fix-get-versionedproposalsiddiff-for-v2-schema-split).

## Changes

**`api/src/versioned/proposal-diff.ts`** — rewrote the failing SQL:

```sql
FROM proposals_current p
LEFT JOIN proposal_actions pa
  ON pa.proposal_id = p.id
 AND pa.proposal_version = p.proposal_version
 AND pa.action_type = 'Publish'
```

`proposals_current` (latest version) is correct — the diff endpoint always operates on the current version of a proposal. The version-scoped join is required because `proposal_actions`' PK now includes `proposal_version` (`schema.ts:619-666`); without it, a re-published proposal would return duplicate Publish rows.

**`api/src/versioned/__tests__/proposal-diff-edit-flow.test.ts`** + **`integration.test.ts`** — migrated DB fixtures from monolithic `proposals` inserts to identity + version inserts (`proposals` → `proposal_versions` → `proposal_actions`). `proposal_actions` no longer has an `id` column; PK is `(proposal_id, proposal_version, index)`.

Added a new `Proposal Status Branches` describe block covering all three branches of `getProposalStatus()`:
- **active** — `executed_at IS NULL`, `now < end_time` → live base state
- **closed (not executed)** — `executed_at IS NULL`, `now > end_time` → versioned base state at `end_time`
- **executed** — `executed_at` set → versioned base state just before `executed_at`

## Out of scope

No e2e flow currently exercises this endpoint. A new `apps/governance-v2/src/flows/proposal-diff.ts` will land in the `geo-e2e` repo separately.

## Test plan

- [x] `bun run check` — clean
- [x] `bun run test` against `src/versioned/` and `src/proposals/__tests__/queries.test.ts` — **223/223 passing**
- [x] Three new status-branch cases log `status=active` / `status=closed` / `status=executed` as expected
- [ ] E2E flow lands in `geo-e2e` (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)