### PR TITLE
feat(search-indexer): clear space_topic_entity_id on TOPIC_REMOVED

### DIFF
--- a/search-indexer-repository/src/lib.rs
+++ b/search-indexer-repository/src/lib.rs
@@ -18,8 +18,9 @@ pub use interfaces::SearchIndexProvider;
 pub use opensearch::OpenSearchProvider;
 pub use service::SearchIndexService;
 pub use types::{
-    BatchOperationResult, BatchOperationSummary, DeleteEntityRequest, EntityOperation,
-    RelationData, RemoveRelationByDocRequest, RemoveRelationData, UnsetEntityPropertiesRequest,
+    BatchOperationResult, BatchOperationSummary, ClearSpaceTopicEntityIdByDocRequest,
+    ClearSpaceTopicEntityIdRequest, DeleteEntityRequest, EntityOperation, RelationData,
+    RemoveRelationByDocRequest, RemoveRelationData, UnsetEntityPropertiesRequest,
     UpdateEntityGlobalScoreByDocRequest, UpdateEntityGlobalScoreRequest, UpdateEntityRequest,
     UpdateEntitySpaceScoreRequest, UpdateInCanonicalGraphByDocRequest,
     UpdateInCanonicalGraphRequest, UpdateSpaceScoreByDocRequest, UpdateSpaceScoreRequest,

--- a/search-indexer-repository/src/opensearch/bulk.rs
+++ b/search-indexer-repository/src/opensearch/bulk.rs
@@ -270,6 +270,7 @@ pub fn parse_bulk_response(
                     || meta.operation_type == "UpdateSpaceScoreByDoc"
                     || meta.operation_type == "UpdateEntitySpaceScore"
                     || meta.operation_type == "UpdateSpaceTopicEntityIdByDoc"
+                    || meta.operation_type == "ClearSpaceTopicEntityIdByDoc"
                     || meta.operation_type == "UpdateInCanonicalGraphByDoc");
             let is_success =
                 (200..300).contains(&(status as u16)) || is_not_found_ok;

--- a/search-indexer-repository/src/opensearch/provider.rs
+++ b/search-indexer-repository/src/opensearch/provider.rs
@@ -1228,6 +1228,25 @@ impl SearchIndexProvider for OpenSearchProvider {
                     });
                     flush_bulk_if_full!(self, bulk_ops, metas, total_succeeded, total_failed, all_results, total_wall_ms, total_took_ms, _bulk_call_count);
                 }
+                EntityOperation::ClearSpaceTopicEntityIdByDoc(request) => {
+                    // Direct doc-ID clear of `space_topic_entity_id` using a painless
+                    // remove (not null-assignment) so the cache-warmup aggregator at
+                    // `get_space_topic_mappings` doesn't see the field at all.
+                    // 404 is treated as success in parse_bulk_response.
+                    let body = json!({
+                        "script": {
+                            "source": "ctx._source.remove('space_topic_entity_id')",
+                            "lang": "painless"
+                        }
+                    });
+                    bulk_ops.push(BulkOperation::update(request.doc_id.clone(), body).into());
+                    metas.push(BulkOperationMeta {
+                        entity_id: request.doc_id.clone(),
+                        space_id: String::new(),
+                        operation_type: "ClearSpaceTopicEntityIdByDoc".to_string(),
+                    });
+                    flush_bulk_if_full!(self, bulk_ops, metas, total_succeeded, total_failed, all_results, total_wall_ms, total_took_ms, _bulk_call_count);
+                }
                 EntityOperation::UpdateSpaceTopicEntityId(request) => {
                     // Flush before executing the update_by_query to maintain ordering
                     flush_pending_bulk!(
@@ -1295,6 +1314,73 @@ impl SearchIndexProvider for OpenSearchProvider {
                                 success: false,
                                 error: Some(SearchIndexError::update(format!(
                                     "Update space topic entity ID failed: {}",
+                                    error_body
+                                ))),
+                            });
+                        }
+                    }
+                }
+                EntityOperation::ClearSpaceTopicEntityId(request) => {
+                    // Slow-path mirror of `UpdateSpaceTopicEntityId`. Used when the
+                    // Postgres entity-space lookup is unavailable. Removes (not nulls)
+                    // the field so the cache-warmup aggregator doesn't see it.
+                    flush_pending_bulk!(
+                        self,
+                        bulk_ops,
+                        metas,
+                        total_succeeded,
+                        total_failed,
+                        all_results,
+                        total_wall_ms,
+                        total_took_ms,
+                        _bulk_call_count
+                    );
+
+                    let space_uuid = uuid::Uuid::parse_str(&request.space_id).map_err(|_| {
+                        SearchIndexError::validation(format!(
+                            "Invalid space_id: {}",
+                            request.space_id
+                        ))
+                    })?;
+
+                    let body = json!({
+                        "query": {
+                            "term": {
+                                "space_id": space_uuid.to_string()
+                            }
+                        },
+                        "script": {
+                            "source": "ctx._source.remove('space_topic_entity_id')",
+                            "lang": "painless"
+                        }
+                    });
+
+                    match self
+                        .update_by_query_with_retry(body, "ClearSpaceTopicEntityId")
+                        .await?
+                    {
+                        UpdateByQueryOutcome::Success { took_ms, wall_ms, .. } => {
+                            total_succeeded += 1;
+                            total_wall_ms += wall_ms;
+                            total_took_ms += took_ms;
+                            _bulk_call_count += 1;
+                            all_results.push(BatchOperationResult {
+                                entity_id: String::new(),
+                                space_id: request.space_id.clone(),
+                                operation_type: "ClearSpaceTopicEntityId".to_string(),
+                                success: true,
+                                error: None,
+                            });
+                        }
+                        UpdateByQueryOutcome::Failed(error_body) => {
+                            total_failed += 1;
+                            all_results.push(BatchOperationResult {
+                                entity_id: String::new(),
+                                space_id: request.space_id.clone(),
+                                operation_type: "ClearSpaceTopicEntityId".to_string(),
+                                success: false,
+                                error: Some(SearchIndexError::update(format!(
+                                    "Clear space topic entity ID failed: {}",
                                     error_body
                                 ))),
                             });

--- a/search-indexer-repository/src/types.rs
+++ b/search-indexer-repository/src/types.rs
@@ -198,6 +198,27 @@ pub struct UpdateSpaceTopicEntityIdRequest {
     pub topic_entity_id: String,
 }
 
+/// Request to clear `space_topic_entity_id` from a single document.
+///
+/// Mirrors `UpdateSpaceTopicEntityIdByDocRequest` but removes the field
+/// instead of setting it. Uses the bulk API with a painless script —
+/// removing (not nulling) keeps the cache-warmup aggregator clean.
+#[derive(Debug, Clone)]
+pub struct ClearSpaceTopicEntityIdByDocRequest {
+    /// The document ID (`{entity_id}_{space_id}`).
+    pub doc_id: String,
+}
+
+/// Request to clear `space_topic_entity_id` from all entities in a space.
+///
+/// Mirrors `UpdateSpaceTopicEntityIdRequest` but removes the field instead
+/// of setting it. Uses `update_by_query` with a painless script.
+#[derive(Debug, Clone)]
+pub struct ClearSpaceTopicEntityIdRequest {
+    /// The space's unique identifier.
+    pub space_id: String,
+}
+
 /// Request to update in_canonical_graph for all entities in a space.
 ///
 /// This will set the `in_canonical_graph` field for ALL documents
@@ -249,6 +270,12 @@ pub enum EntityOperation {
     /// Update space_topic_entity_id by direct doc ID (resolved via Postgres lookup).
     /// Uses the bulk API instead of update_by_query.
     UpdateSpaceTopicEntityIdByDoc(UpdateSpaceTopicEntityIdByDocRequest),
+    /// Clear `space_topic_entity_id` from all entities in a space (slow path).
+    /// Uses `update_by_query` with a painless `remove` script.
+    ClearSpaceTopicEntityId(ClearSpaceTopicEntityIdRequest),
+    /// Clear `space_topic_entity_id` from a single document (fast path).
+    /// Uses the bulk API with a painless `remove` script.
+    ClearSpaceTopicEntityIdByDoc(ClearSpaceTopicEntityIdByDocRequest),
     /// Update in_canonical_graph for all entities in a space.
     /// Uses update_by_query to set the boolean field on all documents in the space.
     UpdateInCanonicalGraph(UpdateInCanonicalGraphRequest),
@@ -274,6 +301,8 @@ impl EntityOperation {
             EntityOperation::UpdateSpaceScoreByDoc(_) => "",
             EntityOperation::UpdateSpaceTopicEntityId(_) => "",
             EntityOperation::UpdateSpaceTopicEntityIdByDoc(_) => "",
+            EntityOperation::ClearSpaceTopicEntityId(_) => "",
+            EntityOperation::ClearSpaceTopicEntityIdByDoc(_) => "",
             EntityOperation::UpdateInCanonicalGraph(_) => "",
             EntityOperation::UpdateInCanonicalGraphByDoc(_) => "",
         }
@@ -295,6 +324,8 @@ impl EntityOperation {
             EntityOperation::UpdateSpaceScoreByDoc(_) => "",
             EntityOperation::UpdateSpaceTopicEntityId(r) => &r.space_id,
             EntityOperation::UpdateSpaceTopicEntityIdByDoc(_) => "",
+            EntityOperation::ClearSpaceTopicEntityId(r) => &r.space_id,
+            EntityOperation::ClearSpaceTopicEntityIdByDoc(_) => "",
             EntityOperation::UpdateInCanonicalGraph(r) => &r.space_id,
             EntityOperation::UpdateInCanonicalGraphByDoc(_) => "",
         }
@@ -315,6 +346,8 @@ impl EntityOperation {
             EntityOperation::UpdateSpaceScoreByDoc(_) => "UpdateSpaceScoreByDoc",
             EntityOperation::UpdateSpaceTopicEntityId(_) => "UpdateSpaceTopicEntityId",
             EntityOperation::UpdateSpaceTopicEntityIdByDoc(_) => "UpdateSpaceTopicEntityIdByDoc",
+            EntityOperation::ClearSpaceTopicEntityId(_) => "ClearSpaceTopicEntityId",
+            EntityOperation::ClearSpaceTopicEntityIdByDoc(_) => "ClearSpaceTopicEntityIdByDoc",
             EntityOperation::UpdateInCanonicalGraph(_) => "UpdateInCanonicalGraph",
             EntityOperation::UpdateInCanonicalGraphByDoc(_) => "UpdateInCanonicalGraphByDoc",
         }

--- a/search-indexer/src/consumer/messages.rs
+++ b/search-indexer/src/consumer/messages.rs
@@ -255,16 +255,29 @@ impl ScoreEvent {
 // Space Topic Events - from space.topics Kafka topic
 // ============================================================================
 
+/// Whether a space topic event is a declaration or a removal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpaceTopicEventKind {
+    /// Space declared a topic — set the topic entity as the space's representative.
+    Declared,
+    /// Space removed its topic — clear the mapping in cache and index.
+    Removed,
+}
+
 /// A space topic event received from the space.topics Kafka topic.
 ///
 /// When a space declares a topic, the topic entity ID serves as the
 /// representative entity for the space (containing its name, description, etc.).
+/// When a space removes its topic, the mapping is cleared but the topic entity
+/// document is preserved (it may carry knowledge-edit content for that entity).
 #[derive(Debug, Clone)]
 pub struct SpaceTopicEvent {
-    /// The space that declared the topic.
+    /// The space that declared or removed its topic.
     pub space_id: Uuid,
-    /// The topic entity ID (represents the space in the entity index).
+    /// The topic entity ID. For `Removed`, this is the topic being cleared.
     pub topic_entity_id: Uuid,
+    /// Whether this is a declaration or a removal.
+    pub kind: SpaceTopicEventKind,
 }
 
 // ============================================================================

--- a/search-indexer/src/consumer/mod.rs
+++ b/search-indexer/src/consumer/mod.rs
@@ -11,7 +11,8 @@ mod topology_consumer;
 
 pub use entities_consumer::EntitiesConsumer;
 pub use messages::{
-    EntityEvent, EntityEventType, ScoreEvent, ScoreEventType, SpaceTopicEvent, StreamMessage,
+    EntityEvent, EntityEventType, ScoreEvent, ScoreEventType, SpaceTopicEvent,
+    SpaceTopicEventKind, StreamMessage,
 };
 pub use scores_consumer::ScoresConsumer;
 pub use space_topics_consumer::SpaceTopicsConsumer;

--- a/search-indexer/src/consumer/space_topics_consumer.rs
+++ b/search-indexer/src/consumer/space_topics_consumer.rs
@@ -1,13 +1,16 @@
 //! Kafka consumer for space topic events from the space.topics topic.
 //!
-//! Consumes HermesTopicDeclared messages and forwards space topic events to the ingest.
+//! Consumes HermesTopicDeclared and HermesTopicRemoved messages and forwards
+//! space topic events to the ingest. The two event types share a Kafka topic
+//! and are distinguished by the `event-type` header (`TOPIC_DECLARED` /
+//! `TOPIC_REMOVED`; `None` is treated as `TOPIC_DECLARED` for back-compat).
 
 use hermes_instrumentation::{debug, error, info, info_span, instrument, warn, Instrument};
 use hermes_kafka::get_topic_prefix;
 use prost::Message;
 use rdkafka::{
     consumer::{Consumer, StreamConsumer},
-    message::Message as KafkaMessage,
+    message::{Headers, Message as KafkaMessage},
     TopicPartitionList,
 };
 use std::env;
@@ -15,11 +18,11 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
-use crate::consumer::messages::{SpaceTopicEvent, StreamMessage};
+use crate::consumer::messages::{SpaceTopicEvent, SpaceTopicEventKind, StreamMessage};
 use crate::errors::IngestError;
 use crate::orchestrator::SpaceTopicProcessingBatch;
 
-use hermes_schema::pb::topics::HermesTopicDeclared;
+use hermes_schema::pb::topics::{HermesTopicDeclared, HermesTopicRemoved};
 
 /// Pending space topic messages for batching.
 struct PendingSpaceTopicMessage {
@@ -322,6 +325,14 @@ impl SpaceTopicsConsumer {
     }
 
     /// Parse a Kafka message into a space topic event.
+    ///
+    /// Dispatches on the `event-type` header:
+    /// - `Some("TOPIC_DECLARED") | None` → decode `HermesTopicDeclared`,
+    ///   emit `SpaceTopicEvent { kind: Declared }`.
+    /// - `Some("TOPIC_REMOVED")` → decode `HermesTopicRemoved`,
+    ///   emit `SpaceTopicEvent { kind: Removed }`.
+    /// - `Some(other)` → error (matches the kg-indexer's fail-fast behavior so
+    ///   typos or newly introduced event types surface loudly).
     fn parse_message(
         &self,
         msg: &rdkafka::message::BorrowedMessage<'_>,
@@ -334,53 +345,106 @@ impl SpaceTopicsConsumer {
             }
         };
 
-        let topic_declared = HermesTopicDeclared::decode(payload).map_err(|e| {
-            IngestError::parse(format!("Failed to decode HermesTopicDeclared: {}", e))
-        })?;
+        let event_type = get_event_type(msg);
 
-        if topic_declared.space_id.len() != 16 {
-            warn!(
-                space_id_len = topic_declared.space_id.len(),
-                "Invalid space_id length in HermesTopicDeclared, expected 16 bytes"
-            );
-            return Ok(None);
+        match event_type.as_deref() {
+            Some("TOPIC_REMOVED") => {
+                let removed = HermesTopicRemoved::decode(payload).map_err(|e| {
+                    IngestError::parse(format!("Failed to decode HermesTopicRemoved: {}", e))
+                })?;
+                let event = match decode_space_topic_event(
+                    &removed.space_id,
+                    &removed.topic_id,
+                    SpaceTopicEventKind::Removed,
+                )? {
+                    Some(e) => e,
+                    None => return Ok(None),
+                };
+                debug!(
+                    space_id = %event.space_id,
+                    topic_entity_id = %event.topic_entity_id,
+                    "Parsed HermesTopicRemoved"
+                );
+                Ok(Some(PendingSpaceTopicMessage {
+                    events: vec![event],
+                }))
+            }
+            Some("TOPIC_DECLARED") | None => {
+                let declared = HermesTopicDeclared::decode(payload).map_err(|e| {
+                    IngestError::parse(format!("Failed to decode HermesTopicDeclared: {}", e))
+                })?;
+                let event = match decode_space_topic_event(
+                    &declared.space_id,
+                    &declared.topic_id,
+                    SpaceTopicEventKind::Declared,
+                )? {
+                    Some(e) => e,
+                    None => return Ok(None),
+                };
+                debug!(
+                    space_id = %event.space_id,
+                    topic_entity_id = %event.topic_entity_id,
+                    "Parsed HermesTopicDeclared"
+                );
+                Ok(Some(PendingSpaceTopicMessage {
+                    events: vec![event],
+                }))
+            }
+            Some(other) => Err(IngestError::parse(format!(
+                "Unknown space.topics event-type header: {}",
+                other
+            ))),
         }
-
-        if topic_declared.topic_id.len() != 16 {
-            warn!(
-                topic_id_len = topic_declared.topic_id.len(),
-                "Invalid topic_id length in HermesTopicDeclared, expected 16 bytes"
-            );
-            return Ok(None);
-        }
-
-        let space_bytes: [u8; 16] = topic_declared
-            .space_id
-            .as_slice()
-            .try_into()
-            .map_err(|_| IngestError::parse("Failed to convert space_id bytes".to_string()))?;
-        let topic_bytes: [u8; 16] = topic_declared
-            .topic_id
-            .as_slice()
-            .try_into()
-            .map_err(|_| IngestError::parse("Failed to convert topic_id bytes".to_string()))?;
-
-        let space_id = Uuid::from_bytes(space_bytes);
-        let topic_entity_id = Uuid::from_bytes(topic_bytes);
-
-        debug!(
-            space_id = %space_id,
-            topic_entity_id = %topic_entity_id,
-            "Parsed HermesTopicDeclared"
-        );
-
-        Ok(Some(PendingSpaceTopicMessage {
-            events: vec![SpaceTopicEvent {
-                space_id,
-                topic_entity_id,
-            }],
-        }))
     }
+}
+
+/// Read the `event-type` Kafka header, if present.
+fn get_event_type(msg: &rdkafka::message::BorrowedMessage<'_>) -> Option<String> {
+    let headers = msg.headers()?;
+    for i in 0..headers.count() {
+        let header = headers.get(i);
+        if header.key == "event-type" {
+            if let Some(value) = header.value {
+                return String::from_utf8(value.to_vec()).ok();
+            }
+        }
+    }
+    None
+}
+
+/// Validate the 16-byte space/topic IDs and build a `SpaceTopicEvent`.
+fn decode_space_topic_event(
+    space_id: &[u8],
+    topic_id: &[u8],
+    kind: SpaceTopicEventKind,
+) -> Result<Option<SpaceTopicEvent>, IngestError> {
+    if space_id.len() != 16 {
+        warn!(
+            space_id_len = space_id.len(),
+            kind = ?kind,
+            "Invalid space_id length, expected 16 bytes"
+        );
+        return Ok(None);
+    }
+    if topic_id.len() != 16 {
+        warn!(
+            topic_id_len = topic_id.len(),
+            kind = ?kind,
+            "Invalid topic_id length, expected 16 bytes"
+        );
+        return Ok(None);
+    }
+    let space_bytes: [u8; 16] = space_id
+        .try_into()
+        .map_err(|_| IngestError::parse("Failed to convert space_id bytes".to_string()))?;
+    let topic_bytes: [u8; 16] = topic_id
+        .try_into()
+        .map_err(|_| IngestError::parse("Failed to convert topic_id bytes".to_string()))?;
+    Ok(Some(SpaceTopicEvent {
+        space_id: Uuid::from_bytes(space_bytes),
+        topic_entity_id: Uuid::from_bytes(topic_bytes),
+        kind,
+    }))
 }
 
 #[cfg(test)]

--- a/search-indexer/src/loader/mod.rs
+++ b/search-indexer/src/loader/mod.rs
@@ -16,8 +16,9 @@ use crate::orchestrator::{BatchSource, ProcessedBatch};
 use crate::processor::ProcessedEvent;
 use crate::relation_map::RelationMap;
 use search_indexer_repository::{
-    EntityOperation, RelationData, RemoveRelationByDocRequest, RemoveRelationData,
-    SearchIndexProvider, UnsetEntityPropertiesRequest, UpdateEntityGlobalScoreByDocRequest,
+    ClearSpaceTopicEntityIdByDocRequest, ClearSpaceTopicEntityIdRequest, EntityOperation,
+    RelationData, RemoveRelationByDocRequest, RemoveRelationData, SearchIndexProvider,
+    UnsetEntityPropertiesRequest, UpdateEntityGlobalScoreByDocRequest,
     UpdateEntityGlobalScoreRequest, UpdateEntityRequest, UpdateEntitySpaceScoreRequest,
     UpdateInCanonicalGraphByDocRequest, UpdateInCanonicalGraphRequest,
     UpdateSpaceScoreByDocRequest, UpdateSpaceScoreRequest, UpdateSpaceTopicEntityIdByDocRequest,
@@ -231,6 +232,20 @@ impl SearchLoader {
                             },
                         ));
                 }
+                ProcessedEvent::ClearSpaceTopicEntityId { space_id } => {
+                    self.pending_operations
+                        .push(EntityOperation::ClearSpaceTopicEntityId(
+                            ClearSpaceTopicEntityIdRequest {
+                                space_id: space_id.to_string(),
+                            },
+                        ));
+                }
+                ProcessedEvent::ClearSpaceTopicEntityIdByDoc { doc_id } => {
+                    self.pending_operations
+                        .push(EntityOperation::ClearSpaceTopicEntityIdByDoc(
+                            ClearSpaceTopicEntityIdByDocRequest { doc_id },
+                        ));
+                }
                 ProcessedEvent::UpdateInCanonicalGraph {
                     space_id,
                     in_canonical_graph,
@@ -405,7 +420,9 @@ impl SearchLoader {
                             metrics.total_score_updates.fetch_add(1, Ordering::Relaxed);
                         }
                         ProcessedEvent::UpdateSpaceTopicEntityId { .. }
-                        | ProcessedEvent::UpdateSpaceTopicEntityIdByDoc { .. } => {
+                        | ProcessedEvent::UpdateSpaceTopicEntityIdByDoc { .. }
+                        | ProcessedEvent::ClearSpaceTopicEntityId { .. }
+                        | ProcessedEvent::ClearSpaceTopicEntityIdByDoc { .. } => {
                             metrics
                                 .total_space_topic_updates
                                 .fetch_add(1, Ordering::Relaxed);
@@ -626,6 +643,8 @@ mod tests {
                     | EntityOperation::RemoveRelationByDoc(_)
                     | EntityOperation::UpdateSpaceTopicEntityId(_)
                     | EntityOperation::UpdateSpaceTopicEntityIdByDoc(_)
+                    | EntityOperation::ClearSpaceTopicEntityId(_)
+                    | EntityOperation::ClearSpaceTopicEntityIdByDoc(_)
                     | EntityOperation::UpdateInCanonicalGraph(_)
                     | EntityOperation::UpdateInCanonicalGraphByDoc(_) => {
                         // Pass through - no special tracking needed

--- a/search-indexer/src/processor/mod.rs
+++ b/search-indexer/src/processor/mod.rs
@@ -10,7 +10,10 @@ use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
 use crate::consumer::StreamMessage;
-use crate::consumer::{EntityEvent, EntityEventType, ScoreEvent, ScoreEventType, SpaceTopicEvent};
+use crate::consumer::{
+    EntityEvent, EntityEventType, ScoreEvent, ScoreEventType, SpaceTopicEvent,
+    SpaceTopicEventKind,
+};
 use crate::errors::IngestError;
 use crate::lookup::EntitySpaceLookup;
 use crate::metrics::SearchIndexerMetrics;
@@ -82,6 +85,12 @@ pub enum ProcessedEvent {
         doc_id: String,
         topic_entity_id: String,
     },
+    /// Clear `space_topic_entity_id` for all entities in a space (slow path).
+    /// Used when Postgres lookup is unavailable.
+    ClearSpaceTopicEntityId { space_id: uuid::Uuid },
+    /// Clear `space_topic_entity_id` for a single doc (fast path — bulk API).
+    /// Resolved via Postgres lookup (plus an explicit clear of the topic entity's stub doc).
+    ClearSpaceTopicEntityIdByDoc { doc_id: String },
     /// Update in_canonical_graph by direct doc ID (fast path — bulk API).
     /// Resolved via Postgres lookup.
     UpdateInCanonicalGraphByDoc {
@@ -502,12 +511,16 @@ impl Processor {
     /// Process a batch of space topic events.
     ///
     /// For each event this:
-    /// 1. Updates the in-memory cache so subsequent entity upserts get `space_topic_entity_id` set.
-    /// 2. Emits an `UpdateSpaceTopicEntityId` to backfill existing docs via `update_by_query`.
-    /// 3. Upserts a stub document for the topic entity itself. This ensures the mapping
-    ///    survives indexer restarts (the cache warm-up query will find this document) even
-    ///    if no other entities in the space have been indexed yet. When the full entity data
-    ///    arrives via `knowledge.edits`, the upsert merges into this stub.
+    /// 1. Updates (declared) or clears (removed) the in-memory `space_id → topic_entity_id`
+    ///    cache so subsequent entity upserts get `space_topic_entity_id` set correctly.
+    /// 2. Emits an `UpdateSpaceTopicEntityId` / `ClearSpaceTopicEntityId` to backfill /
+    ///    clear existing docs via `update_by_query`, or a per-doc fast-path equivalent
+    ///    when a Postgres entity-space lookup is available.
+    /// 3. For declarations: upserts a stub document for the topic entity. For removals:
+    ///    explicitly clears the topic entity's stub doc — the entity may not appear
+    ///    in the Postgres entity-space lookup if it has no knowledge-edit content yet.
+    ///    Either way the document itself is preserved; only `space_topic_entity_id`
+    ///    is cleared, so any knowledge-edit content (name, description, …) survives.
     #[instrument(skip(self, events), fields(event_count = events.len()))]
     pub async fn process_space_topic_batch(
         &mut self,
@@ -515,98 +528,153 @@ impl Processor {
     ) -> Result<Vec<ProcessedEvent>, IngestError> {
         let mut processed = Vec::with_capacity(events.len() * 2);
 
-        // Collect space_id → topic_entity_id mappings for batch resolution
-        let mut topic_updates: Vec<(Uuid, Uuid)> = Vec::new();
+        // Collect space_id → topic_entity_id mappings per kind for batch resolution.
+        let mut declared_updates: Vec<(Uuid, Uuid)> = Vec::new();
+        let mut removed_spaces: Vec<Uuid> = Vec::new();
 
         for event in events {
-            // Update the cache before creating the processed events
-            self.space_topic_cache
-                .insert(event.space_id, event.topic_entity_id);
+            match event.kind {
+                SpaceTopicEventKind::Declared => {
+                    self.space_topic_cache
+                        .insert(event.space_id, event.topic_entity_id);
 
-            if self.should_sample(SampleCategory::UpdateSpaceTopicEntityId) {
-                info!(
-                    space_id = %event.space_id,
-                    topic_entity_id = %event.topic_entity_id,
-                    "[sample] UpdateSpaceTopicEntityId"
-                );
+                    if self.should_sample(SampleCategory::UpdateSpaceTopicEntityId) {
+                        info!(
+                            space_id = %event.space_id,
+                            topic_entity_id = %event.topic_entity_id,
+                            "[sample] UpdateSpaceTopicEntityId"
+                        );
+                    }
+
+                    declared_updates.push((event.space_id, event.topic_entity_id));
+
+                    // Upsert a stub document for the topic entity itself. This is
+                    // necessary for two reasons:
+                    //
+                    // 1. Restart resilience: if the indexer restarts before any entities
+                    //    in this space are indexed, the in-memory cache is lost. The
+                    //    cache warm-up query (`get_space_topic_mappings`) reads
+                    //    `space_topic_entity_id` from the index — without this stub
+                    //    document, there would be nothing to warm from.
+                    //
+                    // 2. Pipeline emit ordering: within a single block, hermes-pipeline
+                    //    emits `space.topics` BEFORE `knowledge.edits`, so the topic
+                    //    entity's full data (name, description, avatar) could arrive
+                    //    AFTER this event. The None fields (name, description, etc.) are
+                    //    ignored by build_update_doc in the loader, so only entity_id,
+                    //    space_id, and space_topic_entity_id are written to the index.
+                    let mut doc =
+                        EntityDocument::new(event.topic_entity_id, event.space_id, None, None);
+                    doc.space_topic_entity_id = Some(event.topic_entity_id.to_string());
+                    processed.push(ProcessedEvent::Index(doc));
+                }
+                SpaceTopicEventKind::Removed => {
+                    self.space_topic_cache.remove(&event.space_id);
+
+                    if self.should_sample(SampleCategory::UpdateSpaceTopicEntityId) {
+                        info!(
+                            space_id = %event.space_id,
+                            topic_entity_id = %event.topic_entity_id,
+                            "[sample] ClearSpaceTopicEntityId"
+                        );
+                    }
+
+                    removed_spaces.push(event.space_id);
+
+                    // Explicitly clear the topic entity's own stub doc. The topic
+                    // entity may have been added via space.topics-only (no
+                    // knowledge.edits content yet), in which case the Postgres
+                    // entity-space lookup below will not return it.
+                    processed.push(ProcessedEvent::ClearSpaceTopicEntityIdByDoc {
+                        doc_id: format!("{}_{}", event.topic_entity_id, event.space_id),
+                    });
+                }
             }
-
-            topic_updates.push((event.space_id, event.topic_entity_id));
-
-            // Upsert a stub document for the topic entity itself. This is
-            // necessary for two reasons:
-            //
-            // 1. Restart resilience: if the indexer restarts before any entities
-            //    in this space are indexed, the in-memory cache is lost. The
-            //    cache warm-up query (`get_space_topic_mappings`) reads
-            //    `space_topic_entity_id` from the index — without this stub
-            //    document, there would be nothing to warm from.
-            //
-            // 2. Pipeline emit ordering: within a single block, hermes-pipeline
-            //    emits `space.topics` BEFORE `knowledge.edits`, so the topic
-            //    entity's full data (name, description, avatar) could arrive
-            //    AFTER this event. The None fields (name, description, etc.) are
-            //    ignored by build_update_doc in the loader, so only entity_id,
-            //    space_id, and space_topic_entity_id are written to the index.
-            let mut doc = EntityDocument::new(event.topic_entity_id, event.space_id, None, None);
-            doc.space_topic_entity_id = Some(event.topic_entity_id.to_string());
-            processed.push(ProcessedEvent::Index(doc));
         }
 
-        // Resolve space_id → entity docs via Postgres, or fall back to update_by_query
-        if !topic_updates.is_empty() {
-            if let Some(lookup) = &self.entity_space_lookup {
-                let space_ids: Vec<Uuid> = topic_updates.iter().map(|(sid, _)| *sid).collect();
-                let topic_map: HashMap<Uuid, Uuid> = topic_updates.into_iter().collect();
+        // Resolve space_id → entity docs via Postgres, or fall back to update_by_query.
+        // Use the same Postgres call for both kinds so we don't double-query when a
+        // declare + remove for different spaces land in the same batch.
+        let mut fast_path_spaces: Vec<Uuid> = declared_updates.iter().map(|(sid, _)| *sid).collect();
+        fast_path_spaces.extend(removed_spaces.iter().copied());
 
-                match lookup.entities_for_spaces(&space_ids).await {
+        if !fast_path_spaces.is_empty() {
+            if let Some(lookup) = &self.entity_space_lookup {
+                let declared_map: HashMap<Uuid, Uuid> = declared_updates.iter().copied().collect();
+                let removed_set: std::collections::HashSet<Uuid> =
+                    removed_spaces.iter().copied().collect();
+
+                match lookup.entities_for_spaces(&fast_path_spaces).await {
                     Ok(pairs) => {
-                        let mut resolved = 0usize;
+                        let mut resolved_declared = 0usize;
+                        let mut resolved_removed = 0usize;
                         for (entity_id, space_id) in &pairs {
-                            if let Some(&topic_entity_id) = topic_map.get(space_id) {
+                            if let Some(&topic_entity_id) = declared_map.get(space_id) {
                                 processed.push(ProcessedEvent::UpdateSpaceTopicEntityIdByDoc {
                                     doc_id: format!("{}_{}", entity_id, space_id),
                                     topic_entity_id: topic_entity_id.to_string(),
                                 });
-                                resolved += 1;
+                                resolved_declared += 1;
+                            } else if removed_set.contains(space_id) {
+                                processed.push(ProcessedEvent::ClearSpaceTopicEntityIdByDoc {
+                                    doc_id: format!("{}_{}", entity_id, space_id),
+                                });
+                                resolved_removed += 1;
                             }
                         }
 
                         let found_spaces: std::collections::HashSet<Uuid> =
                             pairs.iter().map(|(_, sid)| *sid).collect();
-                        let skipped = topic_map
+                        let skipped_declared = declared_map
                             .keys()
                             .filter(|sid| !found_spaces.contains(sid))
                             .count();
+                        let skipped_removed = removed_set
+                            .iter()
+                            .filter(|sid| !found_spaces.contains(sid))
+                            .count();
 
-                        if resolved > 0 || skipped > 0 {
+                        if resolved_declared > 0
+                            || resolved_removed > 0
+                            || skipped_declared > 0
+                            || skipped_removed > 0
+                        {
                             info!(
-                                resolved = resolved,
-                                skipped = skipped,
-                                "UpdateSpaceTopicEntityId batch resolved via Postgres"
+                                resolved_declared = resolved_declared,
+                                resolved_removed = resolved_removed,
+                                skipped_declared = skipped_declared,
+                                skipped_removed = skipped_removed,
+                                "Space topic batch resolved via Postgres"
                             );
                         }
                     }
                     Err(e) => {
                         error!(
                             error = %e,
-                            space_count = topic_map.len(),
-                            "Postgres lookup failed for UpdateSpaceTopicEntityId — falling back to slow update_by_query"
+                            declared = declared_map.len(),
+                            removed = removed_set.len(),
+                            "Postgres lookup failed for space topic batch — falling back to slow update_by_query"
                         );
-                        for (space_id, topic_entity_id) in topic_map {
+                        for (space_id, topic_entity_id) in declared_updates {
                             processed.push(ProcessedEvent::UpdateSpaceTopicEntityId {
                                 space_id,
                                 topic_entity_id,
                             });
                         }
+                        for space_id in removed_spaces {
+                            processed.push(ProcessedEvent::ClearSpaceTopicEntityId { space_id });
+                        }
                     }
                 }
             } else {
-                for (space_id, topic_entity_id) in topic_updates {
+                for (space_id, topic_entity_id) in declared_updates {
                     processed.push(ProcessedEvent::UpdateSpaceTopicEntityId {
                         space_id,
                         topic_entity_id,
                     });
+                }
+                for space_id in removed_spaces {
+                    processed.push(ProcessedEvent::ClearSpaceTopicEntityId { space_id });
                 }
             }
         }
@@ -1819,6 +1887,7 @@ mod tests {
         let events = vec![SpaceTopicEvent {
             space_id,
             topic_entity_id,
+            kind: SpaceTopicEventKind::Declared,
         }];
         let processed = processor.process_space_topic_batch(events).await.unwrap();
 
@@ -1873,6 +1942,68 @@ mod tests {
                 doc.space_topic_entity_id,
                 Some(topic_entity_id.to_string()),
                 "After processing a SpaceTopicEvent, subsequent upserts should have the topic set"
+            );
+        } else {
+            panic!("Expected ProcessedEvent::Index");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_space_topic_batch_removed_clears_cache_and_emits_clear_events() {
+        // Seed the cache to mirror a prior Declared event.
+        let space_id = Uuid::new_v4();
+        let topic_entity_id = Uuid::new_v4();
+        let mut cache = HashMap::new();
+        cache.insert(space_id, topic_entity_id);
+        let mut processor = Processor::with_space_topic_cache(cache, 0);
+        assert_eq!(processor.space_topic_cache_len(), 1);
+
+        let events = vec![SpaceTopicEvent {
+            space_id,
+            topic_entity_id,
+            kind: SpaceTopicEventKind::Removed,
+        }];
+        let processed = processor.process_space_topic_batch(events).await.unwrap();
+
+        // Removed branch should emit 2 events with no Postgres lookup:
+        // (1) ClearSpaceTopicEntityIdByDoc for the topic entity's own stub doc,
+        // (2) ClearSpaceTopicEntityId slow-path fallback for the rest of the space.
+        assert_eq!(processed.len(), 2);
+
+        let expected_stub_doc_id = format!("{}_{}", topic_entity_id, space_id);
+        assert!(
+            processed.iter().any(|e| matches!(
+                e,
+                ProcessedEvent::ClearSpaceTopicEntityIdByDoc { doc_id } if doc_id == &expected_stub_doc_id
+            )),
+            "Expected ClearSpaceTopicEntityIdByDoc for the topic entity's stub doc, got: {processed:?}"
+        );
+        assert!(
+            processed.iter().any(|e| matches!(
+                e,
+                ProcessedEvent::ClearSpaceTopicEntityId { space_id: s } if s == &space_id
+            )),
+            "Expected ClearSpaceTopicEntityId fallback for the rest of the space, got: {processed:?}"
+        );
+
+        // Cache should no longer carry the mapping.
+        assert_eq!(processor.space_topic_cache_len(), 0);
+
+        // A subsequent upsert in that space should NOT carry space_topic_entity_id.
+        let event = EntityEvent::upsert(
+            Uuid::new_v4(),
+            space_id,
+            Some("Post-removal Entity".to_string()),
+            None,
+            None,
+            None,
+            None,
+        );
+        let result = processor.process_event(event).unwrap();
+        if let Some(ProcessedEvent::Index(doc)) = result {
+            assert_eq!(
+                doc.space_topic_entity_id, None,
+                "After Removed, subsequent upserts must not auto-tag the removed topic"
             );
         } else {
             panic!("Expected ProcessedEvent::Index");

--- a/search-indexer/tests/e2e-kafka-search-api/src/generators/space_topics.rs
+++ b/search-indexer/tests/e2e-kafka-search-api/src/generators/space_topics.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use prost::Message;
 use uuid::Uuid;
 
-use hermes_schema::pb::topics::HermesTopicDeclared;
+use hermes_schema::pb::topics::{HermesTopicDeclared, HermesTopicRemoved};
 
 /// Generate a HermesTopicDeclared protobuf message for the space.topics Kafka topic.
 ///
@@ -11,6 +11,23 @@ use hermes_schema::pb::topics::HermesTopicDeclared;
 /// description, avatar, cover) by looking up the topic entity in the index.
 pub fn create_topic_declared(space_id: Uuid, topic_id: Uuid) -> Result<Vec<u8>> {
     let msg = HermesTopicDeclared {
+        space_id: space_id.as_bytes().to_vec(),
+        topic_id: topic_id.as_bytes().to_vec(),
+        meta: None,
+    };
+
+    let mut buf = Vec::new();
+    msg.encode(&mut buf)?;
+    Ok(buf)
+}
+
+/// Generate a HermesTopicRemoved protobuf message for the space.topics Kafka topic.
+///
+/// Used together with the `event-type: TOPIC_REMOVED` Kafka header so the
+/// search-indexer routes the payload through the removal path: cache cleared
+/// and `space_topic_entity_id` removed from all docs in the space.
+pub fn create_topic_removed(space_id: Uuid, topic_id: Uuid) -> Result<Vec<u8>> {
+    let msg = HermesTopicRemoved {
         space_id: space_id.as_bytes().to_vec(),
         topic_id: topic_id.as_bytes().to_vec(),
         meta: None,
@@ -44,5 +61,19 @@ mod tests {
         assert_eq!(msg.space_id, space_id.as_bytes().to_vec());
         assert_eq!(msg.topic_id, topic_id.as_bytes().to_vec());
         assert!(msg.meta.is_none());
+    }
+
+    #[test]
+    fn test_create_topic_removed() {
+        let space_id = Uuid::new_v4();
+        let topic_id = Uuid::new_v4();
+
+        let bytes = create_topic_removed(space_id, topic_id).unwrap();
+        assert!(!bytes.is_empty());
+
+        let decoded = HermesTopicRemoved::decode(&bytes[..]).unwrap();
+        assert_eq!(decoded.space_id, space_id.as_bytes().to_vec());
+        assert_eq!(decoded.topic_id, topic_id.as_bytes().to_vec());
+        assert!(decoded.meta.is_none());
     }
 }

--- a/search-indexer/tests/load-test/src/generators/space_topics.rs
+++ b/search-indexer/tests/load-test/src/generators/space_topics.rs
@@ -2,11 +2,26 @@ use anyhow::Result;
 use prost::Message;
 use uuid::Uuid;
 
-use hermes_schema::pb::topics::HermesTopicDeclared;
+use hermes_schema::pb::topics::{HermesTopicDeclared, HermesTopicRemoved};
 
 /// Generate a HermesTopicDeclared protobuf message for the space.topics Kafka topic.
 pub fn create_topic_declared(space_id: Uuid, topic_id: Uuid) -> Result<Vec<u8>> {
     let msg = HermesTopicDeclared {
+        space_id: space_id.as_bytes().to_vec(),
+        topic_id: topic_id.as_bytes().to_vec(),
+        meta: None,
+    };
+
+    let mut buf = Vec::new();
+    msg.encode(&mut buf)?;
+    Ok(buf)
+}
+
+/// Generate a HermesTopicRemoved protobuf message for the space.topics Kafka topic.
+///
+/// Paired with the `event-type: TOPIC_REMOVED` Kafka header.
+pub fn create_topic_removed(space_id: Uuid, topic_id: Uuid) -> Result<Vec<u8>> {
+    let msg = HermesTopicRemoved {
         space_id: space_id.as_bytes().to_vec(),
         topic_id: topic_id.as_bytes().to_vec(),
         meta: None,

--- a/search-indexer/tests/orchestrator_integration.rs
+++ b/search-indexer/tests/orchestrator_integration.rs
@@ -324,6 +324,8 @@ impl SearchIndexProvider for MockSearchProvider {
                 | EntityOperation::UpdateSpaceScoreByDoc(_)
                 | EntityOperation::UpdateSpaceTopicEntityId(_)
                 | EntityOperation::UpdateSpaceTopicEntityIdByDoc(_)
+                | EntityOperation::ClearSpaceTopicEntityId(_)
+                | EntityOperation::ClearSpaceTopicEntityIdByDoc(_)
                 | EntityOperation::UpdateInCanonicalGraph(_)
                 | EntityOperation::UpdateInCanonicalGraphByDoc(_) => false,
             };
@@ -366,6 +368,8 @@ impl SearchIndexProvider for MockSearchProvider {
                     | EntityOperation::UpdateSpaceScoreByDoc(_)
                     | EntityOperation::UpdateSpaceTopicEntityId(_)
                     | EntityOperation::UpdateSpaceTopicEntityIdByDoc(_)
+                    | EntityOperation::ClearSpaceTopicEntityId(_)
+                    | EntityOperation::ClearSpaceTopicEntityIdByDoc(_)
                     | EntityOperation::UpdateInCanonicalGraph(_)
                     | EntityOperation::UpdateInCanonicalGraphByDoc(_) => {
                         // Tracked via all_operations


### PR DESCRIPTION
Closes [GEO-629](https://linear.app/defi-wonderland/issue/GEO-629). Part of [GEO-619](https://linear.app/defi-wonderland/issue/GEO-619).

> **Stacked PR.** Base is `geo-619-topic-unsetremoved-not-picked-up-by-indexer`, not `dev`. The parent branch already carries [GEO-627](https://linear.app/defi-wonderland/issue/GEO-627) (`HermesTopicRemoved` proto + Kafka emit, PR #195) and [GEO-628](https://linear.app/defi-wonderland/issue/GEO-628) (kg-indexer side, PR #196). With this PR the GEO-619 epic is feature-complete; only the e2e lifecycle test on this PR is outstanding (see "Follow-up" below).

## Summary

The hermes pipeline emits `HermesTopicRemoved` on `space.topics` with header `event-type: TOPIC_REMOVED`, but the search-indexer ignored it: the in-memory `space_id → topic_entity_id` cache kept the stale mapping, and OpenSearch docs still carried `space_topic_entity_id` forever after a removal. New entities indexed afterward got auto-tagged with the removed topic via the cache-hit fast path.

This PR adds the symmetric removal path across every search-indexer layer, mirroring the existing declare flow.

## Changes by layer

- **Consumer** (`search-indexer/src/consumer/space_topics_consumer.rs`): `parse_message` now reads the Kafka `event-type` header. `None | Some("TOPIC_DECLARED")` keeps the existing `HermesTopicDeclared` path for back-compat; `Some("TOPIC_REMOVED")` decodes `HermesTopicRemoved`; `Some(other)` returns an error — same fail-fast pattern as kg-indexer's `space.topics` parser. Decoding is factored into a shared `decode_space_topic_event` helper.

- **Event type** (`search-indexer/src/consumer/messages.rs`): `SpaceTopicEvent` gains a `kind: SpaceTopicEventKind` field (`Declared | Removed`). The struct otherwise stays identical so downstream code that doesn't care about removals continues to work.

- **Processor** (`search-indexer/src/processor/mod.rs`): `process_space_topic_batch` branches on `kind`. The Removed branch:
  1. Calls `space_topic_cache.remove(&event.space_id)` so subsequent upserts in that space don't auto-tag the removed topic.
  2. Explicitly emits a `ClearSpaceTopicEntityIdByDoc` for the topic entity's own stub doc (`{topic_entity_id}_{space_id}`) — the topic entity may not appear in the Postgres entity-space lookup if no `knowledge.edits` content has arrived yet.
  3. Fans out via the same `entities_for_spaces` Postgres lookup as the Declared branch — emitting `ClearSpaceTopicEntityIdByDoc` per resolved doc, or falling back to a slow `ClearSpaceTopicEntityId` update_by_query when the lookup is unavailable. Both kinds in a mixed batch share the same Postgres call so declare + remove for different spaces don't double-query.

- **Loader** (`search-indexer/src/loader/mod.rs`): translates the two new `ProcessedEvent` variants into the matching `EntityOperation`s; metric-counter and pass-through `match` arms updated.

- **Repository** (`search-indexer-repository/src/types.rs`, `opensearch/provider.rs`, `opensearch/bulk.rs`): new `ClearSpaceTopicEntityId` (slow) and `ClearSpaceTopicEntityIdByDoc` (fast) request types and `EntityOperation` variants. Both run a painless `ctx._source.remove('space_topic_entity_id')` — using `remove` rather than null-assignment so the cache-warmup aggregator at `get_space_topic_mappings` (`provider.rs:351`) doesn't see the field at all on restart. The doc itself is preserved so any knowledge-edit content (name, description, …) survives the removal. `bulk.rs` adds `ClearSpaceTopicEntityIdByDoc` to the 404-OK list.

- **Integration-test plumbing** (`search-indexer/tests/orchestrator_integration.rs`): the mock-bulk-fail and operation-tracking exhaustive matches gain the two new variants.

## Tests

- [x] `cargo build --workspace --bins --tests` — clean.
- [x] `cargo test -p search-indexer -p search-indexer-repository --lib` — 68 + 34 tests pass, including the new processor test `test_space_topic_batch_removed_clears_cache_and_emits_clear_events` which asserts the cache is cleared, both `Clear*` events are emitted (stub `ClearSpaceTopicEntityIdByDoc` + slow `ClearSpaceTopicEntityId` fallback), and a post-removal upsert no longer carries `space_topic_entity_id`.
- [x] `cargo test -p e2e-kafka-search-api --bin e2e-kafka-search-api -- --skip end_to_end` — generator unit tests pass, including the new `create_topic_removed`.
- [ ] End-to-end test extending `tests/e2e-kafka-search-api/src/main.rs` — see Follow-up.

## Follow-up

The full e2e lifecycle test described in the issue (declare → `knowledge.edits` content → remove → assert clearing + content survival + cache warmup no longer maps `S → T` → re-declare → field restored, content intact) is **not yet added**. See [the Linear comment on GEO-629](https://linear.app/defi-wonderland/issue/GEO-629) for resume-from instructions (worktree path, generator already wired, file to extend).

## Out of scope

- Producer / Kafka emission of `HermesTopicRemoved` — [GEO-627](https://linear.app/defi-wonderland/issue/GEO-627), merged on the parent branch.
- kg-indexer side (`spaces.topic_id = NULL` on removal) — [GEO-628](https://linear.app/defi-wonderland/issue/GEO-628), merged on the parent branch.
- Backfill / replay of past `TOPIC_REMOVED` events dropped before this fix — separate ops task if needed.