### PR TITLE
feat(hermes): publish latest_processed_block lag metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2733,6 +2733,8 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 name = "hermes-instrumentation"
 version = "0.1.0"
 dependencies = [
+ "metrics",
+ "metrics-exporter-prometheus",
  "opentelemetry 0.31.0",
  "opentelemetry-http",
  "opentelemetry-otlp",
@@ -3842,6 +3844,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "metrics"
+version = "0.24.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff56c2e7dce6bd462e3b8919986a617027481b1dcc703175b58cf9dd98a2f071"
+dependencies = [
+ "portable-atomic",
+ "rapidhash",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b166dea96003ee2531cf14833efedced545751d800f03535801d833313f8c15"
+dependencies = [
+ "base64 0.22.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "indexmap 2.13.0",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ff5c12b797ebf094dc7c1d87e905efc0329cba332f96d51db03875441012b5"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.16.1",
+ "metrics",
+ "quanta",
+ "rand 0.9.2",
+ "rand_xoshiro",
+ "rapidhash",
+ "sketches-ddsketch",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4729,6 +4778,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4987,6 +5042,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5140,12 +5210,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "rapidhash"
-version = "4.2.1"
+name = "rand_xoshiro"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d8b5b858a440a0bc02625b62dd95131b9201aa9f69f411195dd4a7cfb1de3d7"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rapidhash"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -6299,6 +6387,12 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
 
 [[package]]
 name = "slab"
@@ -7774,6 +7868,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7781,6 +7891,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/hermes-instrumentation/Cargo.toml
+++ b/hermes-instrumentation/Cargo.toml
@@ -21,6 +21,10 @@ reqwest = { version = "0.12", default-features = false, features = ["blocking", 
 # Sentry
 sentry = { version = "0.46", default-features = false, features = ["backtrace", "contexts", "logs", "opentelemetry", "panic", "reqwest", "rustls", "tracing"] }
 
+# Prometheus metrics
+metrics = "0.24"
+metrics-exporter-prometheus = { version = "0.17", default-features = false, features = ["http-listener"] }
+
 # Error handling
 thiserror = "2"
 

--- a/hermes-instrumentation/src/lib.rs
+++ b/hermes-instrumentation/src/lib.rs
@@ -35,6 +35,7 @@
 
 mod config;
 mod init;
+pub mod metrics;
 
 // Re-export configuration types
 pub use config::{AxiomConfig, Backend, Config};

--- a/hermes-instrumentation/src/metrics.rs
+++ b/hermes-instrumentation/src/metrics.rs
@@ -1,0 +1,139 @@
+//! Prometheus metrics for the Hermes ecosystem.
+//!
+//! Exposes a small public API for installing a Prometheus recorder and HTTP
+//! `/metrics` listener, plus typed setters for the gauges that hermes services
+//! emit. Service identification (e.g. `hermes-pipeline` vs `hermes-ipfs-cache`)
+//! is provided by the Prometheus `ServiceMonitor` target label, so the gauges
+//! themselves carry no labels.
+//!
+//! # Usage
+//!
+//! ```rust,no_run
+//! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! // Must be called from inside a Tokio runtime — the HTTP listener is spawned
+//! // onto the current runtime. Pass `None` to bind on the default port (9464),
+//! // or `Some(port)` to override (e.g. from a `METRICS_PORT` env var).
+//! hermes_instrumentation::metrics::install("hermes-pipeline", None)?;
+//!
+//! hermes_instrumentation::metrics::set_latest_processed_block(123);
+//! hermes_instrumentation::metrics::set_latest_processed_block_timestamp(1_714_000_000);
+//! # Ok(()) }
+//! ```
+
+use std::net::SocketAddr;
+
+use metrics_exporter_prometheus::{BuildError, PrometheusBuilder};
+
+pub const DEFAULT_PORT: u16 = 9464;
+
+const LATEST_PROCESSED_BLOCK: &str = "hermes_latest_processed_block";
+const LATEST_PROCESSED_BLOCK_TIMESTAMP: &str = "hermes_latest_processed_block_timestamp";
+
+/// Errors returned from [`install`].
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// The exporter failed to bind its HTTP listener or register the recorder.
+    /// Wraps the underlying [`BuildError`] from `metrics-exporter-prometheus`,
+    /// which covers double-install (`set_global_recorder` returns `Err` rather
+    /// than panicking) as well as listener bind failures.
+    #[error("failed to install Prometheus metrics exporter: {0}")]
+    Builder(#[from] BuildError),
+}
+
+/// Install the Prometheus recorder and start an HTTP `/metrics` listener.
+///
+/// Must be called from inside a Tokio runtime — the listener is spawned via
+/// `Handle::current()`. Calling outside a runtime will panic.
+///
+/// `port: None` binds on [`DEFAULT_PORT`]; pass `Some(port)` to override
+/// (e.g. from a `METRICS_PORT` env var).
+///
+/// `service` is informational (logged at startup); the metric labels come from
+/// the `ServiceMonitor` target, not the metric itself.
+///
+/// Calling more than once per process returns `Err` rather than panicking.
+pub fn install(service: &str, port: Option<u16>) -> Result<(), Error> {
+    let port = port.unwrap_or(DEFAULT_PORT);
+    let addr: SocketAddr = ([0, 0, 0, 0], port).into();
+    PrometheusBuilder::new()
+        .with_http_listener(addr)
+        .install()?;
+    tracing::info!(
+        service.name = service,
+        port = port,
+        "Prometheus metrics listener installed"
+    );
+    Ok(())
+}
+
+/// Update the `hermes_latest_processed_block` gauge.
+///
+/// Call this each time a block has been fully processed end-to-end (e.g. block
+/// summary emitted to Kafka, or cursor durably persisted). The chain-tip
+/// distance against `chain_tip_block_number` is what drives the lag alerts.
+pub fn set_latest_processed_block(block: u64) {
+    metrics::gauge!(LATEST_PROCESSED_BLOCK).set(block as f64);
+}
+
+/// Update the `hermes_latest_processed_block_timestamp` gauge (Unix seconds).
+///
+/// This is the *block's* clock time (`clock.timestamp.seconds` from the
+/// substream), not the time the gauge was set. Lag alerts compute
+/// `time() - <gauge>` to produce a "seconds behind real-time" signal that
+/// doesn't depend on a chain-tip exporter being healthy.
+pub fn set_latest_processed_block_timestamp(unix_seconds: i64) {
+    metrics::gauge!(LATEST_PROCESSED_BLOCK_TIMESTAMP).set(unix_seconds as f64);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use metrics_exporter_prometheus::PrometheusBuilder;
+
+    /// Build a local recorder, run the closure with it scoped, and return the
+    /// rendered Prometheus text. Avoids touching the global recorder so tests
+    /// can run in parallel without `serial_test`.
+    fn render_with(f: impl FnOnce()) -> String {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        metrics::with_local_recorder(&recorder, f);
+        handle.render()
+    }
+
+    #[test]
+    fn set_latest_processed_block_emits_gauge() {
+        let rendered = render_with(|| set_latest_processed_block(42));
+        assert!(
+            rendered.contains("hermes_latest_processed_block 42"),
+            "expected gauge in output, got:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn set_latest_processed_block_timestamp_emits_gauge() {
+        let rendered = render_with(|| set_latest_processed_block_timestamp(1_714_000_000));
+        assert!(
+            rendered.contains("hermes_latest_processed_block_timestamp 1714000000"),
+            "expected timestamp gauge in output, got:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn gauge_replaces_previous_value() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        metrics::with_local_recorder(&recorder, || {
+            set_latest_processed_block(42);
+            set_latest_processed_block(7);
+        });
+        let rendered = handle.render();
+        assert!(
+            rendered.contains("hermes_latest_processed_block 7"),
+            "expected replaced value, got:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains("hermes_latest_processed_block 42"),
+            "old value should not be present, got:\n{rendered}"
+        );
+    }
+}

--- a/hermes-ipfs-cache/src/lib.rs
+++ b/hermes-ipfs-cache/src/lib.rs
@@ -72,32 +72,42 @@ pub enum IpfsCacheError {
 /// This ensures correctness while maintaining parallelism across blocks.
 #[derive(Default)]
 struct PendingFetches {
-    /// Map of block number -> (cursor, pending count)
-    blocks: BTreeMap<u64, (String, usize, usize, Instant)>,
+    /// Map of block number -> (cursor, block timestamp seconds, pending count, total count, started at)
+    blocks: BTreeMap<u64, (String, i64, usize, usize, Instant)>,
 }
 
 impl PendingFetches {
     /// Register pending fetches for a block.
-    fn add_block(&mut self, block: u64, cursor: String, count: usize) {
+    fn add_block(&mut self, block: u64, cursor: String, timestamp_seconds: i64, count: usize) {
         if count > 0 {
-            self.blocks
-                .insert(block, (cursor, count, count, Instant::now()));
+            self.blocks.insert(
+                block,
+                (cursor, timestamp_seconds, count, count, Instant::now()),
+            );
         }
     }
 
     /// Mark one fetch as complete for a block.
     ///
-    /// Returns `Some((block, cursor))` if this block is now fully complete
-    /// AND it's the minimum block (safe to persist).
-    fn complete_one(&mut self, block: u64) -> Option<(u64, String, usize, Duration)> {
+    /// Returns `Some((block, cursor, timestamp_seconds, total, duration))` if
+    /// this block is now fully complete AND it's the minimum block (safe to
+    /// persist).
+    fn complete_one(&mut self, block: u64) -> Option<(u64, String, i64, usize, Duration)> {
         // First check if this block exists and decrement
-        let (is_complete, cursor, total, started_at) = match self.blocks.get_mut(&block) {
-            Some((cursor, remaining, total, started_at)) => {
-                *remaining = remaining.saturating_sub(1);
-                (*remaining == 0, cursor.clone(), *total, *started_at)
-            }
-            None => return None,
-        };
+        let (is_complete, cursor, timestamp_seconds, total, started_at) =
+            match self.blocks.get_mut(&block) {
+                Some((cursor, timestamp_seconds, remaining, total, started_at)) => {
+                    *remaining = remaining.saturating_sub(1);
+                    (
+                        *remaining == 0,
+                        cursor.clone(),
+                        *timestamp_seconds,
+                        *total,
+                        *started_at,
+                    )
+                }
+                None => return None,
+            };
 
         if !is_complete {
             return None;
@@ -108,7 +118,13 @@ impl PendingFetches {
         self.blocks.remove(&block);
 
         if is_min {
-            Some((block, cursor, total, started_at.elapsed()))
+            Some((
+                block,
+                cursor,
+                timestamp_seconds,
+                total,
+                started_at.elapsed(),
+            ))
         } else {
             None
         }
@@ -176,6 +192,12 @@ impl Sink for IpfsCacheSink {
 
         // Get block metadata
         let block_number = data.clock.as_ref().map(|c| c.number).unwrap_or(0);
+        let block_timestamp_seconds: i64 = data
+            .clock
+            .as_ref()
+            .and_then(|c| c.timestamp.as_ref())
+            .map(|t| t.seconds)
+            .unwrap_or(0);
         let cursor = data.cursor.clone();
         let edit_count = uri_list.uris.len();
 
@@ -209,10 +231,12 @@ impl Sink for IpfsCacheSink {
         info!(block = block_number, edits = edit_count, "Processing edits");
 
         // Register all pending fetches for this block upfront
-        self.pending
-            .lock()
-            .await
-            .add_block(block_number, cursor.clone(), edit_count);
+        self.pending.lock().await.add_block(
+            block_number,
+            cursor.clone(),
+            block_timestamp_seconds,
+            edit_count,
+        );
 
         // Process each IPFS URI
         for ipfs_uri in uri_list.uris {
@@ -270,8 +294,13 @@ impl Sink for IpfsCacheSink {
                     // Mark this fetch as complete - persist cursor if block fully completed
                     let cursor_to_persist = pending.lock().await.complete_one(block_num);
 
-                    if let Some((persist_block, persist_cursor, total, duration)) =
-                        cursor_to_persist
+                    if let Some((
+                        persist_block,
+                        persist_cursor,
+                        persist_timestamp,
+                        total,
+                        duration,
+                    )) = cursor_to_persist
                     {
                         debug!(
                             block = persist_block,
@@ -291,6 +320,14 @@ impl Sink for IpfsCacheSink {
                             .await
                         {
                             error!(error = %e, "Failed to persist cursor");
+                        } else {
+                            // Cursor durably persisted — update lag gauges.
+                            hermes_instrumentation::metrics::set_latest_processed_block(
+                                persist_block,
+                            );
+                            hermes_instrumentation::metrics::set_latest_processed_block_timestamp(
+                                persist_timestamp,
+                            );
                         }
                     }
 
@@ -435,17 +472,23 @@ async fn process_ipfs_uri(
 mod tests {
     use super::*;
 
+    /// Synthetic Unix-seconds timestamps for tests. Distinct from block numbers
+    /// so a regression that swaps the two would surface.
+    const TS_100: i64 = 1_700_000_100;
+    const TS_101: i64 = 1_700_000_101;
+    const TS_102: i64 = 1_700_000_102;
+
     #[test]
     fn pending_fetches_single_block_single_edit() {
         let mut pending = PendingFetches::default();
 
-        pending.add_block(100, "cursor_100".to_string(), 1);
+        pending.add_block(100, "cursor_100".to_string(), TS_100, 1);
 
         // Completing the only fetch should return the cursor
         let result = pending.complete_one(100);
         assert!(matches!(
             result,
-            Some((100, ref cursor, 1, _)) if cursor == "cursor_100"
+            Some((100, ref cursor, TS_100, 1, _)) if cursor == "cursor_100"
         ));
 
         // No more pending
@@ -456,7 +499,7 @@ mod tests {
     fn pending_fetches_single_block_multiple_edits() {
         let mut pending = PendingFetches::default();
 
-        pending.add_block(100, "cursor_100".to_string(), 3);
+        pending.add_block(100, "cursor_100".to_string(), TS_100, 3);
 
         // First two completions should not persist
         assert_eq!(pending.complete_one(100), None);
@@ -465,7 +508,7 @@ mod tests {
         // Third completion should persist
         assert!(matches!(
             pending.complete_one(100),
-            Some((100, ref cursor, 3, _)) if cursor == "cursor_100"
+            Some((100, ref cursor, TS_100, 3, _)) if cursor == "cursor_100"
         ));
 
         assert!(pending.blocks.is_empty());
@@ -475,20 +518,20 @@ mod tests {
     fn pending_fetches_multiple_blocks_complete_in_order() {
         let mut pending = PendingFetches::default();
 
-        pending.add_block(100, "cursor_100".to_string(), 2);
-        pending.add_block(101, "cursor_101".to_string(), 1);
+        pending.add_block(100, "cursor_100".to_string(), TS_100, 2);
+        pending.add_block(101, "cursor_101".to_string(), TS_101, 1);
 
         // Complete block 100 first
         assert_eq!(pending.complete_one(100), None); // 1 remaining
         assert!(matches!(
             pending.complete_one(100),
-            Some((100, ref cursor, 2, _)) if cursor == "cursor_100"
+            Some((100, ref cursor, TS_100, 2, _)) if cursor == "cursor_100"
         ));
 
         // Now complete block 101
         assert!(matches!(
             pending.complete_one(101),
-            Some((101, ref cursor, 1, _)) if cursor == "cursor_101"
+            Some((101, ref cursor, TS_101, 1, _)) if cursor == "cursor_101"
         ));
 
         assert!(pending.blocks.is_empty());
@@ -498,8 +541,8 @@ mod tests {
     fn pending_fetches_multiple_blocks_complete_out_of_order() {
         let mut pending = PendingFetches::default();
 
-        pending.add_block(100, "cursor_100".to_string(), 2);
-        pending.add_block(101, "cursor_101".to_string(), 1);
+        pending.add_block(100, "cursor_100".to_string(), TS_100, 2);
+        pending.add_block(101, "cursor_101".to_string(), TS_101, 1);
 
         // Complete block 101 first - should NOT persist (100 still pending)
         assert_eq!(pending.complete_one(101), None);
@@ -511,7 +554,7 @@ mod tests {
         assert_eq!(pending.complete_one(100), None); // 1 remaining
         assert!(matches!(
             pending.complete_one(100),
-            Some((100, ref cursor, 2, _)) if cursor == "cursor_100"
+            Some((100, ref cursor, TS_100, 2, _)) if cursor == "cursor_100"
         ));
 
         assert!(pending.blocks.is_empty());
@@ -521,9 +564,9 @@ mod tests {
     fn pending_fetches_three_blocks_middle_completes_first() {
         let mut pending = PendingFetches::default();
 
-        pending.add_block(100, "cursor_100".to_string(), 1);
-        pending.add_block(101, "cursor_101".to_string(), 1);
-        pending.add_block(102, "cursor_102".to_string(), 1);
+        pending.add_block(100, "cursor_100".to_string(), TS_100, 1);
+        pending.add_block(101, "cursor_101".to_string(), TS_101, 1);
+        pending.add_block(102, "cursor_102".to_string(), TS_102, 1);
 
         // Complete middle block - should NOT persist
         assert_eq!(pending.complete_one(101), None);
@@ -534,7 +577,7 @@ mod tests {
         // Complete first block - should persist
         assert!(matches!(
             pending.complete_one(100),
-            Some((100, ref cursor, 1, _)) if cursor == "cursor_100"
+            Some((100, ref cursor, TS_100, 1, _)) if cursor == "cursor_100"
         ));
 
         // 101 and 102 were already removed, nothing left
@@ -546,7 +589,7 @@ mod tests {
         let mut pending = PendingFetches::default();
 
         // Adding a block with 0 edits should not add it
-        pending.add_block(100, "cursor_100".to_string(), 0);
+        pending.add_block(100, "cursor_100".to_string(), TS_100, 0);
 
         assert!(pending.blocks.is_empty());
     }
@@ -555,7 +598,7 @@ mod tests {
     fn pending_fetches_complete_unknown_block() {
         let mut pending = PendingFetches::default();
 
-        pending.add_block(100, "cursor_100".to_string(), 1);
+        pending.add_block(100, "cursor_100".to_string(), TS_100, 1);
 
         // Completing an unknown block should return None
         assert_eq!(pending.complete_one(999), None);
@@ -568,9 +611,9 @@ mod tests {
     fn pending_fetches_later_blocks_complete_then_first() {
         let mut pending = PendingFetches::default();
 
-        pending.add_block(100, "cursor_100".to_string(), 1);
-        pending.add_block(101, "cursor_101".to_string(), 1);
-        pending.add_block(102, "cursor_102".to_string(), 1);
+        pending.add_block(100, "cursor_100".to_string(), TS_100, 1);
+        pending.add_block(101, "cursor_101".to_string(), TS_101, 1);
+        pending.add_block(102, "cursor_102".to_string(), TS_102, 1);
 
         // Complete 102 first - no persist (100 still pending)
         assert_eq!(pending.complete_one(102), None);
@@ -583,7 +626,7 @@ mod tests {
         // Complete 100 - persist cursor 100 (it's now the min and complete)
         assert!(matches!(
             pending.complete_one(100),
-            Some((100, ref cursor, 1, _)) if cursor == "cursor_100"
+            Some((100, ref cursor, TS_100, 1, _)) if cursor == "cursor_100"
         ));
 
         // All blocks removed
@@ -594,8 +637,8 @@ mod tests {
     fn pending_fetches_interleaved_completions() {
         let mut pending = PendingFetches::default();
 
-        pending.add_block(100, "cursor_100".to_string(), 3);
-        pending.add_block(101, "cursor_101".to_string(), 2);
+        pending.add_block(100, "cursor_100".to_string(), TS_100, 3);
+        pending.add_block(101, "cursor_101".to_string(), TS_101, 2);
 
         // Interleaved completions
         assert_eq!(pending.complete_one(100), None); // 100: 2 remaining
@@ -604,7 +647,7 @@ mod tests {
         assert_eq!(pending.complete_one(101), None); // 101: 0 remaining, but 100 still pending
         assert!(matches!(
             pending.complete_one(100),
-            Some((100, ref cursor, 3, _)) if cursor == "cursor_100"
+            Some((100, ref cursor, TS_100, 3, _)) if cursor == "cursor_100"
         )); // 100: 0 remaining
 
         assert!(pending.blocks.is_empty());

--- a/hermes-ipfs-cache/src/main.rs
+++ b/hermes-ipfs-cache/src/main.rs
@@ -151,6 +151,11 @@ fn main() -> anyhow::Result<()> {
 async fn async_main() -> anyhow::Result<()> {
     info!("Hermes IPFS Cache starting");
 
+    // Install Prometheus /metrics listener. Default port 9464 lives in the
+    // metrics module; override with METRICS_PORT for local runs.
+    let metrics_port: Option<u16> = env::var("METRICS_PORT").ok().and_then(|s| s.parse().ok());
+    hermes_instrumentation::metrics::install("hermes-ipfs-cache", metrics_port)?;
+
     // Determine mode: mock (default for backwards compat during dev) or live
     let use_mock = env::var("USE_MOCK")
         .map(|v| v.eq_ignore_ascii_case("true") || v == "1")

--- a/hermes-pipeline/src/main.rs
+++ b/hermes-pipeline/src/main.rs
@@ -690,6 +690,14 @@ impl Pipeline {
         };
         self.emitter.emit(&summary).await?;
 
+        // Block fully ack'd to Kafka — update lag gauges. The timestamp is
+        // the block's clock time, not now(); time-based lag alerts depend on
+        // that distinction.
+        hermes_instrumentation::metrics::set_latest_processed_block(meta.block_number);
+        hermes_instrumentation::metrics::set_latest_processed_block_timestamp(
+            meta.timestamp.parse().unwrap_or(0),
+        );
+
         // Log block summary
         if total > 0 || total_cache_misses > 0 || total_errored_entries > 0 {
             info!(
@@ -843,6 +851,11 @@ fn main() -> anyhow::Result<()> {
 
 async fn async_main() -> anyhow::Result<()> {
     info!("Hermes Pipeline starting");
+
+    // Install Prometheus /metrics listener. Default port 9464 lives in the
+    // metrics module; override with METRICS_PORT for local runs.
+    let metrics_port: Option<u16> = env::var("METRICS_PORT").ok().and_then(|s| s.parse().ok());
+    hermes_instrumentation::metrics::install("hermes-pipeline", metrics_port)?;
 
     // Determine if we're using mock data
     let use_mock = env::var("USE_MOCK")


### PR DESCRIPTION
First three sub-issues of the Hermes pipeline lag observability epic. Adds a Prometheus `/metrics` endpoint to `hermes-pipeline` and `hermes-ipfs-cache` so we can detect when the streaming pipeline falls behind the chain or gets stuck. Today both services log block numbers but nothing reaches Prometheus, so dashboards and alerts can't reason about lag.

Two gauges per service — block number drives the **stuck** alerts (`increase(...) == 0`); block timestamp (the block's clock time, not scrape time) drives the **lag** alerts (`time() - <gauge> > N`, or against a chain-tip exporter when that lands).

## What's in it

### 1. `hermes-instrumentation::metrics` (new module)

Adds `metrics` and `metrics-exporter-prometheus` deps and a small public API consumed by both hermes services:

- `install(service: &str, port: u16) -> Result<(), Error>` — registers the global recorder and spawns an HTTP `/metrics` listener on the current Tokio runtime. Must be called from inside `async_main`, after the runtime is up.
- `set_latest_processed_block(u64)` — writes the unlabeled `hermes_latest_processed_block` gauge.
- `set_latest_processed_block_timestamp(i64)` — writes the unlabeled `hermes_latest_processed_block_timestamp` gauge (Unix seconds).

Service identification (`hermes-pipeline` vs `hermes-ipfs-cache`) comes from the `ServiceMonitor` target label in K8s, so the gauges themselves carry no labels.

### 2. `hermes-pipeline` wiring

`metrics::install("hermes-pipeline", METRICS_PORT)` at the top of `async_main` (default port 9464, OTel convention — avoids node-exporter 9100 confusion). Both gauges set right after `self.emitter.emit(&summary)` in `process_block_impl` — the "block summary fully ack'd to Kafka" point is what matters for downstream lag.

### 3. `hermes-ipfs-cache` wiring

Same `install` pattern in `async_main`. Block timestamp threaded through `PendingFetches` (one extra `i64` in the per-block tuple, one extra arg on `add_block`, one extra element in the `complete_one` return) so it's available at the cursor-persist site. Both gauges set inside the spawned task **after** `cache.persist_cursor` succeeds — the gauge reflects "cursor durably persisted in the cache DB", not just "in-memory counter went to zero". Out-of-order block completions are silently dropped at the persist signal, so the gauge tracks the **durably-checkpointed cursor**, which is exactly what the lag SLO measures.

## Why this design

- **No `service` label on the metric** — Prometheus `ServiceMonitor` already adds a `service` target label, and adding a second source of truth would just be a footgun. The `service` arg on `install` is informational (logged at startup).
- **Block timestamp instead of (or alongside) chain-tip subtraction** — `time() - <timestamp_gauge>` produces a "seconds behind real-time" alert that doesn't depend on the chain-tip exporter being healthy. When the chain-tip exporter lands in a follow-up issue, it complements this rather than replaces it.
- **Gauge update at the persist signal, not inside `complete_one`** — `complete_one` is a pure data-structure method; coupling it to a global recorder would muddy the existing tests. The call site already returns the `(block, cursor, timestamp, total, duration)` tuple after `persist_cursor` succeeds, so the gauge update sits there cleanly.
- **Default port 9464, not 9100** — 9100 is node-exporter's port; in pods there's no actual collision but operators scanning targets at `:9100` would misread our metrics as node-exporter. 9464 is the OTel default for Prometheus exporters. Override with `METRICS_PORT` env.

## Test plan

- [x] 3 new unit tests in `hermes-instrumentation::metrics` covering both setters and gauge-replace semantics, using `metrics::with_local_recorder` so they run in parallel without touching global state.
- [x] 9 existing `PendingFetches` tests in `hermes-ipfs-cache` updated mechanically (added `TS_xxx` constants and one tuple element).
- [x] `cargo test -p hermes-instrumentation -p hermes-pipeline -p hermes-ipfs-cache` — **116 passed**, 0 failed (3 new + 13 existing in ipfs-cache + 85 + 15 in pipeline).
- [x] Ran both binaries against live Pinax substreams locally; both `/metrics` endpoints returned `HTTP 200` with both gauges populated and advancing block-by-block in real time. ipfs-cache running ~100–200 blocks ahead of pipeline as designed.
- [ ] After merge: K8s `Service` + `ServiceMonitor` + `PrometheusRule` (separate sub-issues in the epic).

## Out of scope (separate sub-issues in the epic)

- chain-tip exporter (publishes `chain_tip_block_number{,_timestamp}`)
- K8s `Service` + `ServiceMonitor` + container port wiring for both services + the chain-tip exporter
- `PrometheusRule` with the lag/stuck/stale alerts
- Observability docs

## Files

- `hermes-instrumentation/Cargo.toml` — `metrics`, `metrics-exporter-prometheus` deps
- `hermes-instrumentation/src/metrics.rs` (new) — `install` + 2 setters + tests
- `hermes-instrumentation/src/lib.rs` — `pub mod metrics;`
- `hermes-pipeline/src/main.rs` — install + 2 gauge calls
- `hermes-ipfs-cache/src/main.rs` — install
- `hermes-ipfs-cache/src/lib.rs` — plumb timestamp through `PendingFetches` + 2 gauge calls