### PR TITLE
fix(api): redact Sentry DSN from k8s secret templates

### DIFF
--- a/api/k8s/production/api-sentry.yaml
+++ b/api/k8s/production/api-sentry.yaml
@@ -1,13 +1,18 @@
 # Sentry credentials for API
 #
-# To create the secret:
+# The api Deployment reads these via secretKeyRef (see api.yaml). Create the
+# secret in-cluster; do not commit a real DSN to git.
+#
+# To create the secret (copy DSN from Sentry → Project Settings → Client Keys):
 #   kubectl create secret generic api-sentry \
 #     --namespace=api \
-#     --from-literal=SENTRY_DSN=https://1a38e0e1ae7120452be7f11b9ab9f7ec@o4510426526908417.ingest.us.sentry.io/4510778951925760 \
+#     --from-literal=SENTRY_DSN='<dsn>' \
 #     --from-literal=SENTRY_TRACES_SAMPLE_RATE=1.0 \
 #     --from-literal=SENTRY_ENVIRONMENT=production \
 #     --from-literal=SENTRY_RELEASE=api@<version> \
 #     --from-literal=SENTRY_DEBUG=false
+#
+# To update an existing secret, delete and recreate, or use kubectl edit secret.
 #
 # DO NOT commit actual credentials to version control.
 apiVersion: v1

--- a/api/k8s/staging/api-sentry.yaml
+++ b/api/k8s/staging/api-sentry.yaml
@@ -1,13 +1,18 @@
 # Sentry credentials for API (staging)
 #
-# To create the secret:
+# The api Deployment reads these via secretKeyRef (see api.yaml). Create the
+# secret in-cluster; do not commit a real DSN to git.
+#
+# To create the secret (copy DSN from Sentry → Project Settings → Client Keys):
 #   kubectl create secret generic api-sentry \
 #     --namespace=api-staging \
-#     --from-literal=SENTRY_DSN=https://1a38e0e1ae7120452be7f11b9ab9f7ec@o4510426526908417.ingest.us.sentry.io/4510778951925760 \
+#     --from-literal=SENTRY_DSN='<dsn>' \
 #     --from-literal=SENTRY_TRACES_SAMPLE_RATE=1.0 \
 #     --from-literal=SENTRY_ENVIRONMENT=staging \
 #     --from-literal=SENTRY_RELEASE=api@<version> \
 #     --from-literal=SENTRY_DEBUG=false
+#
+# To update an existing secret, delete and recreate, or use kubectl edit secret.
 #
 # DO NOT commit actual credentials to version control.
 apiVersion: v1


### PR DESCRIPTION
## Summary

- Removes a **production Sentry DSN** that was committed in commented `kubectl` examples in `api/k8s/{production,staging}/api-sentry.yaml`.
- Clarifies that the API **already** loads Sentry from the `api-sentry` Kubernetes Secret via `secretKeyRef` in `api.yaml` (same pattern as Hermes services).
- Aligns template comments with `hermes/k8s/production/hermes-pipeline-otel.yaml` (`<dsn>` placeholders only).

No deployment or runtime behavior change — only docs/templates in git.

## How other services do it

| Service | Secret name | Notes |
|---------|-------------|--------|
| **api** | `api-sentry` | Dedicated Secret; optional env refs in `api.yaml` |
| **hermes-pipeline** | `hermes-pipeline-otel` | Dedicated Secret manifest + `secretKeyRef` |
| **atlas** | `atlas-otel` | Same pattern |
| **kg-indexer** | `kg-indexer-secrets` | Sentry keys bundled with Kafka/DB secrets |
| **chain-tip-exporter** | `chain-tip-exporter-*-secrets` | `SENTRY_DSN` optional in deploy secret |
| **search-indexer** | `search-indexer-sentry` | Empty `stringData` in template; set via kubectl/CI |

Secrets are created with `kubectl create secret` (or copied from another namespace); deploy workflows do **not** apply real DSNs from git.

## Follow-up (ops)

- **Rotate** the exposed Sentry DSN in Sentry if this repo is public or widely shared.
- Confirm in-cluster `api-sentry` secrets still have the real DSN (this PR does not touch cluster state).

## Test plan

- [x] Grep confirms no remaining `4510778951925760` / ingest URL key in repo
- [ ] `kubectl apply -f api/k8s/production/api-sentry.yaml` only when bootstrapping a new env (replace `<dsn>` first)