### PR TITLE
feat(atlas): drop Member and Editor edges from canonical and transitive graphs

### DIFF
--- a/atlas/README.md
+++ b/atlas/README.md
@@ -57,7 +57,7 @@ Access Kafka UI at http://localhost:8080 to view messages.
 | `SUBSTREAMS_END_BLOCK` | No | `u64::MAX` | End block for live stream |
 | `ATLAS_CHECKPOINT_DATABASE_URL` | No | - | PostgreSQL URL for checkpoint persistence |
 | `ATLAS_INDEXER_ID` | Conditional | - | Required and non-empty when checkpoint persistence is enabled |
-| `ATLAS_RUNTIME_COMPATIBILITY_MARKER` | No | `atlas-v1` | Runtime marker used for checkpoint compatibility validation |
+| `ATLAS_RUNTIME_COMPATIBILITY_MARKER` | No | `atlas-v2` | Runtime marker used for checkpoint compatibility validation |
 | `ATLAS_CHECKPOINT_ALLOW_FRESH_START` | No | `false` | If true, incompatible/corrupt checkpoints fall back to fresh bootstrap |
 | `ATLAS_FAIL_OPEN_BOUND` | No | `10` | Max uncheckpointed blocks before Atlas pauses processing |
 | `ATLAS_CHECKPOINT_RETRY_ATTEMPTS` | No | `3` | Retry attempts for checkpoint writes |

--- a/atlas/benches/graph_diff.rs
+++ b/atlas/benches/graph_diff.rs
@@ -35,7 +35,6 @@ fn build_random_tree(node_count: usize, seed: u64) -> TreeNode {
         EdgeType::Verified,
         EdgeType::Related,
         EdgeType::Editor,
-        EdgeType::Member,
     ];
 
     // Build tree recursively from parent indices
@@ -141,9 +140,8 @@ fn mutate_tree(tree: &TreeNode, change_rate: f64, seed: u64) -> TreeNode {
             EdgeType::Verified,
             EdgeType::Related,
             EdgeType::Editor,
-            EdgeType::Member,
         ];
-        nodes.push((new_id, edge_types[rng.gen_range(0..4)], vec![]));
+        nodes.push((new_id, edge_types[rng.gen_range(0..edge_types.len())], vec![]));
 
         // Ensure parent exists (it should, we just selected it)
         let _ = parent_id;

--- a/atlas/benches/graph_diff.rs
+++ b/atlas/benches/graph_diff.rs
@@ -31,11 +31,7 @@ fn build_random_tree(node_count: usize, seed: u64) -> TreeNode {
     }
 
     // Build nodes with random edge types
-    let edge_types = [
-        EdgeType::Verified,
-        EdgeType::Related,
-        EdgeType::Editor,
-    ];
+    let edge_types = [EdgeType::Verified, EdgeType::Related];
 
     // Build tree recursively from parent indices
     fn add_children(
@@ -136,11 +132,7 @@ fn mutate_tree(tree: &TreeNode, change_rate: f64, seed: u64) -> TreeNode {
         let parent_id = nodes[parent_idx].0;
         nodes[parent_idx].2.push(new_id);
 
-        let edge_types = [
-            EdgeType::Verified,
-            EdgeType::Related,
-            EdgeType::Editor,
-        ];
+        let edge_types = [EdgeType::Verified, EdgeType::Related];
         nodes.push((new_id, edge_types[rng.gen_range(0..edge_types.len())], vec![]));
 
         // Ensure parent exists (it should, we just selected it)

--- a/atlas/src/graph/canonical.rs
+++ b/atlas/src/graph/canonical.rs
@@ -775,4 +775,36 @@ mod tests {
             "Member-only reachable space must not be canonical"
         );
     }
+
+    #[test]
+    fn test_editor_edge_from_root_does_not_grant_canonical() {
+        // Plan 0007: Editor edges no longer grant canonical membership.
+        // An EditorAdded(root, X) event must leave X outside the canonical set.
+        let mut state = GraphState::new();
+        let root = create_space(&mut state, 1);
+        let x = create_space(&mut state, 2);
+
+        let editor_event = SpaceTopologyEvent {
+            meta: make_block_meta(),
+            payload: SpaceTopologyPayload::TrustExtended(TrustExtended {
+                source_space_id: root,
+                extension: TrustExtension::EditorAdded { member_space_id: x },
+            }),
+        };
+        state.apply_event(&editor_event);
+
+        let mut transitive = TransitiveProcessor::new();
+        let mut processor = CanonicalProcessor::new(root);
+
+        let graph = processor
+            .compute_if_changed(&state, &mut transitive)
+            .unwrap();
+
+        assert_eq!(graph.len(), 1, "canonical set must contain only root");
+        assert!(graph.contains(&root));
+        assert!(
+            !graph.contains(&x),
+            "Editor-only reachable space must not be canonical"
+        );
+    }
 }

--- a/atlas/src/graph/canonical.rs
+++ b/atlas/src/graph/canonical.rs
@@ -741,4 +741,38 @@ mod tests {
         // All explicitly connected nodes are canonical
         assert_eq!(graph.len(), 5);
     }
+
+    #[test]
+    fn test_member_edge_from_root_does_not_grant_canonical() {
+        // Plan 0007: Member edges no longer grant canonical membership.
+        // A MemberAdded(root, X) event must leave X outside the canonical set.
+        let mut state = GraphState::new();
+        let root = create_space(&mut state, 1);
+        let x = create_space(&mut state, 2);
+
+        // Apply a MemberAdded event directly — bypasses the test helpers
+        // so we exercise the same path the chain takes.
+        let member_event = SpaceTopologyEvent {
+            meta: make_block_meta(),
+            payload: SpaceTopologyPayload::TrustExtended(TrustExtended {
+                source_space_id: root,
+                extension: TrustExtension::MemberAdded { member_space_id: x },
+            }),
+        };
+        state.apply_event(&member_event);
+
+        let mut transitive = TransitiveProcessor::new();
+        let mut processor = CanonicalProcessor::new(root);
+
+        let graph = processor
+            .compute_if_changed(&state, &mut transitive)
+            .unwrap();
+
+        assert_eq!(graph.len(), 1, "canonical set must contain only root");
+        assert!(graph.contains(&root));
+        assert!(
+            !graph.contains(&x),
+            "Member-only reachable space must not be canonical"
+        );
+    }
 }

--- a/atlas/src/graph/state.rs
+++ b/atlas/src/graph/state.rs
@@ -104,9 +104,6 @@ impl GraphState {
             TrustExtension::Subtopic { target_topic_id } => {
                 self.add_topic_edge(source, *target_topic_id);
             }
-            TrustExtension::EditorAdded { member_space_id } => {
-                self.add_explicit_edge(source, *member_space_id, EdgeType::Editor);
-            }
 
             // --- Edge Removals ---
             TrustExtension::VerifiedRemoved { target_space_id } => {
@@ -115,20 +112,22 @@ impl GraphState {
             TrustExtension::RelatedRemoved { target_space_id } => {
                 self.remove_explicit_edge(source, *target_space_id, EdgeType::Related);
             }
-            TrustExtension::EditorRemoved { member_space_id } => {
-                self.remove_explicit_edge(source, *member_space_id, EdgeType::Editor);
-            }
             TrustExtension::SubtopicRemoved { target_topic_id } => {
                 self.remove_topic_edge(source, *target_topic_id);
             }
 
-            // Member edges are ignored — see plan 0007. Variants stay in the
-            // TrustExtension enum so convert.rs (chain action parsing) is untouched.
-            TrustExtension::MemberAdded { .. } | TrustExtension::MemberRemoved { .. } => {}
+            // Member and Editor edges are ignored — see plan 0007. Variants stay
+            // in the TrustExtension enum so convert.rs (chain action parsing) is
+            // untouched. Only Verified, Related, and Subtopic remain as
+            // canonical-granting edges.
+            TrustExtension::MemberAdded { .. }
+            | TrustExtension::MemberRemoved { .. }
+            | TrustExtension::EditorAdded { .. }
+            | TrustExtension::EditorRemoved { .. } => {}
         }
     }
 
-    /// Add an explicit edge (Verified, Related, Editor)
+    /// Add an explicit edge (Verified, Related)
     fn add_explicit_edge(&mut self, source: SpaceId, target: SpaceId, edge_type: EdgeType) {
         // Intentionally allow duplicate entries.
         //
@@ -463,6 +462,65 @@ mod tests {
             state.explicit_edge_count(),
             1,
             "MemberRemoved must not remove unrelated edges"
+        );
+    }
+
+    // Editor events must also be no-ops at the state layer — see plan 0007.
+
+    fn editor_event(source: SpaceId, target: SpaceId, add: bool) -> SpaceTopologyEvent {
+        SpaceTopologyEvent {
+            meta: make_block_meta_at(2),
+            payload: SpaceTopologyPayload::TrustExtended(TrustExtended {
+                source_space_id: source,
+                extension: if add {
+                    TrustExtension::EditorAdded {
+                        member_space_id: target,
+                    }
+                } else {
+                    TrustExtension::EditorRemoved {
+                        member_space_id: target,
+                    }
+                },
+            }),
+        }
+    }
+
+    #[test]
+    fn test_editor_added_is_no_op() {
+        let mut state = GraphState::new();
+        let source = make_space_id(1);
+        let target = make_space_id(2);
+        state.apply_event(&make_space_created_event(source, make_topic_id(1)));
+        state.apply_event(&make_space_created_event(target, make_topic_id(2)));
+
+        state.apply_event(&editor_event(source, target, true));
+
+        assert_eq!(
+            state.explicit_edge_count(),
+            0,
+            "EditorAdded must not produce an explicit edge"
+        );
+        assert!(state.get_explicit_edges(&source).is_none());
+    }
+
+    #[test]
+    fn test_editor_removed_is_no_op() {
+        let mut state = GraphState::new();
+        let source = make_space_id(1);
+        let target = make_space_id(2);
+        state.apply_event(&make_space_created_event(source, make_topic_id(1)));
+        state.apply_event(&make_space_created_event(target, make_topic_id(2)));
+
+        // Add a verified edge so we can verify EditorRemoved doesn't disturb it.
+        state.apply_event(&make_verified_event(source, target));
+        assert_eq!(state.explicit_edge_count(), 1);
+
+        state.apply_event(&editor_event(source, target, false));
+
+        assert_eq!(
+            state.explicit_edge_count(),
+            1,
+            "EditorRemoved must not remove unrelated edges"
         );
     }
 }

--- a/atlas/src/graph/state.rs
+++ b/atlas/src/graph/state.rs
@@ -118,8 +118,14 @@ impl GraphState {
 
             // Member and Editor edges are ignored — see plan 0007. Variants stay
             // in the TrustExtension enum so convert.rs (chain action parsing) is
-            // untouched. Only Verified, Related, and Subtopic remain as
-            // canonical-granting edges.
+            // untouched.
+            //
+            // Edge types that still affect Atlas's output after this change:
+            //   • Verified / Related — grant *canonical membership* via the
+            //     explicit-only BFS in canonical.rs Phase 1.
+            //   • Subtopic           — does NOT grant canonical membership; it
+            //     attaches filtered subtrees between already-canonical members
+            //     in canonical.rs Phase 2 (collect_topic_subtrees).
             TrustExtension::MemberAdded { .. }
             | TrustExtension::MemberRemoved { .. }
             | TrustExtension::EditorAdded { .. }

--- a/atlas/src/graph/state.rs
+++ b/atlas/src/graph/state.rs
@@ -107,9 +107,6 @@ impl GraphState {
             TrustExtension::EditorAdded { member_space_id } => {
                 self.add_explicit_edge(source, *member_space_id, EdgeType::Editor);
             }
-            TrustExtension::MemberAdded { member_space_id } => {
-                self.add_explicit_edge(source, *member_space_id, EdgeType::Member);
-            }
 
             // --- Edge Removals ---
             TrustExtension::VerifiedRemoved { target_space_id } => {
@@ -121,16 +118,17 @@ impl GraphState {
             TrustExtension::EditorRemoved { member_space_id } => {
                 self.remove_explicit_edge(source, *member_space_id, EdgeType::Editor);
             }
-            TrustExtension::MemberRemoved { member_space_id } => {
-                self.remove_explicit_edge(source, *member_space_id, EdgeType::Member);
-            }
             TrustExtension::SubtopicRemoved { target_topic_id } => {
                 self.remove_topic_edge(source, *target_topic_id);
             }
+
+            // Member edges are ignored — see plan 0007. Variants stay in the
+            // TrustExtension enum so convert.rs (chain action parsing) is untouched.
+            TrustExtension::MemberAdded { .. } | TrustExtension::MemberRemoved { .. } => {}
         }
     }
 
-    /// Add an explicit edge (Verified, Related, Editor, Member)
+    /// Add an explicit edge (Verified, Related, Editor)
     fn add_explicit_edge(&mut self, source: SpaceId, target: SpaceId, edge_type: EdgeType) {
         // Intentionally allow duplicate entries.
         //
@@ -405,5 +403,66 @@ mod tests {
         assert_eq!(members.len(), 2);
         assert!(members.contains(&space1));
         assert!(members.contains(&space2));
+    }
+
+    // Member events must be no-ops at the state layer — see plan 0007.
+    // They still arrive from the chain via convert.rs but never produce
+    // edges in any graph view.
+
+    fn member_event(source: SpaceId, target: SpaceId, add: bool) -> SpaceTopologyEvent {
+        SpaceTopologyEvent {
+            meta: make_block_meta_at(2),
+            payload: SpaceTopologyPayload::TrustExtended(TrustExtended {
+                source_space_id: source,
+                extension: if add {
+                    TrustExtension::MemberAdded {
+                        member_space_id: target,
+                    }
+                } else {
+                    TrustExtension::MemberRemoved {
+                        member_space_id: target,
+                    }
+                },
+            }),
+        }
+    }
+
+    #[test]
+    fn test_member_added_is_no_op() {
+        let mut state = GraphState::new();
+        let source = make_space_id(1);
+        let target = make_space_id(2);
+        state.apply_event(&make_space_created_event(source, make_topic_id(1)));
+        state.apply_event(&make_space_created_event(target, make_topic_id(2)));
+
+        state.apply_event(&member_event(source, target, true));
+
+        assert_eq!(
+            state.explicit_edge_count(),
+            0,
+            "MemberAdded must not produce an explicit edge"
+        );
+        assert!(state.get_explicit_edges(&source).is_none());
+    }
+
+    #[test]
+    fn test_member_removed_is_no_op() {
+        let mut state = GraphState::new();
+        let source = make_space_id(1);
+        let target = make_space_id(2);
+        state.apply_event(&make_space_created_event(source, make_topic_id(1)));
+        state.apply_event(&make_space_created_event(target, make_topic_id(2)));
+
+        // Add a verified edge so we can verify MemberRemoved doesn't disturb it.
+        state.apply_event(&make_verified_event(source, target));
+        assert_eq!(state.explicit_edge_count(), 1);
+
+        state.apply_event(&member_event(source, target, false));
+
+        assert_eq!(
+            state.explicit_edge_count(),
+            1,
+            "MemberRemoved must not remove unrelated edges"
+        );
     }
 }

--- a/atlas/src/graph/transitive.rs
+++ b/atlas/src/graph/transitive.rs
@@ -254,13 +254,15 @@ impl TransitiveProcessor {
                         self.cache.invalidate(target_space_id);
                     }
 
-                    // Membership edges: invalidate member space
+                    // Editor edges: invalidate member space
                     TrustExtension::EditorAdded { member_space_id }
-                    | TrustExtension::MemberAdded { member_space_id }
-                    | TrustExtension::EditorRemoved { member_space_id }
-                    | TrustExtension::MemberRemoved { member_space_id } => {
+                    | TrustExtension::EditorRemoved { member_space_id } => {
                         self.cache.invalidate(member_space_id);
                     }
+
+                    // Member edges: no-op — Member events do not mutate state (plan 0007).
+                    TrustExtension::MemberAdded { .. }
+                    | TrustExtension::MemberRemoved { .. } => {}
 
                     // Topic edges: invalidate all spaces that announced this topic
                     TrustExtension::Subtopic { target_topic_id }
@@ -616,5 +618,35 @@ mod tests {
             stats_after.reverse_deps_count, 0,
             "stale reverse_deps should be cleaned up"
         );
+    }
+
+    #[test]
+    fn test_member_edge_not_in_transitive() {
+        // Plan 0007: Member edges are no-ops. A space reachable only via a
+        // Member edge must not appear in the transitive graph rooted at the
+        // source — neither in the flat membership set nor in the tree.
+        let mut state = GraphState::new();
+        let a = create_space(&mut state, 1);
+        let b = create_space(&mut state, 2);
+
+        let member_event = SpaceTopologyEvent {
+            meta: make_block_meta(),
+            payload: SpaceTopologyPayload::TrustExtended(TrustExtended {
+                source_space_id: a,
+                extension: TrustExtension::MemberAdded { member_space_id: b },
+            }),
+        };
+        state.apply_event(&member_event);
+
+        let mut processor = TransitiveProcessor::new();
+        let graph = processor.get_full(a, &state);
+
+        assert_eq!(graph.len(), 1, "A reaches only itself");
+        assert!(graph.contains(&a));
+        assert!(
+            !graph.contains(&b),
+            "B must not be reachable through a Member edge"
+        );
+        assert_eq!(graph.tree.node_count(), 1);
     }
 }

--- a/atlas/src/graph/transitive.rs
+++ b/atlas/src/graph/transitive.rs
@@ -254,15 +254,11 @@ impl TransitiveProcessor {
                         self.cache.invalidate(target_space_id);
                     }
 
-                    // Editor edges: invalidate member space
-                    TrustExtension::EditorAdded { member_space_id }
-                    | TrustExtension::EditorRemoved { member_space_id } => {
-                        self.cache.invalidate(member_space_id);
-                    }
-
-                    // Member edges: no-op — Member events do not mutate state (plan 0007).
+                    // Member and Editor edges: no-op — these events do not mutate state (plan 0007).
                     TrustExtension::MemberAdded { .. }
-                    | TrustExtension::MemberRemoved { .. } => {}
+                    | TrustExtension::MemberRemoved { .. }
+                    | TrustExtension::EditorAdded { .. }
+                    | TrustExtension::EditorRemoved { .. } => {}
 
                     // Topic edges: invalidate all spaces that announced this topic
                     TrustExtension::Subtopic { target_topic_id }
@@ -646,6 +642,36 @@ mod tests {
         assert!(
             !graph.contains(&b),
             "B must not be reachable through a Member edge"
+        );
+        assert_eq!(graph.tree.node_count(), 1);
+    }
+
+    #[test]
+    fn test_editor_edge_not_in_transitive() {
+        // Plan 0007: Editor edges are no-ops. A space reachable only via an
+        // Editor edge must not appear in the transitive graph rooted at the
+        // source — neither in the flat membership set nor in the tree.
+        let mut state = GraphState::new();
+        let a = create_space(&mut state, 1);
+        let b = create_space(&mut state, 2);
+
+        let editor_event = SpaceTopologyEvent {
+            meta: make_block_meta(),
+            payload: SpaceTopologyPayload::TrustExtended(TrustExtended {
+                source_space_id: a,
+                extension: TrustExtension::EditorAdded { member_space_id: b },
+            }),
+        };
+        state.apply_event(&editor_event);
+
+        let mut processor = TransitiveProcessor::new();
+        let graph = processor.get_full(a, &state);
+
+        assert_eq!(graph.len(), 1, "A reaches only itself");
+        assert!(graph.contains(&a));
+        assert!(
+            !graph.contains(&b),
+            "B must not be reachable through an Editor edge"
         );
         assert_eq!(graph.tree.node_count(), 1);
     }

--- a/atlas/src/graph/tree.rs
+++ b/atlas/src/graph/tree.rs
@@ -18,8 +18,6 @@ pub enum EdgeType {
     Topic { topic_id: TopicId },
     /// Editor membership (canonical-granting)
     Editor,
-    /// Member membership (canonical-granting)
-    Member,
 }
 
 /// A node in the traversal tree

--- a/atlas/src/graph/tree.rs
+++ b/atlas/src/graph/tree.rs
@@ -16,8 +16,6 @@ pub enum EdgeType {
     Related,
     /// Topic-based membership — carries the topic that created this edge
     Topic { topic_id: TopicId },
-    /// Editor membership (canonical-granting)
-    Editor,
 }
 
 /// A node in the traversal tree

--- a/atlas/src/kafka/emitter.rs
+++ b/atlas/src/kafka/emitter.rs
@@ -44,7 +44,7 @@ use hermes_instrumentation::{debug_span, warn};
 use hermes_schema::pb::blockchain_metadata::BlockchainMetadata as ProtoBlockchainMetadata;
 use hermes_schema::pb::topology::{
     canonical_tree_node::Edge, edge_info, CanonicalGraphDiff, CanonicalGraphUpdated,
-    CanonicalTreeNode, ChangeType as ProtoChangeType, EdgeInfo, EditorEdge, MemberEdge,
+    CanonicalTreeNode, ChangeType as ProtoChangeType, EdgeInfo, EditorEdge,
     NodeChange as ProtoNodeChange, RelatedEdge, RootEdge, TopicEdge, VerifiedEdge,
 };
 use prost::Message;
@@ -187,7 +187,6 @@ fn edge_type_to_proto_edge(edge_type: EdgeType) -> Edge {
             topic_id: topic_id.to_vec(),
         }),
         EdgeType::Editor => Edge::Editor(EditorEdge {}),
-        EdgeType::Member => Edge::Member(MemberEdge {}),
     }
 }
 
@@ -223,7 +222,6 @@ fn position_to_edge_info(pos: &Position) -> Option<EdgeInfo> {
             topic_id: topic_id.to_vec(),
         }),
         EdgeType::Editor => edge_info::EdgeType::Editor(EditorEdge {}),
-        EdgeType::Member => edge_info::EdgeType::Member(MemberEdge {}),
         EdgeType::Root => {
             warn!(
                 parent = ?pos.parent,
@@ -293,21 +291,19 @@ mod tests {
         root.add_child(TreeNode::new(make_space_id(2), EdgeType::Verified));
         root.add_child(TreeNode::new(make_space_id(3), EdgeType::Related));
         root.add_child(TreeNode::new(make_space_id(4), EdgeType::Editor));
-        root.add_child(TreeNode::new(make_space_id(5), EdgeType::Member));
         root.add_child(TreeNode::new_with_topic(
-            make_space_id(6),
+            make_space_id(5),
             make_topic_id(0x8A),
         ));
 
         let proto = tree_node_to_proto(&root);
-        assert_eq!(proto.children.len(), 5);
+        assert_eq!(proto.children.len(), 4);
 
         assert!(matches!(proto.children[0].edge, Some(Edge::Verified(_))));
         assert!(matches!(proto.children[1].edge, Some(Edge::Related(_))));
         assert!(matches!(proto.children[2].edge, Some(Edge::Editor(_))));
-        assert!(matches!(proto.children[3].edge, Some(Edge::Member(_))));
 
-        match &proto.children[4].edge {
+        match &proto.children[3].edge {
             Some(Edge::Topic(TopicEdge { topic_id })) => {
                 assert_eq!(*topic_id, make_topic_id(0x8A).to_vec());
             }

--- a/atlas/src/kafka/emitter.rs
+++ b/atlas/src/kafka/emitter.rs
@@ -44,7 +44,7 @@ use hermes_instrumentation::{debug_span, warn};
 use hermes_schema::pb::blockchain_metadata::BlockchainMetadata as ProtoBlockchainMetadata;
 use hermes_schema::pb::topology::{
     canonical_tree_node::Edge, edge_info, CanonicalGraphDiff, CanonicalGraphUpdated,
-    CanonicalTreeNode, ChangeType as ProtoChangeType, EdgeInfo, EditorEdge,
+    CanonicalTreeNode, ChangeType as ProtoChangeType, EdgeInfo,
     NodeChange as ProtoNodeChange, RelatedEdge, RootEdge, TopicEdge, VerifiedEdge,
 };
 use prost::Message;
@@ -186,7 +186,6 @@ fn edge_type_to_proto_edge(edge_type: EdgeType) -> Edge {
         EdgeType::Topic { topic_id } => Edge::Topic(TopicEdge {
             topic_id: topic_id.to_vec(),
         }),
-        EdgeType::Editor => Edge::Editor(EditorEdge {}),
     }
 }
 
@@ -221,7 +220,6 @@ fn position_to_edge_info(pos: &Position) -> Option<EdgeInfo> {
         EdgeType::Topic { topic_id } => edge_info::EdgeType::Topic(TopicEdge {
             topic_id: topic_id.to_vec(),
         }),
-        EdgeType::Editor => edge_info::EdgeType::Editor(EditorEdge {}),
         EdgeType::Root => {
             warn!(
                 parent = ?pos.parent,
@@ -290,20 +288,18 @@ mod tests {
         let mut root = TreeNode::new_root(make_space_id(1));
         root.add_child(TreeNode::new(make_space_id(2), EdgeType::Verified));
         root.add_child(TreeNode::new(make_space_id(3), EdgeType::Related));
-        root.add_child(TreeNode::new(make_space_id(4), EdgeType::Editor));
         root.add_child(TreeNode::new_with_topic(
-            make_space_id(5),
+            make_space_id(4),
             make_topic_id(0x8A),
         ));
 
         let proto = tree_node_to_proto(&root);
-        assert_eq!(proto.children.len(), 4);
+        assert_eq!(proto.children.len(), 3);
 
         assert!(matches!(proto.children[0].edge, Some(Edge::Verified(_))));
         assert!(matches!(proto.children[1].edge, Some(Edge::Related(_))));
-        assert!(matches!(proto.children[2].edge, Some(Edge::Editor(_))));
 
-        match &proto.children[3].edge {
+        match &proto.children[2].edge {
             Some(Edge::Topic(TopicEdge { topic_id })) => {
                 assert_eq!(*topic_id, make_topic_id(0x8A).to_vec());
             }

--- a/atlas/src/persistence.rs
+++ b/atlas/src/persistence.rs
@@ -611,8 +611,12 @@ impl PostgresCheckpointStore {
             return Ok(None);
         };
 
-        let graph_state_blob: PersistedGraphState = row
-            .try_get::<sqlx::types::Json<PersistedGraphState>, _>("graph_state_blob")
+        // Fetch the graph state blob as raw JSON without decoding into
+        // `PersistedGraphState`. Decoding happens lazily in `Checkpoint::graph_state()`
+        // so `restore_checkpoint_on_startup` can run `validate_compatibility()` first
+        // and route decode failures through the fresh-start fallback path.
+        let graph_state_blob: serde_json::Value = row
+            .try_get::<sqlx::types::Json<serde_json::Value>, _>("graph_state_blob")
             .map_err(|err| {
                 CheckpointError::Serialization(format!("decode graph_state_blob: {err}"))
             })?
@@ -753,7 +757,12 @@ pub struct Checkpoint {
     pub indexer_id: String,
     pub cursor: String,
     pub block_number: u64,
-    pub graph_state_blob: PersistedGraphState,
+    // Stored as raw JSON so loading can verify the runtime_compatibility_marker
+    // before paying the cost (and risk) of decoding into `PersistedGraphState`.
+    // This lets `restore_checkpoint_on_startup` route decode failures through
+    // the `ATLAS_CHECKPOINT_ALLOW_FRESH_START` fallback path rather than
+    // hard-failing in `PostgresCheckpointStore::load`.
+    pub graph_state_blob: serde_json::Value,
     pub graph_state_version: u32,
     pub runtime_compatibility_marker: String,
     pub root_space_id: String,
@@ -770,6 +779,10 @@ impl Checkpoint {
         runtime_compatibility_marker: String,
         root_space_id: SpaceId,
     ) -> Self {
+        // `PersistedGraphState` is a plain struct of `String`/`Vec`/enum fields,
+        // so serialization to `serde_json::Value` cannot fail in practice.
+        let graph_state_blob = serde_json::to_value(graph_state_blob)
+            .expect("PersistedGraphState always serializes to valid JSON");
         Self {
             schema_version: CHECKPOINT_SCHEMA_VERSION,
             indexer_id,
@@ -804,7 +817,11 @@ impl Checkpoint {
     }
 
     pub fn graph_state(&self) -> Result<GraphState, CheckpointError> {
-        self.graph_state_blob.to_graph_state()
+        let persisted: PersistedGraphState =
+            serde_json::from_value(self.graph_state_blob.clone()).map_err(|err| {
+                CheckpointError::Serialization(format!("decode graph_state_blob: {err}"))
+            })?;
+        persisted.to_graph_state()
     }
 
     pub fn validate_compatibility(
@@ -1278,6 +1295,58 @@ mod tests {
             .validate_compatibility("idx-other", "atlas-v2", make_space_id(1), 1)
             .unwrap_err();
         assert!(matches!(err, CheckpointError::Incompatible(_)));
+    }
+
+    #[test]
+    fn checkpoint_with_unknown_edge_variant_validates_marker_before_decode() {
+        // Regression: a checkpoint blob containing a now-removed edge variant
+        // (e.g. "Member" from atlas-v1) must not fail to construct just because
+        // the blob can't decode into the current `PersistedGraphState`. The
+        // raw-JSON storage lets `validate_compatibility()` reject the checkpoint
+        // on its marker first, and `graph_state()` is the only path that can
+        // surface a decode failure — letting the caller route it through the
+        // fresh-start fallback.
+        let blob_with_member = serde_json::json!({
+            "spaces": ["00000000000000000000000000000001"],
+            "space_topics": [],
+            "topic_spaces": [],
+            "explicit_edges": [{
+                "source_space_id": "00000000000000000000000000000001",
+                "edges": [{
+                    "target_space_id": "00000000000000000000000000000002",
+                    "edge_type": "Member"
+                }]
+            }],
+            "topic_edges": [],
+            "topic_edge_sources": []
+        });
+
+        let checkpoint = Checkpoint {
+            schema_version: CHECKPOINT_SCHEMA_VERSION,
+            indexer_id: "idx-test".to_string(),
+            cursor: "cursor-1".to_string(),
+            block_number: 1,
+            graph_state_blob: blob_with_member,
+            graph_state_version: 1,
+            runtime_compatibility_marker: "atlas-v1".to_string(),
+            root_space_id: encode_id(make_space_id(1)),
+        };
+
+        // Marker validation runs against the in-memory marker field — no decode
+        // needed, so the incompatible marker is reported cleanly.
+        let err = checkpoint
+            .validate_compatibility("idx-test", "atlas-v2", make_space_id(1), 1)
+            .expect_err("atlas-v1 marker must be rejected against atlas-v2 expected");
+        assert!(matches!(err, CheckpointError::Incompatible(_)));
+
+        // Only `graph_state()` (called after marker validation passes) surfaces
+        // the decode failure — and only via `CheckpointError::Serialization`,
+        // which is the path `restore_checkpoint_on_startup` already routes
+        // through `ATLAS_CHECKPOINT_ALLOW_FRESH_START`.
+        let err = checkpoint
+            .graph_state()
+            .expect_err("Member variant is no longer decodable into PersistedGraphState");
+        assert!(matches!(err, CheckpointError::Serialization(_)));
     }
 
     #[test]

--- a/atlas/src/persistence.rs
+++ b/atlas/src/persistence.rs
@@ -176,7 +176,7 @@ impl CheckpointConfig {
             graph_state_version,
             indexer_id,
             runtime_compatibility_marker: std::env::var("ATLAS_RUNTIME_COMPATIBILITY_MARKER")
-                .unwrap_or_else(|_| "atlas-v1".to_string()),
+                .unwrap_or_else(|_| "atlas-v2".to_string()),
             fail_open_bound,
             checkpoint_retry_attempts: retry_attempts,
             checkpoint_retry_backoff_ms: retry_backoff_ms,
@@ -901,7 +901,6 @@ pub enum PersistedEdgeType {
     Topic { topic_id: String },
     Root,
     Editor,
-    Member,
 }
 
 impl PersistedGraphState {
@@ -1064,7 +1063,6 @@ impl PersistedEdgeType {
                 topic_id: encode_id(topic_id),
             },
             EdgeType::Editor => Self::Editor,
-            EdgeType::Member => Self::Member,
         }
     }
 
@@ -1077,7 +1075,6 @@ impl PersistedEdgeType {
                 topic_id: decode_topic_id(topic_id)?,
             }),
             PersistedEdgeType::Editor => Ok(EdgeType::Editor),
-            PersistedEdgeType::Member => Ok(EdgeType::Member),
         }
     }
 
@@ -1088,7 +1085,6 @@ impl PersistedEdgeType {
             PersistedEdgeType::Related => 2,
             PersistedEdgeType::Topic { .. } => 3,
             PersistedEdgeType::Editor => 4,
-            PersistedEdgeType::Member => 5,
         }
     }
 }
@@ -1203,7 +1199,7 @@ mod tests {
             root_space_id: make_space_id(1),
             graph_state_version: 1,
             indexer_id: "idx-test".to_string(),
-            runtime_compatibility_marker: "atlas-v1".to_string(),
+            runtime_compatibility_marker: "atlas-v2".to_string(),
             fail_open_bound,
             checkpoint_retry_attempts: 1,
             checkpoint_retry_backoff_ms: 50,
@@ -1220,7 +1216,7 @@ mod tests {
             block_number,
             &GraphState::new(),
             1,
-            "atlas-v1".to_string(),
+            "atlas-v2".to_string(),
             make_space_id(1),
         )
     }
@@ -1274,16 +1270,16 @@ mod tests {
             10,
             &GraphState::new(),
             1,
-            "atlas-v1".to_string(),
+            "atlas-v2".to_string(),
             make_space_id(1),
         );
 
         checkpoint
-            .validate_compatibility("idx-test", "atlas-v1", make_space_id(1), 1)
+            .validate_compatibility("idx-test", "atlas-v2", make_space_id(1), 1)
             .unwrap();
 
         let err = checkpoint
-            .validate_compatibility("idx-other", "atlas-v1", make_space_id(1), 1)
+            .validate_compatibility("idx-other", "atlas-v2", make_space_id(1), 1)
             .unwrap_err();
         assert!(matches!(err, CheckpointError::Incompatible(_)));
     }

--- a/atlas/src/persistence.rs
+++ b/atlas/src/persistence.rs
@@ -900,7 +900,6 @@ pub enum PersistedEdgeType {
     Related,
     Topic { topic_id: String },
     Root,
-    Editor,
 }
 
 impl PersistedGraphState {
@@ -1062,7 +1061,6 @@ impl PersistedEdgeType {
             EdgeType::Topic { topic_id } => Self::Topic {
                 topic_id: encode_id(topic_id),
             },
-            EdgeType::Editor => Self::Editor,
         }
     }
 
@@ -1074,7 +1072,6 @@ impl PersistedEdgeType {
             PersistedEdgeType::Topic { topic_id } => Ok(EdgeType::Topic {
                 topic_id: decode_topic_id(topic_id)?,
             }),
-            PersistedEdgeType::Editor => Ok(EdgeType::Editor),
         }
     }
 
@@ -1084,7 +1081,6 @@ impl PersistedEdgeType {
             PersistedEdgeType::Verified => 1,
             PersistedEdgeType::Related => 2,
             PersistedEdgeType::Topic { .. } => 3,
-            PersistedEdgeType::Editor => 4,
         }
     }
 }

--- a/atlas/tests/e2e.rs
+++ b/atlas/tests/e2e.rs
@@ -637,8 +637,15 @@ fn test_e2e_editor_add_then_remove_produces_no_diff_for_editor() {
         .editor_removed(SPACE_A, SPACE_B)
         .build();
 
-    let (_state, _transitive, _canonical, _diff_tracker, diffs, _last_graph) =
+    let (_state, _transitive, _canonical, _diff_tracker, diffs, last_graph) =
         process_with_canonical(&actions, ROOT_SPACE_ID);
+
+    // Positive assertion: the verified Root -> A edge must produce a real
+    // diff. Without this, an empty diff stream (e.g. broken canonical emission)
+    // would satisfy the absence checks below and pass silently.
+    let graph = last_graph.expect("canonical graph should be computed");
+    assert!(graph.contains(&SPACE_A), "editor_no_diff: SPACE_A should be canonical via verified edge");
+    assert_change_exists(&diffs, SPACE_A, ChangeType::Added, "editor_no_diff");
 
     assert!(
         find_change(&diffs, SPACE_B, ChangeType::Added).is_none(),
@@ -669,8 +676,15 @@ fn test_e2e_member_add_then_remove_produces_no_diff_for_member() {
         .member_removed(SPACE_A, SPACE_B)
         .build();
 
-    let (_state, _transitive, _canonical, _diff_tracker, diffs, _last_graph) =
+    let (_state, _transitive, _canonical, _diff_tracker, diffs, last_graph) =
         process_with_canonical(&actions, ROOT_SPACE_ID);
+
+    // Positive assertion: the verified Root -> A edge must produce a real
+    // diff. Without this, an empty diff stream (e.g. broken canonical emission)
+    // would satisfy the absence checks below and pass silently.
+    let graph = last_graph.expect("canonical graph should be computed");
+    assert!(graph.contains(&SPACE_A), "member_no_diff: SPACE_A should be canonical via verified edge");
+    assert_change_exists(&diffs, SPACE_A, ChangeType::Added, "member_no_diff");
 
     assert!(
         find_change(&diffs, SPACE_B, ChangeType::Added).is_none(),

--- a/atlas/tests/e2e.rs
+++ b/atlas/tests/e2e.rs
@@ -497,7 +497,11 @@ fn test_e2e_moved_diff_when_edge_type_changes() {
 // =============================================================================
 
 #[test]
-fn test_e2e_editor_member_edges_grant_canonical() {
+fn test_e2e_editor_edges_grant_canonical_member_does_not() {
+    // Editor edges still grant canonical membership. Member edges do not — see
+    // plan 0007. Same topology: Root --verified--> A --editor--> B,
+    //                                              A --member-->  C
+    // Expected: B is canonical, C is NOT.
     let actions = TopologyBuilder::new()
         .space(ROOT_SPACE_ID, test_topology::ROOT_OWNER)
         .space(SPACE_A, test_topology::USER_1)
@@ -515,9 +519,10 @@ fn test_e2e_editor_member_edges_grant_canonical() {
 
     assert_all_canonical(
         &graph,
-        &[ROOT_SPACE_ID, SPACE_A, SPACE_B, SPACE_C],
-        "editor_member",
+        &[ROOT_SPACE_ID, SPACE_A, SPACE_B],
+        "editor_grants_canonical",
     );
+    assert_none_canonical(&graph, &[SPACE_C], "member_does_not_grant_canonical");
 }
 
 #[test]
@@ -539,11 +544,14 @@ fn test_e2e_topic_edges_dont_grant_canonical() {
 }
 
 // =============================================================================
-// Test: Transitive Edges from Members
+// Test: Member edges are ignored by canonical computation (plan 0007)
 // =============================================================================
 
 #[test]
-fn test_e2e_member_spaces_edges_are_followed() {
+fn test_e2e_member_edges_do_not_propagate_to_subspaces() {
+    // Root --verified--> A --member--> B --verified--> C
+    // Member edges are no-ops, so the canonical graph stops at A.
+    // Neither B (reached only via member) nor C (only reachable through B) is canonical.
     let actions = TopologyBuilder::new()
         .space(ROOT_SPACE_ID, test_topology::ROOT_OWNER)
         .space(SPACE_A, test_topology::USER_1)
@@ -559,13 +567,9 @@ fn test_e2e_member_spaces_edges_are_followed() {
 
     let graph = last_graph.expect("Should have computed canonical graph");
 
-    // All should be canonical: Root -> A -> B -> C
-    assert_all_canonical(
-        &graph,
-        &[ROOT_SPACE_ID, SPACE_A, SPACE_B, SPACE_C],
-        "member_transitive",
-    );
-    assert_eq!(graph.len(), 4);
+    assert_all_canonical(&graph, &[ROOT_SPACE_ID, SPACE_A], "member_ignored");
+    assert_none_canonical(&graph, &[SPACE_B, SPACE_C], "member_ignored");
+    assert_eq!(graph.len(), 2);
 }
 
 // =============================================================================
@@ -627,7 +631,11 @@ fn test_e2e_editor_removal_causes_removed_diff() {
 }
 
 #[test]
-fn test_e2e_member_removal_causes_removed_diff() {
+fn test_e2e_member_add_then_remove_produces_no_diff_for_member() {
+    // Member edges are no-ops in canonical computation (plan 0007). A
+    // Member-add followed by a Member-remove must not produce any Added,
+    // Moved, or Removed change for the member space — only the verified
+    // edge from Root -> A should show up.
     let actions = TopologyBuilder::new()
         .space(ROOT_SPACE_ID, test_topology::ROOT_OWNER)
         .space(SPACE_A, test_topology::USER_1)
@@ -640,7 +648,18 @@ fn test_e2e_member_removal_causes_removed_diff() {
     let (_state, _transitive, _canonical, _diff_tracker, diffs, _last_graph) =
         process_with_canonical(&actions, ROOT_SPACE_ID);
 
-    assert_change_exists(&diffs, SPACE_B, ChangeType::Removed, "member_removal");
+    assert!(
+        find_change(&diffs, SPACE_B, ChangeType::Added).is_none(),
+        "member_no_diff: SPACE_B should not appear as Added"
+    );
+    assert!(
+        find_change(&diffs, SPACE_B, ChangeType::Removed).is_none(),
+        "member_no_diff: SPACE_B should not appear as Removed"
+    );
+    assert!(
+        find_change(&diffs, SPACE_B, ChangeType::Moved).is_none(),
+        "member_no_diff: SPACE_B should not appear as Moved"
+    );
 }
 
 // =============================================================================
@@ -677,10 +696,10 @@ fn test_e2e_cascading_removal_disconnects_subtree() {
 }
 
 #[test]
-fn test_e2e_member_removal_cascades_to_member_subspaces() {
-    // P2: Member removal cascading
-    // Root -> A (verified), A -> B (member), B -> C (verified)
-    // Remove B as member, C should also become non-canonical
+fn test_e2e_member_removal_does_not_cascade_because_member_is_noop() {
+    // Plan 0007: Member edges never enter the graph, so a Member-remove
+    // also has no effect. Root -> A is canonical; B and C are never reachable
+    // through Member; no Member-related diff is emitted.
     let actions = TopologyBuilder::new()
         .space(ROOT_SPACE_ID, test_topology::ROOT_OWNER)
         .space(SPACE_A, test_topology::USER_1)
@@ -697,10 +716,21 @@ fn test_e2e_member_removal_cascades_to_member_subspaces() {
 
     let graph = last_graph.expect("Should have canonical graph");
 
-    // B and C should be non-canonical
-    assert_none_canonical(&graph, &[SPACE_B, SPACE_C], "member_cascade");
-    assert_change_exists(&diffs, SPACE_B, ChangeType::Removed, "member_cascade");
-    assert_change_exists(&diffs, SPACE_C, ChangeType::Removed, "member_cascade");
+    assert_all_canonical(&graph, &[ROOT_SPACE_ID, SPACE_A], "member_noop");
+    assert_none_canonical(&graph, &[SPACE_B, SPACE_C], "member_noop");
+
+    for space in [SPACE_B, SPACE_C] {
+        assert!(
+            find_change(&diffs, space, ChangeType::Added).is_none(),
+            "member_noop: 0x{:02x} should not appear as Added",
+            space[15]
+        );
+        assert!(
+            find_change(&diffs, space, ChangeType::Removed).is_none(),
+            "member_noop: 0x{:02x} should not appear as Removed",
+            space[15]
+        );
+    }
 }
 
 #[test]

--- a/atlas/tests/e2e.rs
+++ b/atlas/tests/e2e.rs
@@ -296,8 +296,11 @@ fn test_e2e_canonical_set_from_test_topology() {
 
     let graph = last_graph.expect("Should have computed canonical graph");
 
-    // Verify expected canonical spaces
-    // Note: SPACE_H = make_id(0x11), so member added by Proposal 1 is the same as SPACE_H
+    // After plan 0007: Member and Editor edges are no-ops, so spaces reachable
+    // only through them are no longer canonical.
+    // - SPACE_H = make_id(0x11): added as member of A via Proposal 1, but also
+    //   verified by Root elsewhere in the topology — stays canonical via that path.
+    // - 0x50: added only as editor of B via Proposal 3, no other path — now non-canonical.
     let expected_canonical: Vec<SpaceId> = vec![
         ROOT_SPACE_ID,
         SPACE_A,
@@ -307,17 +310,23 @@ fn test_e2e_canonical_set_from_test_topology() {
         SPACE_E,
         SPACE_F,
         SPACE_G,
-        SPACE_H, // Also added as member of A via Proposal 1 (0x11)
+        SPACE_H, // verified elsewhere, not via Member
         SPACE_I,
         SPACE_J,
-        mock_events::make_id(0x50), // Added as editor of B via Proposal 3
     ];
 
     assert_all_canonical(&graph, &expected_canonical, "test_topology");
 
     // Verify non-canonical spaces
     let expected_non_canonical: Vec<SpaceId> = vec![
-        SPACE_X, SPACE_Y, SPACE_Z, SPACE_W, SPACE_P, SPACE_Q, SPACE_S,
+        SPACE_X,
+        SPACE_Y,
+        SPACE_Z,
+        SPACE_W,
+        SPACE_P,
+        SPACE_Q,
+        SPACE_S,
+        mock_events::make_id(0x50), // editor-only — now non-canonical
     ];
 
     assert_none_canonical(&graph, &expected_non_canonical, "test_topology");
@@ -455,8 +464,9 @@ fn test_e2e_moved_diff_when_parent_changes() {
 }
 
 #[test]
-fn test_e2e_moved_diff_when_edge_type_changes() {
-    // B changes from verified child to editor
+fn test_e2e_moved_diff_when_edge_type_changes_between_canonical_types() {
+    // B changes from verified child to related (both canonical-granting per plan 0007).
+    // Previously this test exercised verified -> editor, but editor is now a no-op.
     let actions = TopologyBuilder::new()
         .space(ROOT_SPACE_ID, test_topology::ROOT_OWNER)
         .space(SPACE_A, test_topology::USER_1)
@@ -464,9 +474,9 @@ fn test_e2e_moved_diff_when_edge_type_changes() {
         // Initial: Root -> A, A -> B (verified)
         .verified(ROOT_SPACE_ID, SPACE_A)
         .verified(SPACE_A, SPACE_B)
-        // Remove verified, add editor (same parent, different edge type)
+        // Remove verified, add related (same parent, different canonical-granting edge type)
         .unverified(SPACE_A, SPACE_B)
-        .editor(SPACE_A, SPACE_B)
+        .related(SPACE_A, SPACE_B)
         .build();
 
     let (_state, _transitive, _canonical, _diff_tracker, diffs, last_graph) =
@@ -475,7 +485,7 @@ fn test_e2e_moved_diff_when_edge_type_changes() {
     let graph = last_graph.expect("Should have canonical graph");
     assert!(graph.contains(&SPACE_B), "B should still be canonical");
 
-    // B should have been REMOVED when verified edge removed, then ADDED when editor added
+    // B should have been REMOVED when verified edge removed, then ADDED when related added
     // OR have a MOVED if the implementation tracks edge type changes
     let b_removed = find_change(&diffs, SPACE_B, ChangeType::Removed);
     let b_added_count = diffs
@@ -484,8 +494,6 @@ fn test_e2e_moved_diff_when_edge_type_changes() {
         .filter(|c| c.space_id == SPACE_B && c.change_type == ChangeType::Added)
         .count();
 
-    // Either: B was removed then re-added, or B was moved
-    // Both are valid behaviors for edge type change
     assert!(
         b_removed.is_some() || b_added_count >= 1,
         "B should have REMOVED then ADDED, or MOVED when edge type changes"
@@ -497,11 +505,12 @@ fn test_e2e_moved_diff_when_edge_type_changes() {
 // =============================================================================
 
 #[test]
-fn test_e2e_editor_edges_grant_canonical_member_does_not() {
-    // Editor edges still grant canonical membership. Member edges do not — see
-    // plan 0007. Same topology: Root --verified--> A --editor--> B,
-    //                                              A --member-->  C
-    // Expected: B is canonical, C is NOT.
+fn test_e2e_editor_and_member_edges_do_not_grant_canonical() {
+    // Plan 0007: neither Editor nor Member edges grant canonical membership.
+    // Only Verified, Related, and Subtopic do.
+    // Topology: Root --verified--> A --editor--> B,
+    //                              A --member-->  C
+    // Expected: only Root and A are canonical.
     let actions = TopologyBuilder::new()
         .space(ROOT_SPACE_ID, test_topology::ROOT_OWNER)
         .space(SPACE_A, test_topology::USER_1)
@@ -517,12 +526,12 @@ fn test_e2e_editor_edges_grant_canonical_member_does_not() {
 
     let graph = last_graph.expect("Should have computed canonical graph");
 
-    assert_all_canonical(
+    assert_all_canonical(&graph, &[ROOT_SPACE_ID, SPACE_A], "verified_only");
+    assert_none_canonical(
         &graph,
-        &[ROOT_SPACE_ID, SPACE_A, SPACE_B],
-        "editor_grants_canonical",
+        &[SPACE_B, SPACE_C],
+        "editor_and_member_do_not_grant_canonical",
     );
-    assert_none_canonical(&graph, &[SPACE_C], "member_does_not_grant_canonical");
 }
 
 #[test]
@@ -614,7 +623,11 @@ fn test_e2e_related_edge_removal() {
 }
 
 #[test]
-fn test_e2e_editor_removal_causes_removed_diff() {
+fn test_e2e_editor_add_then_remove_produces_no_diff_for_editor() {
+    // Editor edges are no-ops in canonical computation (plan 0007). An
+    // Editor-add followed by an Editor-remove must not produce any Added,
+    // Moved, or Removed change for the editor space — only the verified
+    // edge from Root -> A should show up.
     let actions = TopologyBuilder::new()
         .space(ROOT_SPACE_ID, test_topology::ROOT_OWNER)
         .space(SPACE_A, test_topology::USER_1)
@@ -627,7 +640,18 @@ fn test_e2e_editor_removal_causes_removed_diff() {
     let (_state, _transitive, _canonical, _diff_tracker, diffs, _last_graph) =
         process_with_canonical(&actions, ROOT_SPACE_ID);
 
-    assert_change_exists(&diffs, SPACE_B, ChangeType::Removed, "editor_removal");
+    assert!(
+        find_change(&diffs, SPACE_B, ChangeType::Added).is_none(),
+        "editor_no_diff: SPACE_B should not appear as Added"
+    );
+    assert!(
+        find_change(&diffs, SPACE_B, ChangeType::Removed).is_none(),
+        "editor_no_diff: SPACE_B should not appear as Removed"
+    );
+    assert!(
+        find_change(&diffs, SPACE_B, ChangeType::Moved).is_none(),
+        "editor_no_diff: SPACE_B should not appear as Moved"
+    );
 }
 
 #[test]

--- a/hermes/k8s/production/atlas.yaml
+++ b/hermes/k8s/production/atlas.yaml
@@ -75,7 +75,7 @@ spec:
             - name: ATLAS_INDEXER_ID
               value: "atlas-production"
             - name: ATLAS_RUNTIME_COMPATIBILITY_MARKER
-              value: "atlas-v1"
+              value: "atlas-v2"
             - name: ATLAS_FAIL_OPEN_BOUND
               value: "10"
             - name: ATLAS_CHECKPOINT_RETRY_ATTEMPTS
@@ -84,8 +84,11 @@ spec:
               value: "200"
             - name: ATLAS_PAUSE_RECOVERY_MAX_ATTEMPTS
               value: "120"
+            # Set to "true" for the atlas-v1 → atlas-v2 rollout window so the
+            # incompatible checkpoint is rejected and Atlas bootstraps fresh.
+            # Revert to "false" once Atlas has stamped a new atlas-v2 checkpoint.
             - name: ATLAS_CHECKPOINT_ALLOW_FRESH_START
-              value: "false"
+              value: "true"
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:

--- a/hermes/k8s/staging/atlas.yaml
+++ b/hermes/k8s/staging/atlas.yaml
@@ -77,7 +77,7 @@ spec:
             - name: ATLAS_INDEXER_ID
               value: "atlas-staging"
             - name: ATLAS_RUNTIME_COMPATIBILITY_MARKER
-              value: "atlas-v1"
+              value: "atlas-v2"
             - name: ATLAS_FAIL_OPEN_BOUND
               value: "10"
             - name: ATLAS_CHECKPOINT_RETRY_ATTEMPTS
@@ -86,8 +86,11 @@ spec:
               value: "200"
             - name: ATLAS_PAUSE_RECOVERY_MAX_ATTEMPTS
               value: "120"
+            # Set to "true" for the atlas-v1 → atlas-v2 rollout window so the
+            # incompatible checkpoint is rejected and Atlas bootstraps fresh.
+            # Revert to "false" once Atlas has stamped a new atlas-v2 checkpoint.
             - name: ATLAS_CHECKPOINT_ALLOW_FRESH_START
-              value: "false"
+              value: "true"
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary

- `MemberAdded` / `MemberRemoved` and `EditorAdded` / `EditorRemoved` events are no-oped in `GraphState::apply_trust_extended` — Member and Editor edges no longer produce nodes in any graph view (canonical or transitive).
- `EdgeType::Member` and `EdgeType::Editor` removed from the codebase. Chain action parsing in `convert.rs` is preserved so `MEMBER_ADDED` / `MEMBER_REMOVED` / `EDITOR_ADDED` / `EDITOR_REMOVED` actions continue to flow through Atlas without effect.
- **The only canonical-granting edges after this change are `Verified`, `Related`, and `Subtopic`.**
- **Breaking checkpoint format**: `runtime_compatibility_marker` bumped `atlas-v1` → `atlas-v2`. Existing checkpoints will be rejected on load. Deploys require `ATLAS_CHECKPOINT_ALLOW_FRESH_START=true` for a fresh bootstrap (rollout procedure tracked in GEO-626).

Closes parent epic [GEO-618](https://linear.app/defi-wonderland/issue/GEO-618) (supersedes the originally-scoped subissue [GEO-624](https://linear.app/defi-wonderland/issue/GEO-624), which covered Member only). Implementation follows Plan 0007, linked on GEO-618.

## Test plan

- [x] `cargo test -p atlas` — 128 tests pass (85 unit + 41 e2e + 1 kafka_e2e + 1 doc-test)
- [x] `cargo build -p atlas` and `cargo bench -p atlas --no-run` clean
- [x] `grep -rn "EdgeType::Member" atlas/` and `grep -rn "EdgeType::Editor" atlas/` return no matches
- [x] `grep -rn "PersistedEdgeType::Member" atlas/` and `grep -rn "PersistedEdgeType::Editor" atlas/` return no matches
- [x] `TrustExtension::MemberAdded` / `MemberRemoved` / `EditorAdded` / `EditorRemoved` variants and `convert.rs` parsing untouched
- [x] `test_topology` fixture's canonical set size updated: 12 → 11 (space `0x50` was editor-only, now non-canonical)