### PR TITLE
feat(hermes-pipeline): persist substreams cursor in meta table

### DIFF
--- a/hermes-ipfs-cache/README.md
+++ b/hermes-ipfs-cache/README.md
@@ -41,7 +41,7 @@ Environment variables:
 | `IPFS_GATEWAY_URL` | Live mode | IPFS gateway URL (e.g., `https://ipfs.io/ipfs/`) |
 | `SUBSTREAMS_ENDPOINT` | Live mode | Substreams endpoint URL (e.g., `geotest.substreams.pinax.network:443`) |
 | `SUBSTREAMS_API_TOKEN` | Live mode | API token for substreams authentication |
-| `SUBSTREAMS_START_BLOCK` | No | Block to start from (default: 88109) |
+| `SUBSTREAMS_START_BLOCK` | No | Cold-start block (default: 138000, ignored when a persisted cursor exists) |
 | `SUBSTREAMS_END_BLOCK` | No | Block to end at (default: u64::MAX = stream forever) |
 
 ## Database Schema
@@ -112,7 +112,7 @@ DATABASE_URL=postgres://postgres:postgres@localhost:5433/ipfs_cache
 IPFS_GATEWAY_URL=https://ipfs.io/ipfs/
 SUBSTREAMS_ENDPOINT=geotest.substreams.pinax.network:443
 SUBSTREAMS_API_TOKEN=...
-SUBSTREAMS_START_BLOCK=88109
+SUBSTREAMS_START_BLOCK=138000
 RUST_LOG=info,hermes_ipfs_cache=debug
 ```
 

--- a/hermes-ipfs-cache/k8s/production/hermes-ipfs-cache.yaml
+++ b/hermes-ipfs-cache/k8s/production/hermes-ipfs-cache.yaml
@@ -83,7 +83,7 @@ spec:
                   name: hermes-ipfs-cache-secrets
                   key: SUBSTREAMS_API_TOKEN
             - name: SUBSTREAMS_START_BLOCK
-              value: "82656"
+              value: "138000"
             - name: IPFS_GATEWAY_URL
               valueFrom:
                 secretKeyRef:

--- a/hermes-ipfs-cache/k8s/staging/hermes-ipfs-cache.yaml
+++ b/hermes-ipfs-cache/k8s/staging/hermes-ipfs-cache.yaml
@@ -85,7 +85,7 @@ spec:
                   name: hermes-ipfs-cache-secrets
                   key: SUBSTREAMS_API_TOKEN
             - name: SUBSTREAMS_START_BLOCK
-              value: "82656"
+              value: "138000"
             - name: IPFS_GATEWAY_URL
               valueFrom:
                 secretKeyRef:

--- a/hermes-ipfs-cache/src/main.rs
+++ b/hermes-ipfs-cache/src/main.rs
@@ -14,7 +14,8 @@
 //! - `SUBSTREAMS_API_TOKEN` - API token for substreams authentication
 //!
 //! Optional:
-//! - `SUBSTREAMS_START_BLOCK` - First block to consume (default: 82655)
+//! - `SUBSTREAMS_START_BLOCK` - First block to consume on cold start (default: 138000).
+//!   Ignored when a persisted cursor exists in the `meta` table.
 //! - `SUBSTREAMS_END_BLOCK` - Last block to consume (default: u64::MAX for continuous)
 
 use std::borrow::Cow;
@@ -187,7 +188,7 @@ async fn async_main() -> anyhow::Result<()> {
         let start_block: i64 = env::var("SUBSTREAMS_START_BLOCK")
             .ok()
             .and_then(|s| s.parse().ok())
-            .unwrap_or(82655);
+            .unwrap_or(138000);
 
         let end_block: u64 = env::var("SUBSTREAMS_END_BLOCK")
             .ok()

--- a/hermes-pipeline/.env.example
+++ b/hermes-pipeline/.env.example
@@ -12,8 +12,9 @@
 # Auth token for substreams endpoint (read by hermes-relay)
 # SUBSTREAMS_API_TOKEN=
 
-# Block number to start from
-# SUBSTREAMS_START_BLOCK=82655
+# Block number to start from on cold start.
+# Ignored when a persisted cursor exists in the `meta` table.
+# SUBSTREAMS_START_BLOCK=138000
 
 # Block number to stop at (default: continuous)
 # SUBSTREAMS_END_BLOCK=

--- a/hermes-pipeline/README.md
+++ b/hermes-pipeline/README.md
@@ -87,7 +87,7 @@ This transformer is part of the Hermes architecture (see `docs/architecture.md`)
 | `USE_MOCK` | Set to "true" or "1" to use mock data | `false` |
 | `SUBSTREAMS_ENDPOINT` | Substreams gRPC endpoint URL | `geotest.substreams.pinax.network:443` |
 | `SUBSTREAMS_API_TOKEN` | Auth token for substreams | - |
-| `SUBSTREAMS_START_BLOCK` | Block number to start from | `88109` |
+| `SUBSTREAMS_START_BLOCK` | Block to start from on cold start (ignored when a persisted cursor exists) | `138000` |
 | `SUBSTREAMS_END_BLOCK` | Block number to stop at | `u64::MAX` (continuous) |
 
 ### Kafka Environment Variables
@@ -122,7 +122,7 @@ docker compose --profile infra up -d
 
 # Run with live substreams data (default)
 SUBSTREAMS_API_TOKEN=your-token \
-SUBSTREAMS_START_BLOCK=81809 \
+SUBSTREAMS_START_BLOCK=138000 \
 KAFKA_BROKER=localhost:9092 \
 cargo run --package hermes-pipeline
 ```

--- a/hermes-pipeline/README.md
+++ b/hermes-pipeline/README.md
@@ -308,9 +308,33 @@ The pipeline transform is not a bottleneck. Network I/O (substreams, Kafka, IPFS
 - The system remains at-least-once at block level.
 - If a block partially emits and then fails, a retry can re-emit previously delivered events from that block.
 - Consumers should treat `event-id` as an idempotency key and deduplicate accordingly.
-- Reorg undo handling and persistent cursor recovery are still future work.
+- Cursor persistence: the pipeline writes the substreams cursor to the shared `meta` table (`id='hermes_pipeline'`) after every successfully-emitted block and resumes from it on restart. See [Cursor Persistence](#cursor-persistence) below.
+- Reorg undo handling: on a `BlockUndoSignal` the cursor rewinds automatically via the trait's `run_live`, so substreams re-streams the reorged blocks; downstream consumers must dedupe by `event_id`. Stale events from the orphaned chain remain in Kafka — a known correctness gap.
+
+## Cursor Persistence
+
+Cursors are persisted to the `meta` table after every block via `PostgresCursorStore` (see `src/cursor.rs`). On startup the pipeline reads the row (`id = 'hermes_pipeline'`) and resumes from that cursor; otherwise it falls back to `SUBSTREAMS_START_BLOCK`.
+
+### Recovery
+
+If the `meta.cursor` row for `id = 'hermes_pipeline'` is corrupted or lost, the most recent safe cursor can be reconstructed from logs. Every persist emits an `info!` line with `event = "hermes_pipeline.batch_end"` carrying `indexer_id`, `block_number`, and `cursor` *before* the database write — the line reaches stdout / Sentry / Axiom even when the persist itself fails (the failure surfaces separately as `event = "hermes_pipeline.persist_cursor_failed"` with the same fields, and the pipeline keeps processing).
+
+To recover:
+
+1. In Axiom (or Sentry / your log store) filter for `event = "hermes_pipeline.batch_end"` sorted by time descending. Take the most recent entry.
+2. Note its `cursor` and `block_number`.
+3. Restore the `meta` row:
+
+   ```sql
+   INSERT INTO meta (id, cursor, block_number)
+   VALUES ('hermes_pipeline', '<cursor from log>', '<block_number from log>')
+   ON CONFLICT (id) DO UPDATE
+     SET cursor = EXCLUDED.cursor,
+         block_number = EXCLUDED.block_number;
+   ```
+
+4. Restart the service. It will log `event = "hermes_pipeline.resume"` and continue from there.
 
 ## Future Work
 
-- **Cursor persistence**: Add PostgreSQL/Redis storage for cursor to resume from last processed block
 - **Metrics**: Add Prometheus metrics for monitoring

--- a/hermes-pipeline/src/cursor.rs
+++ b/hermes-pipeline/src/cursor.rs
@@ -99,11 +99,13 @@ fn env_or<T: std::str::FromStr>(key: &str, default: T) -> T {
 ///
 /// Timeout knobs (idle / acquire) honor the same env vars `hermes-ipfs-cache`
 /// reads — same DB, same connection-behavior expectations. `max_connections`
-/// is **not** shared: cursor writes are ~1 per block (sequential, one persist
-/// per successful block), so 2 connections covers the steady state plus retry
-/// headroom. Inheriting `PG_POOL_MAX` (default 20) would double the pipeline
-/// pod's Postgres footprint for no real concurrency.
-const CURSOR_POOL_MAX_CONNECTIONS: u32 = 2;
+/// is **not** shared with `PG_POOL_MAX`: cursor writes are ~1 per block
+/// (sequential, one persist per successful block), so 2 connections covers
+/// the steady state plus retry headroom. Inheriting the cache's 20-connection
+/// default would double the pipeline pod's Postgres footprint for no real
+/// concurrency. Operators who need a different cap can override with
+/// `CURSOR_PG_POOL_MAX`.
+const DEFAULT_CURSOR_PG_POOL_MAX: u32 = 2;
 
 pub struct PostgresCursorStore {
     pool: sqlx::Pool<Postgres>,
@@ -112,7 +114,7 @@ pub struct PostgresCursorStore {
 impl PostgresCursorStore {
     pub async fn new(database_url: &str) -> Result<Self, CursorStoreError> {
         let pool = PgPoolOptions::new()
-            .max_connections(CURSOR_POOL_MAX_CONNECTIONS)
+            .max_connections(env_or("CURSOR_PG_POOL_MAX", DEFAULT_CURSOR_PG_POOL_MAX))
             // Close idle connections after 30s to free PgBouncer slots.
             .idle_timeout(Duration::from_secs(env_or("PG_IDLE_TIMEOUT_SECS", 30)))
             // Fail fast when pool is saturated.

--- a/hermes-pipeline/src/cursor.rs
+++ b/hermes-pipeline/src/cursor.rs
@@ -97,8 +97,14 @@ fn env_or<T: std::str::FromStr>(key: &str, default: T) -> T {
 
 /// PostgreSQL-backed cursor store.
 ///
-/// Pool tuning honors the same env vars `hermes-ipfs-cache` reads so a single
-/// set of operator knobs governs both pools in the pipeline pod.
+/// Timeout knobs (idle / acquire) honor the same env vars `hermes-ipfs-cache`
+/// reads — same DB, same connection-behavior expectations. `max_connections`
+/// is **not** shared: cursor writes are ~1 per block (sequential, one persist
+/// per successful block), so 2 connections covers the steady state plus retry
+/// headroom. Inheriting `PG_POOL_MAX` (default 20) would double the pipeline
+/// pod's Postgres footprint for no real concurrency.
+const CURSOR_POOL_MAX_CONNECTIONS: u32 = 2;
+
 pub struct PostgresCursorStore {
     pool: sqlx::Pool<Postgres>,
 }
@@ -106,7 +112,7 @@ pub struct PostgresCursorStore {
 impl PostgresCursorStore {
     pub async fn new(database_url: &str) -> Result<Self, CursorStoreError> {
         let pool = PgPoolOptions::new()
-            .max_connections(env_or("PG_POOL_MAX", 20))
+            .max_connections(CURSOR_POOL_MAX_CONNECTIONS)
             // Close idle connections after 30s to free PgBouncer slots.
             .idle_timeout(Duration::from_secs(env_or("PG_IDLE_TIMEOUT_SECS", 30)))
             // Fail fast when pool is saturated.

--- a/hermes-pipeline/src/cursor.rs
+++ b/hermes-pipeline/src/cursor.rs
@@ -1,0 +1,206 @@
+//! Cursor persistence for hermes-pipeline.
+//!
+//! Stores the last successfully-processed substreams cursor so the pipeline
+//! can resume after restart instead of re-streaming from
+//! `SUBSTREAMS_START_BLOCK`.
+//!
+//! Storage shape mirrors the `meta` table that `hermes-ipfs-cache` already
+//! owns: `(id TEXT PK, cursor TEXT, block_number TEXT)`. We write rows with
+//! `id = "hermes_pipeline"`; the cache writes with `id = "hermes_ipfs_cache"`.
+//! The table is shared, the abstraction is not — the pipeline doesn't need
+//! the full `IpfsCache` surface just to checkpoint itself.
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! use hermes_pipeline::cursor::{CursorStore, MockCursorStore, PostgresCursorStore};
+//! use std::sync::Arc;
+//!
+//! // Development: in-memory store
+//! let store: Arc<dyn CursorStore> = Arc::new(MockCursorStore::new());
+//!
+//! // Production: PostgreSQL
+//! let store: Arc<dyn CursorStore> =
+//!     Arc::new(PostgresCursorStore::new("postgres://...").await?);
+//! ```
+
+use std::env;
+use std::sync::RwLock;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use sqlx::{Postgres, postgres::PgPoolOptions};
+use thiserror::Error;
+
+/// Indexer ID for cursor persistence. Identifies the pipeline's row in the
+/// shared `meta` table.
+pub const INDEXER_ID: &str = "hermes_pipeline";
+
+#[derive(Error, Debug)]
+pub enum CursorStoreError {
+    #[error("database error: {0}")]
+    Database(#[from] sqlx::Error),
+}
+
+/// Storage backend for the pipeline's substreams cursor.
+#[async_trait]
+pub trait CursorStore: Send + Sync {
+    /// Load the persisted cursor. Returns `None` on cold start.
+    async fn load(&self) -> Result<Option<String>, CursorStoreError>;
+
+    /// Persist the cursor for the most recently completed block.
+    async fn persist(&self, cursor: &str, block: u64) -> Result<(), CursorStoreError>;
+}
+
+// =============================================================================
+// Mock (in-memory) store
+// =============================================================================
+
+/// In-memory cursor store for tests and mock-mode runs.
+#[derive(Default)]
+pub struct MockCursorStore {
+    state: RwLock<Option<(String, u64)>>,
+}
+
+impl MockCursorStore {
+    pub fn new() -> Self {
+        Self {
+            state: RwLock::new(None),
+        }
+    }
+}
+
+#[async_trait]
+impl CursorStore for MockCursorStore {
+    async fn load(&self) -> Result<Option<String>, CursorStoreError> {
+        let state = self.state.read().expect("MockCursorStore lock poisoned");
+        Ok(state.as_ref().map(|(c, _)| c.clone()))
+    }
+
+    async fn persist(&self, cursor: &str, block: u64) -> Result<(), CursorStoreError> {
+        let mut state = self.state.write().expect("MockCursorStore lock poisoned");
+        *state = Some((cursor.to_string(), block));
+        Ok(())
+    }
+}
+
+// =============================================================================
+// PostgreSQL store
+// =============================================================================
+
+fn env_or<T: std::str::FromStr>(key: &str, default: T) -> T {
+    env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+/// PostgreSQL-backed cursor store.
+///
+/// Pool tuning honors the same env vars `hermes-ipfs-cache` reads so a single
+/// set of operator knobs governs both pools in the pipeline pod.
+pub struct PostgresCursorStore {
+    pool: sqlx::Pool<Postgres>,
+}
+
+impl PostgresCursorStore {
+    pub async fn new(database_url: &str) -> Result<Self, CursorStoreError> {
+        let pool = PgPoolOptions::new()
+            .max_connections(env_or("PG_POOL_MAX", 20))
+            // Close idle connections after 30s to free PgBouncer slots.
+            .idle_timeout(Duration::from_secs(env_or("PG_IDLE_TIMEOUT_SECS", 30)))
+            // Fail fast when pool is saturated.
+            .acquire_timeout(Duration::from_secs(env_or("PG_ACQUIRE_TIMEOUT_SECS", 3)))
+            .connect(database_url)
+            .await?;
+        Ok(Self { pool })
+    }
+}
+
+#[async_trait]
+impl CursorStore for PostgresCursorStore {
+    async fn load(&self) -> Result<Option<String>, CursorStoreError> {
+        let cursor = sqlx::query_scalar::<_, String>("SELECT cursor FROM meta WHERE id = $1")
+            .bind(INDEXER_ID)
+            .fetch_optional(&self.pool)
+            .await?;
+        Ok(cursor)
+    }
+
+    async fn persist(&self, cursor: &str, block: u64) -> Result<(), CursorStoreError> {
+        // block_number is TEXT in the meta table — match hermes-ipfs-cache's
+        // binding convention rather than introducing a column-type mismatch.
+        sqlx::query(
+            "INSERT INTO meta (id, cursor, block_number) VALUES ($1, $2, $3) \
+             ON CONFLICT (id) DO UPDATE SET cursor = $2, block_number = $3",
+        )
+        .bind(INDEXER_ID)
+        .bind(cursor)
+        .bind(block.to_string())
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn mock_cold_start_returns_none() {
+        let store = MockCursorStore::new();
+        assert!(store.load().await.expect("load").is_none());
+    }
+
+    #[tokio::test]
+    async fn mock_persist_then_load_roundtrips() {
+        let store = MockCursorStore::new();
+        store.persist("cursor_abc", 100).await.expect("persist");
+
+        assert_eq!(
+            store.load().await.expect("load"),
+            Some("cursor_abc".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn mock_persist_overwrites_previous() {
+        let store = MockCursorStore::new();
+        store.persist("cursor_abc", 100).await.expect("first");
+        store.persist("cursor_def", 200).await.expect("second");
+
+        assert_eq!(
+            store.load().await.expect("load"),
+            Some("cursor_def".to_string())
+        );
+    }
+
+    /// Integration test against a real Postgres. Mirrors the ignored-by-default
+    /// pattern in hermes-ipfs-cache: run via `DATABASE_URL=... cargo test
+    /// -p hermes-pipeline -- --ignored postgres_cursor`.
+    #[tokio::test]
+    #[ignore]
+    async fn postgres_persist_then_load_roundtrips() {
+        let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+        let store = PostgresCursorStore::new(&database_url)
+            .await
+            .expect("connect");
+
+        // Use a unique cursor each run so we can detect that this write
+        // (not a prior one) was what we read back. We share `INDEXER_ID =
+        // hermes_pipeline` with the live pipeline; the upsert semantics make
+        // this fine for a manual integration test.
+        let cursor = format!(
+            "test_cursor_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        );
+        store.persist(&cursor, 12345).await.expect("persist");
+
+        let loaded = store.load().await.expect("load");
+        assert_eq!(loaded, Some(cursor));
+    }
+}

--- a/hermes-pipeline/src/emit.rs
+++ b/hermes-pipeline/src/emit.rs
@@ -615,7 +615,16 @@ impl Emitter {
     /// Reads `ENVIRONMENT` from environment to support environment isolation.
     /// If set to "staging", all topics will be prefixed with "staging.".
     pub fn new(producer: FutureProducer) -> Self {
-        let topic_prefix = get_topic_prefix();
+        Self::new_with_prefix(producer, get_topic_prefix())
+    }
+
+    /// Create an emitter with an explicit topic prefix. Bypasses the
+    /// `ENVIRONMENT` env-var lookup that `Emitter::new` performs via
+    /// `get_topic_prefix`. Useful for tests so they don't have to mutate
+    /// the process-wide ENVIRONMENT variable to satisfy the prefix
+    /// `OnceLock` cache (which is initialized exactly once for the
+    /// lifetime of the process and would otherwise leak between tests).
+    pub fn new_with_prefix(producer: FutureProducer, topic_prefix: &'static str) -> Self {
         info!(
             topic_prefix = %topic_prefix,
             "Kafka topic prefix configured"

--- a/hermes-pipeline/src/lib.rs
+++ b/hermes-pipeline/src/lib.rs
@@ -4,6 +4,7 @@
 //! integration tests and other consumers.
 
 pub mod cache;
+pub mod cursor;
 pub mod decode;
 pub mod pipelines;
 

--- a/hermes-pipeline/src/main.rs
+++ b/hermes-pipeline/src/main.rs
@@ -28,7 +28,8 @@
 //! - `USE_MOCK` - Set to "true" or "1" to use mock data (default: false)
 //! - `SUBSTREAMS_ENDPOINT` - Substreams endpoint URL (default: geotest.substreams.pinax.network:443)
 //! - `SUBSTREAMS_API_TOKEN` - API token for substreams authentication
-//! - `SUBSTREAMS_START_BLOCK` - First block to consume (default: 82655)
+//! - `SUBSTREAMS_START_BLOCK` - First block to consume on cold start (default: 138000).
+//!   Ignored when a persisted cursor exists in the `meta` table.
 //! - `SUBSTREAMS_END_BLOCK` - Last block to consume (default: u64::MAX for continuous)
 //! - `KAFKA_BROKER` - Kafka broker address (default: localhost:9092)
 //! - `KAFKA_USERNAME` - SASL username for managed Kafka (optional)
@@ -42,6 +43,7 @@ use std::collections::HashMap;
 use std::env;
 use std::fmt;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicI64, Ordering};
 
 use hermes_instrumentation::{Instrument, debug, error, info, info_span, warn};
 use prost::Message;
@@ -53,6 +55,7 @@ use hermes_relay::stream::utils;
 use hermes_relay::{Actions, HermesModule, Sink, StreamSource};
 
 use hermes_pipeline::cache::{CacheSource, IpfsCache};
+use hermes_pipeline::cursor::{self, CursorStore, MockCursorStore, PostgresCursorStore};
 use hermes_pipeline::pipelines;
 use hermes_pipeline::pipelines::BlockMetadata;
 use hermes_pipeline::pipelines::prefetch::{self, RetryConfig};
@@ -106,14 +109,26 @@ impl From<prost::DecodeError> for PipelineError {
 pub struct Pipeline {
     emitter: Emitter,
     cache: Arc<dyn IpfsCache>,
+    cursor_store: Arc<dyn CursorStore>,
+    /// Clock timestamp (Unix seconds) of the most recently processed block.
+    /// Stashed by `process_block_impl` so `persist_cursor` can update lag
+    /// gauges only after the cursor has been durably written. Zero means
+    /// "no block processed yet this run" (e.g., right after startup).
+    last_block_timestamp: AtomicI64,
     retry_config: RetryConfig,
 }
 
 impl Pipeline {
-    pub fn new(emitter: Emitter, cache: Arc<dyn IpfsCache>) -> Self {
+    pub fn new(
+        emitter: Emitter,
+        cache: Arc<dyn IpfsCache>,
+        cursor_store: Arc<dyn CursorStore>,
+    ) -> Self {
         Self {
             emitter,
             cache,
+            cursor_store,
+            last_block_timestamp: AtomicI64::new(0),
             retry_config: RetryConfig::default(),
         }
     }
@@ -123,11 +138,14 @@ impl Pipeline {
     pub fn with_retry_config(
         emitter: Emitter,
         cache: Arc<dyn IpfsCache>,
+        cursor_store: Arc<dyn CursorStore>,
         retry_config: RetryConfig,
     ) -> Self {
         Self {
             emitter,
             cache,
+            cursor_store,
+            last_block_timestamp: AtomicI64::new(0),
             retry_config,
         }
     }
@@ -694,13 +712,13 @@ impl Pipeline {
         };
         self.emitter.emit(&summary).await?;
 
-        // Block fully ack'd to Kafka — update lag gauges. The timestamp is
-        // the block's clock time, not now(); time-based lag alerts depend on
-        // that distinction.
-        hermes_instrumentation::metrics::set_latest_processed_block(meta.block_number);
-        hermes_instrumentation::metrics::set_latest_processed_block_timestamp(
-            meta.timestamp.parse().unwrap_or(0),
-        );
+        // Block fully ack'd to Kafka. Stash the block's clock time so
+        // `persist_cursor` can update the lag gauges only after the cursor
+        // is durably persisted — keeping the gauges consistent with what a
+        // restart would actually resume from. Mirrors the pattern in
+        // hermes-ipfs-cache/src/lib.rs:340-346.
+        self.last_block_timestamp
+            .store(meta.timestamp.parse().unwrap_or(0), Ordering::Relaxed);
 
         // Log block summary
         if total > 0 || total_cache_misses > 0 || total_errored_entries > 0 {
@@ -752,21 +770,85 @@ impl Sink for Pipeline {
         &self,
         undo_signal: &hermes_relay::stream::pb::sf::substreams::rpc::v2::BlockUndoSignal,
     ) -> std::result::Result<(), Self::Error> {
-        // For now, just log the undo signal
-        // In a production system, we would delete any data recorded after this block
+        // We don't implement structural rollback. Kafka messages for the now-
+        // invalid blocks have already been published and cannot be unsent;
+        // emitting an undo signal that downstream consumers can act on is
+        // out of scope here. The trait's `run_live` will rewind the cursor
+        // (via `persist_cursor(undo_signal.last_valid_cursor, ...)`) so
+        // substreams replays the reorged blocks with their new canonical
+        // contents — kg-indexer's event_id dedup makes the replay safe for
+        // net-new state. Stale events from the orphaned chain remain — a
+        // known correctness gap acknowledged in the cursor-persistence
+        // design.
         let last_valid_block = undo_signal
             .last_valid_block
             .as_ref()
             .map_or(0, |b| b.number);
         warn!(
+            event = "hermes_pipeline.undo_signal",
+            indexer_id = cursor::INDEXER_ID,
             last_valid_block,
-            "Block undo signal received, rollback required"
+            "Block undo signal received — cursor will rewind on persist"
         );
-
-        // TODO: Implement actual rollback logic when cursor persistence is added
-        // This would involve deleting Kafka messages or updating state
-
         Ok(())
+    }
+
+    async fn persist_cursor(&self, cursor: String, block: u64) -> Result<(), Self::Error> {
+        // Log BEFORE the write so the cursor is recoverable from Axiom/Sentry
+        // even if the DB write fails (the failure surfaces separately as
+        // `event = "hermes_pipeline.persist_cursor_failed"` with the same
+        // fields). Mirrors hermes-ipfs-cache/README.md:154-167.
+        info!(
+            event = "hermes_pipeline.batch_end",
+            indexer_id = cursor::INDEXER_ID,
+            block_number = block,
+            cursor = %cursor,
+            "Cursor persist"
+        );
+        if let Err(e) = self.cursor_store.persist(&cursor, block).await {
+            warn!(
+                event = "hermes_pipeline.persist_cursor_failed",
+                indexer_id = cursor::INDEXER_ID,
+                block_number = block,
+                cursor = %cursor,
+                error = %e,
+                "Failed to persist cursor"
+            );
+            return Err(anyhow::Error::from(e).into());
+        }
+        // Cursor durably persisted — update lag gauges. We always update the
+        // block gauge (from the trait argument), but only update the
+        // timestamp gauge if a normal block has been processed this run;
+        // otherwise (e.g. an undo signal arrives before any block) the
+        // timestamp would be zero, which would corrupt the lag dashboard.
+        hermes_instrumentation::metrics::set_latest_processed_block(block);
+        let ts = self.last_block_timestamp.load(Ordering::Relaxed);
+        if ts > 0 {
+            hermes_instrumentation::metrics::set_latest_processed_block_timestamp(ts);
+        }
+        Ok(())
+    }
+
+    async fn load_persisted_cursor(&self) -> Result<Option<String>, Self::Error> {
+        let cursor = self
+            .cursor_store
+            .load()
+            .await
+            .map_err(anyhow::Error::from)?;
+        match &cursor {
+            Some(c) => info!(
+                event = "hermes_pipeline.resume",
+                indexer_id = cursor::INDEXER_ID,
+                cursor = %c,
+                "Resuming from persisted cursor"
+            ),
+            None => info!(
+                event = "hermes_pipeline.cold_start",
+                indexer_id = cursor::INDEXER_ID,
+                "No persisted cursor — starting from SUBSTREAMS_START_BLOCK"
+            ),
+        }
+        Ok(cursor)
     }
 }
 
@@ -875,20 +957,26 @@ async fn async_main() -> anyhow::Result<()> {
     let emitter = Emitter::new(producer);
     info!("Connected to Kafka broker");
 
-    // Create the IPFS cache: mock for testing, PostgreSQL for production
-    let cache = if use_mock {
-        info!("Using mock IPFS cache");
-        CacheSource::mock().into_cache().await?
+    // Create the IPFS cache and cursor store. Both are mock for testing,
+    // PostgreSQL for production — and they share the same DATABASE_URL.
+    let (cache, cursor_store): (Arc<dyn IpfsCache>, Arc<dyn CursorStore>) = if use_mock {
+        info!("Using mock IPFS cache and cursor store");
+        (
+            CacheSource::mock().into_cache().await?,
+            Arc::new(MockCursorStore::new()),
+        )
     } else {
         let database_url =
             env::var("DATABASE_URL").expect("DATABASE_URL must be set when USE_MOCK is not true");
         info!("Connecting to IPFS cache database");
-        CacheSource::live(&database_url).into_cache().await?
+        let cache = CacheSource::live(&database_url).into_cache().await?;
+        let cursor_store = Arc::new(PostgresCursorStore::new(&database_url).await?);
+        (cache, cursor_store)
     };
-    info!("IPFS cache initialized");
+    info!("IPFS cache and cursor store initialized");
 
     // Create the pipeline
-    let pipeline = Pipeline::new(emitter, cache);
+    let pipeline = Pipeline::new(emitter, cache, cursor_store);
 
     // Determine stream source: mock or live substreams
     let source = if use_mock {
@@ -899,7 +987,7 @@ async fn async_main() -> anyhow::Result<()> {
         let start_block: i64 = env::var("SUBSTREAMS_START_BLOCK")
             .ok()
             .and_then(|s| s.parse().ok())
-            .unwrap_or(82655);
+            .unwrap_or(138000);
         let end_block: u64 = env::var("SUBSTREAMS_END_BLOCK")
             .ok()
             .and_then(|s| s.parse().ok())

--- a/hermes-pipeline/src/main.rs
+++ b/hermes-pipeline/src/main.rs
@@ -1166,9 +1166,7 @@ mod sink_tests {
         // return Ok so the trait's `run_live` loop keeps processing
         // blocks. The next block's persist_cursor call will retry the
         // write. See the comment on `impl Sink for Pipeline::persist_cursor`.
-        let result = pipeline
-            .persist_cursor("any_cursor".to_string(), 1)
-            .await;
+        let result = pipeline.persist_cursor("any_cursor".to_string(), 1).await;
         assert!(
             result.is_ok(),
             "persist_cursor must not halt the stream loop on store failure; got {result:?}"

--- a/hermes-pipeline/src/main.rs
+++ b/hermes-pipeline/src/main.rs
@@ -770,14 +770,14 @@ impl Sink for Pipeline {
         &self,
         undo_signal: &hermes_relay::stream::pb::sf::substreams::rpc::v2::BlockUndoSignal,
     ) -> std::result::Result<(), Self::Error> {
-        // We don't implement structural rollback. Kafka messages for the now-
-        // invalid blocks have already been published and cannot be unsent;
-        // emitting an undo signal that downstream consumers can act on is
-        // out of scope here. The trait's `run_live` will rewind the cursor
-        // (via `persist_cursor(undo_signal.last_valid_cursor, ...)`) so
-        // substreams replays the reorged blocks with their new canonical
-        // contents — kg-indexer's event_id dedup makes the replay safe for
-        // net-new state. Stale events from the orphaned chain remain — a
+        // For now, just log the undo signal.
+        // In a production system, we would delete any data recorded after this block.
+        //
+        // The trait's `run_live` will still rewind the cursor (via
+        // `persist_cursor(undo_signal.last_valid_cursor, ...)`) so substreams
+        // replays the reorged blocks with their new canonical contents —
+        // kg-indexer's event_id dedup makes the replay safe for net-new
+        // state. Stale events from the orphaned chain remain in Kafka — a
         // known correctness gap acknowledged in the cursor-persistence
         // design.
         let last_valid_block = undo_signal
@@ -1045,4 +1045,133 @@ async fn async_main() -> anyhow::Result<()> {
     info!("Pipeline finished");
 
     Ok(())
+}
+
+#[cfg(test)]
+mod sink_tests {
+    //! Sink-level integration tests exercising the cursor hooks on a real
+    //! `Pipeline` instance wired to a `MockCursorStore`. Validates the
+    //! `Sink` trait override path end-to-end without needing Kafka or a
+    //! database — `process_block_scoped_data` is bypassed here; we call
+    //! the cursor hooks directly to verify they delegate to the store
+    //! correctly and handle errors per the documented contract.
+    //!
+    //! `PostgresCursorStore` is covered separately in `cursor::tests`
+    //! (run via `cargo test -p hermes-pipeline -- --ignored postgres_cursor`).
+    use super::*;
+    use async_trait::async_trait;
+    use hermes_pipeline::cursor::CursorStoreError;
+
+    async fn make_pipeline(cursor_store: Arc<dyn CursorStore>) -> Pipeline {
+        // hermes-kafka's create_producer reads ENVIRONMENT for the message
+        // timeout config. rdkafka's FutureProducer is lazy — it doesn't
+        // connect at construction — so a bogus broker is fine; we never
+        // call send() in these tests.
+        unsafe {
+            std::env::set_var("ENVIRONMENT", "production");
+        }
+        let producer = create_producer("localhost:1", "test-sink").expect("create producer");
+        let emitter = Emitter::new(producer);
+        let cache = CacheSource::mock().into_cache().await.expect("mock cache");
+        Pipeline::new(emitter, cache, cursor_store)
+    }
+
+    #[tokio::test]
+    async fn cold_start_load_returns_none() {
+        let store = Arc::new(MockCursorStore::new());
+        let pipeline = make_pipeline(store).await;
+
+        let loaded = pipeline
+            .load_persisted_cursor()
+            .await
+            .expect("load_persisted_cursor");
+        assert!(loaded.is_none(), "empty store must report cold start");
+    }
+
+    #[tokio::test]
+    async fn persist_cursor_writes_to_store() {
+        let store = Arc::new(MockCursorStore::new());
+        let pipeline = make_pipeline(store.clone()).await;
+
+        pipeline
+            .persist_cursor("cursor_abc".to_string(), 12345)
+            .await
+            .expect("persist_cursor");
+
+        let loaded = store.load().await.expect("store.load");
+        assert_eq!(loaded, Some("cursor_abc".to_string()));
+    }
+
+    #[tokio::test]
+    async fn load_after_persist_round_trips_via_sink_hook() {
+        let store = Arc::new(MockCursorStore::new());
+        let pipeline = make_pipeline(store).await;
+
+        pipeline
+            .persist_cursor("cursor_xyz".to_string(), 999)
+            .await
+            .expect("persist_cursor");
+
+        // Same Pipeline reading the cursor back through the trait surface.
+        let loaded = pipeline
+            .load_persisted_cursor()
+            .await
+            .expect("load_persisted_cursor");
+        assert_eq!(loaded, Some("cursor_xyz".to_string()));
+    }
+
+    #[tokio::test]
+    async fn persist_cursor_overwrites_previous_value() {
+        let store = Arc::new(MockCursorStore::new());
+        let pipeline = make_pipeline(store.clone()).await;
+
+        pipeline
+            .persist_cursor("cursor_first".to_string(), 100)
+            .await
+            .expect("first persist");
+        pipeline
+            .persist_cursor("cursor_second".to_string(), 200)
+            .await
+            .expect("second persist");
+
+        assert_eq!(
+            store.load().await.expect("store.load"),
+            Some("cursor_second".to_string())
+        );
+    }
+
+    /// A `CursorStore` that always fails to persist — used to verify that
+    /// the Sink-level override does not propagate the error and halt the
+    /// stream loop. Matches the failure-policy contract documented on
+    /// `Sink::persist_cursor` and mirrors `hermes-ipfs-cache`.
+    struct FailingCursorStore;
+
+    #[async_trait]
+    impl CursorStore for FailingCursorStore {
+        async fn load(&self) -> Result<Option<String>, CursorStoreError> {
+            Ok(None)
+        }
+
+        async fn persist(&self, _cursor: &str, _block: u64) -> Result<(), CursorStoreError> {
+            Err(CursorStoreError::Database(sqlx::Error::PoolClosed))
+        }
+    }
+
+    #[tokio::test]
+    async fn persist_failure_does_not_halt_pipeline() {
+        let store: Arc<dyn CursorStore> = Arc::new(FailingCursorStore);
+        let pipeline = make_pipeline(store).await;
+
+        // Even though the store fails internally, the Sink-level hook must
+        // return Ok so the trait's `run_live` loop keeps processing
+        // blocks. The next block's persist_cursor call will retry the
+        // write. See the comment on `impl Sink for Pipeline::persist_cursor`.
+        let result = pipeline
+            .persist_cursor("any_cursor".to_string(), 1)
+            .await;
+        assert!(
+            result.is_ok(),
+            "persist_cursor must not halt the stream loop on store failure; got {result:?}"
+        );
+    }
 }

--- a/hermes-pipeline/src/main.rs
+++ b/hermes-pipeline/src/main.rs
@@ -1063,15 +1063,15 @@ mod sink_tests {
     use hermes_pipeline::cursor::CursorStoreError;
 
     async fn make_pipeline(cursor_store: Arc<dyn CursorStore>) -> Pipeline {
-        // hermes-kafka's create_producer reads ENVIRONMENT for the message
-        // timeout config. rdkafka's FutureProducer is lazy — it doesn't
-        // connect at construction — so a bogus broker is fine; we never
-        // call send() in these tests.
-        unsafe {
-            std::env::set_var("ENVIRONMENT", "production");
-        }
+        // rdkafka's FutureProducer is lazy — construction doesn't connect,
+        // so a bogus broker is fine; we never call send() in these tests.
         let producer = create_producer("localhost:1", "test-sink").expect("create producer");
-        let emitter = Emitter::new(producer);
+        // Use Emitter::new_with_prefix to bypass the ENVIRONMENT lookup
+        // inside Emitter::new — that path calls hermes_kafka::get_topic_prefix
+        // which caches the prefix in a process-wide OnceLock, leaking state
+        // between tests in an order-dependent way. Tests don't emit anything,
+        // so the prefix value doesn't matter — empty is fine.
+        let emitter = Emitter::new_with_prefix(producer, "");
         let cache = CacheSource::mock().into_cache().await.expect("mock cache");
         Pipeline::new(emitter, cache, cursor_store)
     }

--- a/hermes-pipeline/src/main.rs
+++ b/hermes-pipeline/src/main.rs
@@ -805,26 +805,41 @@ impl Sink for Pipeline {
             cursor = %cursor,
             "Cursor persist"
         );
-        if let Err(e) = self.cursor_store.persist(&cursor, block).await {
-            warn!(
-                event = "hermes_pipeline.persist_cursor_failed",
-                indexer_id = cursor::INDEXER_ID,
-                block_number = block,
-                cursor = %cursor,
-                error = %e,
-                "Failed to persist cursor"
-            );
-            return Err(anyhow::Error::from(e).into());
-        }
-        // Cursor durably persisted — update lag gauges. We always update the
-        // block gauge (from the trait argument), but only update the
-        // timestamp gauge if a normal block has been processed this run;
-        // otherwise (e.g. an undo signal arrives before any block) the
-        // timestamp would be zero, which would corrupt the lag dashboard.
-        hermes_instrumentation::metrics::set_latest_processed_block(block);
-        let ts = self.last_block_timestamp.load(Ordering::Relaxed);
-        if ts > 0 {
-            hermes_instrumentation::metrics::set_latest_processed_block_timestamp(ts);
+        match self.cursor_store.persist(&cursor, block).await {
+            Ok(()) => {
+                // Cursor durably persisted — update lag gauges. We always
+                // update the block gauge (from the trait argument), but
+                // only update the timestamp gauge if a normal block has
+                // been processed this run; otherwise (e.g. an undo signal
+                // arrives before any block) the timestamp would be zero
+                // and corrupt the lag dashboard.
+                hermes_instrumentation::metrics::set_latest_processed_block(block);
+                let ts = self.last_block_timestamp.load(Ordering::Relaxed);
+                if ts > 0 {
+                    hermes_instrumentation::metrics::set_latest_processed_block_timestamp(ts);
+                }
+            }
+            Err(e) => {
+                // Persist failure is non-fatal: keep processing blocks and
+                // retry on the next persist_cursor call (called per-block
+                // by the Sink trait). The cursor in the batch_end log above
+                // is enough to manually recover the row if it stays missing
+                // — see hermes-ipfs-cache/README.md:154-167 for the
+                // procedure; ours mirrors it under event="batch_end".
+                // Lag gauges intentionally stay at the last *durably*
+                // persisted block so they reflect resume-from state, not
+                // in-memory state. Matches the hermes-ipfs-cache failure
+                // policy (lib.rs:330-346) — halting here would multiply
+                // the disruption on transient DB blips.
+                error!(
+                    event = "hermes_pipeline.persist_cursor_failed",
+                    indexer_id = cursor::INDEXER_ID,
+                    block_number = block,
+                    cursor = %cursor,
+                    error = %e,
+                    "Failed to persist cursor — continuing; will retry on next block"
+                );
+            }
         }
         Ok(())
     }

--- a/hermes/k8s/production/hermes-pipeline.yaml
+++ b/hermes/k8s/production/hermes-pipeline.yaml
@@ -105,6 +105,8 @@ spec:
                 secretKeyRef:
                   name: hermes-ipfs-cache-secrets
                   key: SUBSTREAMS_API_TOKEN
+            - name: SUBSTREAMS_START_BLOCK
+              value: "138000"
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:

--- a/hermes/k8s/staging/hermes-pipeline.yaml
+++ b/hermes/k8s/staging/hermes-pipeline.yaml
@@ -107,6 +107,8 @@ spec:
                 secretKeyRef:
                   name: hermes-ipfs-cache-secrets
                   key: SUBSTREAMS_API_TOKEN
+            - name: SUBSTREAMS_START_BLOCK
+              value: "138000"
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary

- **hermes-pipeline now persists its substreams cursor** to the `meta` table (`id='hermes_pipeline'`) and resumes from it on restart, instead of replaying from `SUBSTREAMS_START_BLOCK` every time. Closes the long-standing replay-on-every-restart issue. Shares the table with `hermes-ipfs-cache`; the abstraction is separate (`CursorStore` trait in `hermes-pipeline/src/cursor.rs`).
- **Lag gauges (`hermes_latest_processed_block` + `_timestamp`)** now update only after the cursor write succeeds, matching the existing `hermes-ipfs-cache` pattern. They were previously updated inside `process_block_impl`, before the (no-op) `persist_cursor` call.
- **Cold-start `SUBSTREAMS_START_BLOCK` default bumped 82655 → 138000** for `hermes-pipeline` and `hermes-ipfs-cache` (source defaults, .env.examples, READMEs, and `hermes-ipfs-cache` k8s manifests). Atlas left untouched — it has its own checkpoint mechanism. The bump only matters on the very first cold start; the persisted cursor takes precedence after that.

## Out of scope

- `BlockUndoSignal` handling — cursor will rewind automatically on undo via the trait's `run_live`, but no Kafka undo emission or downstream rollback contract is added. The existing warn-log handler is preserved.

## Test plan

- [x] `cargo test -p hermes-pipeline` — 106 tests pass, including 3 new MockCursorStore tests
- [x] `cargo test -p hermes-pipeline -- --ignored postgres_cursor` against real Postgres — round-trip persist/load passes
- [x] `cargo check + clippy -p hermes-pipeline -p hermes-ipfs-cache` clean
- [x] **End-to-end smoke** against live substreams + real Postgres + real Kafka:
  - First run (empty `meta`): `event=hermes_pipeline.cold_start` → 4 blocks processed (137800-137803) → each fires `batch_end` → DB row written with real 220-byte substreams cursor
  - Restart: `event=hermes_pipeline.resume` with cursor byte-for-byte matching the DB → next `batch_end` is for block 137804, **no replay of 137800-137803**