### PR TITLE
feat(hermes): emit HermesTopicRemoved on space.topics

### DIFF
--- a/hermes-pipeline/src/emit.rs
+++ b/hermes-pipeline/src/emit.rs
@@ -29,7 +29,7 @@ use hermes_schema::pb::{
         HermesCreateSpace, HermesSpaceTrustExtension, hermes_create_space,
         hermes_space_trust_extension,
     },
-    topics::HermesTopicDeclared,
+    topics::{HermesTopicDeclared, HermesTopicRemoved},
     voting::{HermesVoteCast, VoteDirection},
 };
 
@@ -499,6 +499,27 @@ impl HasMeta for HermesTopicDeclared {
     }
 }
 
+impl KafkaEvent for HermesTopicRemoved {
+    const TOPIC: &'static str = topics::TOPICS;
+
+    fn key(&self) -> Vec<u8> {
+        self.space_id.clone()
+    }
+
+    fn headers(&self) -> OwnedHeaders {
+        OwnedHeaders::new().insert(Header {
+            key: "event-type",
+            value: Some("TOPIC_REMOVED"),
+        })
+    }
+}
+
+impl HasMeta for HermesTopicRemoved {
+    fn meta(&self) -> Option<&BlockchainMetadata> {
+        self.meta.as_ref()
+    }
+}
+
 // =============================================================================
 // Voting events
 // =============================================================================
@@ -815,6 +836,21 @@ mod tests {
     #[test]
     fn test_topic_declared_topic() {
         assert_eq!(HermesTopicDeclared::TOPIC, "space.topics");
+    }
+
+    #[test]
+    fn test_topic_removed_topic() {
+        assert_eq!(HermesTopicRemoved::TOPIC, "space.topics");
+    }
+
+    #[test]
+    fn test_topic_removed_key() {
+        let event = HermesTopicRemoved {
+            space_id: vec![0xAB; 16],
+            topic_id: vec![0xCD; 16],
+            meta: None,
+        };
+        assert_eq!(event.key(), vec![0xAB; 16]);
     }
 
     #[test]

--- a/hermes-pipeline/src/main.rs
+++ b/hermes-pipeline/src/main.rs
@@ -287,6 +287,7 @@ impl Pipeline {
                 max_sequence(&moderation.content_flagged),
                 max_sequence(&moderation.content_unflagged),
                 max_sequence(&topics.topics_declared),
+                max_sequence(&topics.topics_removed),
                 max_sequence(&governance.proposals_created),
                 max_sequence(&governance.proposals_updated),
                 max_sequence(&governance.proposals_voted),
@@ -310,6 +311,7 @@ impl Pipeline {
                 || mark_sequence_as_last(&mut moderation.content_flagged, max_seq)
                 || mark_sequence_as_last(&mut moderation.content_unflagged, max_seq)
                 || mark_sequence_as_last(&mut topics.topics_declared, max_seq)
+                || mark_sequence_as_last(&mut topics.topics_removed, max_seq)
                 || mark_sequence_as_last(&mut governance.proposals_created, max_seq)
                 || mark_sequence_as_last(&mut governance.proposals_updated, max_seq)
                 || mark_sequence_as_last(&mut governance.proposals_voted, max_seq)
@@ -406,6 +408,10 @@ impl Pipeline {
         counts_by_event_type.insert(
             "TOPIC_DECLARED".to_string(),
             topics.topics_declared.len() as u64,
+        );
+        counts_by_event_type.insert(
+            "TOPIC_REMOVED".to_string(),
+            topics.topics_removed.len() as u64,
         );
         counts_by_event_type.insert(
             "PROPOSAL_CREATED".to_string(),
@@ -537,15 +543,65 @@ impl Pipeline {
                 }
             }
 
-            // 5. Emit topic declarations
+            // 5. Emit topic declarations and removals.
+            // Both vecs are individually sorted by sequence (transform iterates
+            // actions in order). Merge-sort by sequence here so that declare/
+            // remove pairs in the same block are emitted in chain order — this
+            // matters because per-partition Kafka order determines the order
+            // consumers apply the writes, and a remove emitted after a later
+            // declare for the same space would leave the indexer in NULL state
+            // when the chain ended in the declared state.
             if topics.total() > 0 {
-                for event in &topics.topics_declared {
-                    self.emitter.emit(event).await?;
-                    debug!(
-                        space_id = %hex::encode(&event.space_id),
-                        topic_id = %hex::encode(&event.topic_id),
-                        "Topic declared"
-                    );
+                let mut declared_iter = topics.topics_declared.iter().peekable();
+                let mut removed_iter = topics.topics_removed.iter().peekable();
+                loop {
+                    let next_declared_seq = declared_iter
+                        .peek()
+                        .and_then(|e| e.meta.as_ref())
+                        .map(|m| m.sequence);
+                    let next_removed_seq = removed_iter
+                        .peek()
+                        .and_then(|e| e.meta.as_ref())
+                        .map(|m| m.sequence);
+                    match (next_declared_seq, next_removed_seq) {
+                        (Some(d), Some(r)) if d <= r => {
+                            let event = declared_iter.next().unwrap();
+                            self.emitter.emit(event).await?;
+                            debug!(
+                                space_id = %hex::encode(&event.space_id),
+                                topic_id = %hex::encode(&event.topic_id),
+                                "Topic declared"
+                            );
+                        }
+                        (Some(_), Some(_)) => {
+                            let event = removed_iter.next().unwrap();
+                            self.emitter.emit(event).await?;
+                            debug!(
+                                space_id = %hex::encode(&event.space_id),
+                                topic_id = %hex::encode(&event.topic_id),
+                                "Topic removed"
+                            );
+                        }
+                        (Some(_), None) => {
+                            let event = declared_iter.next().unwrap();
+                            self.emitter.emit(event).await?;
+                            debug!(
+                                space_id = %hex::encode(&event.space_id),
+                                topic_id = %hex::encode(&event.topic_id),
+                                "Topic declared"
+                            );
+                        }
+                        (None, Some(_)) => {
+                            let event = removed_iter.next().unwrap();
+                            self.emitter.emit(event).await?;
+                            debug!(
+                                space_id = %hex::encode(&event.space_id),
+                                topic_id = %hex::encode(&event.topic_id),
+                                "Topic removed"
+                            );
+                        }
+                        (None, None) => break,
+                    }
                 }
             }
 

--- a/hermes-pipeline/src/pipelines/mod.rs
+++ b/hermes-pipeline/src/pipelines/mod.rs
@@ -31,7 +31,7 @@ use hermes_schema::pb::moderation::{
     HermesContentFlagged, HermesContentUnflagged, HermesEditorFlagged, HermesEditorUnflagged,
 };
 use hermes_schema::pb::space::{HermesCreateSpace, HermesSpaceTrustExtension};
-use hermes_schema::pb::topics::HermesTopicDeclared;
+use hermes_schema::pb::topics::{HermesTopicDeclared, HermesTopicRemoved};
 use hermes_schema::pb::voting::HermesVoteCast;
 
 /// Trait for event types that have blockchain metadata.
@@ -66,6 +66,7 @@ impl_has_meta!(
     HermesContentFlagged,
     HermesContentUnflagged,
     HermesTopicDeclared,
+    HermesTopicRemoved,
     HermesProposalCreated,
     HermesProposalUpdated,
     HermesProposalVoted,

--- a/hermes-pipeline/src/pipelines/topics.rs
+++ b/hermes-pipeline/src/pipelines/topics.rs
@@ -1,12 +1,12 @@
-//! Pipeline: TOPIC_DECLARED → space.topics
+//! Pipeline: TOPIC_DECLARED / TOPIC_REMOVED → space.topics
 //!
-//! Converts topic declaration actions to typed Hermes events with decoded data.
+//! Converts topic declaration and removal actions to typed Hermes events with decoded data.
 
 use anyhow::Result;
 use hermes_instrumentation::{debug_span, warn};
 
 use hermes_relay::{Action, actions};
-use hermes_schema::pb::topics::HermesTopicDeclared;
+use hermes_schema::pb::topics::{HermesTopicDeclared, HermesTopicRemoved};
 
 use crate::decode;
 
@@ -16,15 +16,16 @@ use super::BlockMetadata;
 #[derive(Debug, Default)]
 pub struct TransformResult {
     pub topics_declared: Vec<HermesTopicDeclared>,
+    pub topics_removed: Vec<HermesTopicRemoved>,
 }
 
 impl TransformResult {
     pub fn total(&self) -> usize {
-        self.topics_declared.len()
+        self.topics_declared.len() + self.topics_removed.len()
     }
 }
 
-/// Transform all topic declaration actions in a block.
+/// Transform all topic-related actions in a block.
 ///
 /// Returns transformed events without sending to Kafka.
 pub fn transform(actions: &[Action], meta: &BlockMetadata) -> Result<TransformResult> {
@@ -42,6 +43,14 @@ pub fn transform(actions: &[Action], meta: &BlockMetadata) -> Result<TransformRe
             )
             .in_scope(|| convert_topic_declared(action, meta, sequence))?;
             result.topics_declared.push(event);
+        } else if actions::matches(action_type, &actions::TOPIC_REMOVED) {
+            let event = debug_span!(
+                "convert.topics.removed",
+                space_id = %hex::encode(&action.from_id),
+                topic_id = %hex::encode(&action.topic)
+            )
+            .in_scope(|| convert_topic_removed(action, meta, sequence))?;
+            result.topics_removed.push(event);
         }
     }
 
@@ -72,6 +81,36 @@ fn convert_topic_declared(
     };
 
     Ok(HermesTopicDeclared {
+        space_id: action.from_id.clone(),
+        topic_id,
+        meta: Some(meta.to_proto(sequence)),
+    })
+}
+
+/// Convert a TOPIC_REMOVED action to HermesTopicRemoved proto.
+///
+/// The action structure mirrors TOPIC_DECLARED:
+/// - from_id: space_id (16 bytes) - space removing topic
+/// - topic: bytes32(bytes16(topicId) | padding)
+/// - data: empty
+fn convert_topic_removed(
+    action: &Action,
+    meta: &BlockMetadata,
+    sequence: u32,
+) -> Result<HermesTopicRemoved> {
+    let topic_id = match decode::decode_topic_declared(&action.topic) {
+        Ok(id) => id,
+        Err(e) => {
+            warn!(
+                error = %e,
+                space_id = %hex::encode(&action.from_id),
+                "Failed to decode topic removed topic field"
+            );
+            vec![0; 16]
+        }
+    };
+
+    Ok(HermesTopicRemoved {
         space_id: action.from_id.clone(),
         topic_id,
         meta: Some(meta.to_proto(sequence)),
@@ -153,5 +192,123 @@ mod tests {
         let result = transform(&actions, &test_meta()).unwrap();
         assert_eq!(result.topics_declared.len(), 2);
         assert_eq!(result.total(), 2);
+    }
+
+    #[test]
+    fn test_convert_topic_removed_uses_topic_field() {
+        let mut topic = vec![2; 16];
+        topic.extend_from_slice(&[0; 16]);
+
+        let action = Action {
+            from_id: vec![1; 16],
+            to_id: vec![],
+            action: actions::TOPIC_REMOVED.to_vec(),
+            topic,
+            data: vec![],
+        };
+
+        let result = convert_topic_removed(&action, &test_meta(), 0).unwrap();
+        assert_eq!(result.space_id, vec![1; 16]);
+        assert_eq!(result.topic_id, vec![2; 16]);
+    }
+
+    #[test]
+    fn test_convert_topic_removed_empty_topic() {
+        let action = Action {
+            from_id: vec![1; 16],
+            to_id: vec![],
+            action: actions::TOPIC_REMOVED.to_vec(),
+            topic: vec![],
+            data: vec![],
+        };
+
+        let result = convert_topic_removed(&action, &test_meta(), 0).unwrap();
+        assert_eq!(result.space_id, vec![1; 16]);
+        assert_eq!(result.topic_id, vec![0; 16]);
+    }
+
+    #[test]
+    fn test_transform_counts_remove() {
+        let actions = vec![
+            Action {
+                from_id: vec![1; 16],
+                to_id: vec![],
+                action: actions::TOPIC_REMOVED.to_vec(),
+                topic: vec![2; 32],
+                data: vec![],
+            },
+            Action {
+                from_id: vec![3; 16],
+                to_id: vec![],
+                action: actions::TOPIC_REMOVED.to_vec(),
+                topic: vec![4; 32],
+                data: vec![],
+            },
+            // Should NOT be included
+            Action {
+                from_id: vec![5; 16],
+                to_id: vec![],
+                action: actions::SPACE_REGISTERED.to_vec(),
+                topic: vec![6; 32],
+                data: vec![],
+            },
+        ];
+
+        let result = transform(&actions, &test_meta()).unwrap();
+        assert_eq!(result.topics_declared.len(), 0);
+        assert_eq!(result.topics_removed.len(), 2);
+        assert_eq!(result.total(), 2);
+    }
+
+    /// Declare + remove for the same space within a single block.
+    /// Both must end up in the result with their original block-sequence
+    /// indexes preserved on the proto metadata, so the downstream Kafka
+    /// emit order matches the on-chain order.
+    #[test]
+    fn test_transform_interleaved_declare_remove() {
+        let actions = vec![
+            Action {
+                from_id: vec![1; 16],
+                to_id: vec![],
+                action: actions::TOPIC_DECLARED.to_vec(),
+                topic: vec![2; 32],
+                data: vec![],
+            },
+            Action {
+                from_id: vec![1; 16],
+                to_id: vec![],
+                action: actions::TOPIC_REMOVED.to_vec(),
+                topic: vec![2; 32],
+                data: vec![],
+            },
+            Action {
+                from_id: vec![1; 16],
+                to_id: vec![],
+                action: actions::TOPIC_DECLARED.to_vec(),
+                topic: vec![3; 32],
+                data: vec![],
+            },
+        ];
+
+        let result = transform(&actions, &test_meta()).unwrap();
+        assert_eq!(result.topics_declared.len(), 2);
+        assert_eq!(result.topics_removed.len(), 1);
+        assert_eq!(result.total(), 3);
+
+        // Sequence indexes from BlockMetadata::to_proto reflect the per-block
+        // action index, so the consumer can interleave events correctly.
+        let declared_seqs: Vec<u32> = result
+            .topics_declared
+            .iter()
+            .map(|e| e.meta.as_ref().unwrap().sequence)
+            .collect();
+        assert_eq!(declared_seqs, vec![0, 2]);
+
+        let removed_seqs: Vec<u32> = result
+            .topics_removed
+            .iter()
+            .map(|e| e.meta.as_ref().unwrap().sequence)
+            .collect();
+        assert_eq!(removed_seqs, vec![1]);
     }
 }

--- a/hermes-relay/src/source/mock_events.rs
+++ b/hermes-relay/src/source/mock_events.rs
@@ -901,6 +901,23 @@ pub fn topic_declared(space_id: SpaceId, topic_id: TopicId) -> Action {
     }
 }
 
+/// Create a TOPIC_REMOVED action.
+///
+/// - `space_id`: The space removing the topic
+/// - `topic_id`: The 16-byte topic UUID stored in the first 16 bytes of `topic`
+pub fn topic_removed(space_id: SpaceId, topic_id: TopicId) -> Action {
+    let mut topic = topic_id.to_vec();
+    topic.extend_from_slice(&[0u8; 16]);
+
+    Action {
+        from_id: space_id.to_vec(),
+        to_id: vec![0u8; 16],
+        action: actions::TOPIC_REMOVED.to_vec(),
+        topic,
+        data: vec![],
+    }
+}
+
 /// Create an EDITS_PUBLISHED action.
 ///
 /// - `space_id`: The space publishing the edit

--- a/hermes-schema/proto/topics.proto
+++ b/hermes-schema/proto/topics.proto
@@ -11,3 +11,11 @@ message HermesTopicDeclared {
   bytes topic_id = 2;             // 16 bytes - topic UUID
   blockchain_metadata.BlockchainMetadata meta = 3;
 }
+
+// HermesTopicRemoved - space removes a previously declared topic
+// Data encoding: abi.encode(bytes16(topicId))
+message HermesTopicRemoved {
+  bytes space_id = 1;             // 16 bytes - space removing topic
+  bytes topic_id = 2;             // 16 bytes - topic UUID
+  blockchain_metadata.BlockchainMetadata meta = 3;
+}

--- a/hermes-schema/src/pb/topics.rs
+++ b/hermes-schema/src/pb/topics.rs
@@ -12,3 +12,16 @@ pub struct HermesTopicDeclared {
     #[prost(message, optional, tag = "3")]
     pub meta: ::core::option::Option<super::blockchain_metadata::BlockchainMetadata>,
 }
+/// HermesTopicRemoved - space removes a previously declared topic
+/// Data encoding: abi.encode(bytes16(topicId))
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HermesTopicRemoved {
+    /// 16 bytes - space removing topic
+    #[prost(bytes = "vec", tag = "1")]
+    pub space_id: ::prost::alloc::vec::Vec<u8>,
+    /// 16 bytes - topic UUID
+    #[prost(bytes = "vec", tag = "2")]
+    pub topic_id: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, optional, tag = "3")]
+    pub meta: ::core::option::Option<super::blockchain_metadata::BlockchainMetadata>,
+}


### PR DESCRIPTION
Closes [GEO-627](https://linear.app/defi-wonderland/issue/GEO-627). Part of [GEO-619](https://linear.app/defi-wonderland/issue/GEO-619).

> **Stacked PR.** Base is `geo-619-topic-unsetremoved-not-picked-up-by-indexer`, not `dev`. Merge order: this → kg-indexer consumer ([GEO-628](https://linear.app/defi-wonderland/issue/GEO-628)) → search-indexer consumer ([GEO-629](https://linear.app/defi-wonderland/issue/GEO-629)) → parent branch into `dev`.

## Summary

Producer side of the `TOPIC_REMOVED` fix. On testnet today, the action reaches `hermes-pipeline` but `pipelines::topics::transform` only matches `TOPIC_DECLARED`, so removals are silently dropped — no Kafka message, no consumer state change.

This PR:

- Adds the `HermesTopicRemoved` proto (`hermes-schema/proto/topics.proto`, regenerated via the existing prost build).
- Adds a `TOPIC_REMOVED` branch to `pipelines::topics::transform` + `convert_topic_removed` (mirrors `convert_topic_declared`; same `bytes32(bytes16(topicId) | padding)` layout, same decode helper).
- Emits the new event to the existing `space.topics` Kafka topic, keyed by `space_id`, with header `event-type: TOPIC_REMOVED` so consumers can route via the existing header pattern (`HermesTopicDeclared` already uses `event-type: TOPIC_DECLARED`).
- **Merge-sorts declared/removed events by block sequence at emit time** so interleaved pairs in the same block hit Kafka in chain order. Without this, `[declare(A), remove, declare(B)]` would emit as `[declare(A), declare(B), remove]` and the indexer would end at NULL instead of B.
- Adds a `topic_removed(space_id, topic_id)` mock helper in `hermes-relay` for downstream tests.
- Wires the `TOPIC_REMOVED` counter into block-summary metrics + max-sequence / mark-last bookkeeping.

Consumer-side changes (kg-indexer, search-indexer) ship in GEO-628 / GEO-629, both blocked on this PR.

Full design rationale lives in [`docs/issues/topic-removed-not-picked-up.md`](https://github.com/defi-wonderland/gaia/blob/geo-619-topic-unsetremoved-not-picked-up-by-indexer/docs/issues/topic-removed-not-picked-up.md) on the parent GEO-619 branch.

## Test plan

- [x] `cargo test -p hermes-pipeline --lib pipelines::topics::` — 7 tests pass (4 existing declared + 3 new removed, plus `test_transform_interleaved_declare_remove` proving the merge-sort preserves block sequence)
- [x] `cargo test -p hermes-pipeline --bin hermes-pipeline test_topic` — 3 emit tests pass (`test_topic_declared_topic`, `test_topic_removed_topic`, `test_topic_removed_key`)
- [x] `cargo build -p hermes-schema`, `cargo build -p hermes-pipeline`, `cargo build -p hermes-relay` — all clean
- [ ] Manual: send a `TOPIC_REMOVED` mock action through hermes-relay → confirm a Kafka message lands on `space.topics` with header `event-type: TOPIC_REMOVED` and the correct `space_id` / `topic_id` payload

## Out of scope

- kg-indexer / search-indexer consumer handling — see [GEO-628](https://linear.app/defi-wonderland/issue/GEO-628) and [GEO-629](https://linear.app/defi-wonderland/issue/GEO-629).
- v2 selector rename (`TOPIC_SET` / `TOPIC_UNSET`) — covered by PR #177 (GEO-568) once v2 contracts land. The rename only swaps the constant in `hermes-substream`; everything in this PR continues to work.