### PR TITLE
feat(atlas): persist emission baseline across rules-change deploys

### DIFF
--- a/api/drizzle/0057_atlas_emission_baseline.sql
+++ b/api/drizzle/0057_atlas_emission_baseline.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "atlas_checkpoints" ADD COLUMN "emission_baseline_blob" "bytea";

--- a/api/drizzle/meta/0057_snapshot.json
+++ b/api/drizzle/meta/0057_snapshot.json
@@ -1,0 +1,3314 @@
+{
+  "id": "35d7f3c5-6562-4096-955a-4543c4479274",
+  "prevId": "8844e0b6-b70a-474f-b092-307b7d002c9e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.app_webhooks": {
+      "name": "app_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "app_name": {
+          "name": "app_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_webhooks_app_name_unique": {
+          "name": "app_webhooks_app_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "app_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.atlas_checkpoints": {
+      "name": "atlas_checkpoints",
+      "schema": "",
+      "columns": {
+        "indexer_id": {
+          "name": "indexer_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph_state_version": {
+          "name": "graph_state_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_compatibility_marker": {
+          "name": "runtime_compatibility_marker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_space_id": {
+          "name": "root_space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph_state_blob": {
+          "name": "graph_state_blob",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emission_baseline_blob": {
+          "name": "emission_baseline_blob",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.edit_versions": {
+      "name": "edit_versions",
+      "schema": "",
+      "columns": {
+        "edit_id": {
+          "name": "edit_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_key": {
+          "name": "version_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "edit_versions_version_key_idx": {
+          "name": "edit_versions_version_key_idx",
+          "columns": [
+            {
+              "expression": "version_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "edit_versions_block_sequence_unique": {
+          "name": "edit_versions_block_sequence_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "block_number",
+            "sequence"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.editors": {
+      "name": "editors",
+      "schema": "",
+      "columns": {
+        "member_space_id": {
+          "name": "member_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "editors_space_id_idx": {
+          "name": "editors_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "editors_member_space_id_space_id_pk": {
+          "name": "editors_member_space_id_space_id_pk",
+          "columns": [
+            "member_space_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_block": {
+          "name": "created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at_block": {
+          "name": "updated_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "entities_updated_at_idx": {
+          "name": "entities_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entities_updated_at_id_idx": {
+          "name": "entities_updated_at_id_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entities_created_at_id_idx": {
+          "name": "entities_created_at_id_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.global_scores": {
+      "name": "global_scores",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ipfs_cache": {
+      "name": "ipfs_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_errored": {
+          "name": "is_errored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "block": {
+          "name": "block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space": {
+          "name": "space",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ipfs_cache_uri_unique": {
+          "name": "ipfs_cache_uri_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uri"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.local_scores": {
+      "name": "local_scores",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_local_scores_space_id": {
+          "name": "idx_local_scores_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_local_scores_entity_id": {
+          "name": "idx_local_scores_entity_id",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_local_scores_space_score": {
+          "name": "idx_local_scores_space_score",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "local_scores_entity_id_space_id_pk": {
+          "name": "local_scores_entity_id_space_id_pk",
+          "columns": [
+            "entity_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "member_space_id": {
+          "name": "member_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "members_space_id_idx": {
+          "name": "members_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "members_member_space_id_space_id_pk": {
+          "name": "members_member_space_id_space_id_pk",
+          "columns": [
+            "member_space_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta": {
+      "name": "meta",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_deliveries": {
+      "name": "notification_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "outbox_id": {
+          "name": "outbox_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_deliveries_pending": {
+          "name": "idx_deliveries_pending",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_deliveries_outbox_id_notification_outbox_id_fk": {
+          "name": "notification_deliveries_outbox_id_notification_outbox_id_fk",
+          "tableFrom": "notification_deliveries",
+          "tableTo": "notification_outbox",
+          "columnsFrom": [
+            "outbox_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_deliveries_webhook_id_app_webhooks_id_fk": {
+          "name": "notification_deliveries_webhook_id_app_webhooks_id_fk",
+          "tableFrom": "notification_deliveries",
+          "tableTo": "app_webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_deliveries_outbox_id_webhook_id_unique": {
+          "name": "notification_deliveries_outbox_id_webhook_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "outbox_id",
+            "webhook_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_outbox": {
+      "name": "notification_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_outbox_idempotency_key_unique": {
+          "name": "notification_outbox_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_actions": {
+      "name": "proposal_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "proposalActionType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_uri": {
+          "name": "content_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quorum": {
+          "name": "quorum",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fast_threshold": {
+          "name": "fast_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slow_threshold": {
+          "name": "slow_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "proposal_actions_proposal_id_idx": {
+          "name": "proposal_actions_proposal_id_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_actions_action_type_idx": {
+          "name": "proposal_actions_action_type_idx",
+          "columns": [
+            {
+              "expression": "action_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_actions_proposal_action_target_idx": {
+          "name": "proposal_actions_proposal_action_target_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_actions_proposal_id_proposals_id_fk": {
+          "name": "proposal_actions_proposal_id_proposals_id_fk",
+          "tableFrom": "proposal_actions",
+          "tableTo": "proposals",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_tally_queue": {
+      "name": "proposal_tally_queue",
+      "schema": "",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "proposal_tally_queue_proposal_id_proposals_id_fk": {
+          "name": "proposal_tally_queue_proposal_id_proposals_id_fk",
+          "tableFrom": "proposal_tally_queue",
+          "tableTo": "proposals",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_votes": {
+      "name": "proposal_votes",
+      "schema": "",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "voteOption",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_block": {
+          "name": "created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "proposal_votes_space_id_idx": {
+          "name": "proposal_votes_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_votes_voter_id_idx": {
+          "name": "proposal_votes_voter_id_idx",
+          "columns": [
+            {
+              "expression": "voter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_votes_vote_idx": {
+          "name": "proposal_votes_vote_idx",
+          "columns": [
+            {
+              "expression": "vote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_votes_proposal_id_proposals_id_fk": {
+          "name": "proposal_votes_proposal_id_proposals_id_fk",
+          "tableFrom": "proposal_votes",
+          "tableTo": "proposals",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "proposal_votes_space_id_spaces_id_fk": {
+          "name": "proposal_votes_space_id_spaces_id_fk",
+          "tableFrom": "proposal_votes",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "proposal_votes_proposal_id_voter_id_pk": {
+          "name": "proposal_votes_proposal_id_voter_id_pk",
+          "columns": [
+            "proposal_id",
+            "voter_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposals": {
+      "name": "proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by": {
+          "name": "proposed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voting_mode": {
+          "name": "voting_mode",
+          "type": "votingMode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quorum": {
+          "name": "quorum",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_block": {
+          "name": "created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yes_count": {
+          "name": "yes_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "no_count": {
+          "name": "no_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "abstain_count": {
+          "name": "abstain_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "proposals_space_id_idx": {
+          "name": "proposals_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_proposed_by_idx": {
+          "name": "proposals_proposed_by_idx",
+          "columns": [
+            {
+              "expression": "proposed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_created_at_idx": {
+          "name": "proposals_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_space_created_at_idx": {
+          "name": "proposals_space_created_at_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_space_end_time_idx": {
+          "name": "proposals_space_end_time_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_space_start_time_idx": {
+          "name": "proposals_space_start_time_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposals_space_id_spaces_id_fk": {
+          "name": "proposals_space_id_spaces_id_fk",
+          "tableFrom": "proposals",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relation_versions": {
+      "name": "relation_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "relation_id": {
+          "name": "relation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_space_id": {
+          "name": "from_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_entity_id": {
+          "name": "to_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_space_id": {
+          "name": "to_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_from_key": {
+          "name": "valid_from_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_to_key": {
+          "name": "valid_to_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_root_id": {
+          "name": "context_root_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_edge_type_id": {
+          "name": "context_edge_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "relation_versions_relation_idx": {
+          "name": "relation_versions_relation_idx",
+          "columns": [
+            {
+              "expression": "relation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_entity_idx": {
+          "name": "relation_versions_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_open_idx": {
+          "name": "relation_versions_open_idx",
+          "columns": [
+            {
+              "expression": "relation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"relation_versions\".\"valid_to_key\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_range_idx": {
+          "name": "relation_versions_range_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_from_entity_type_idx": {
+          "name": "relation_versions_from_entity_type_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_from_entity_valid_to_idx": {
+          "name": "relation_versions_from_entity_valid_to_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_to_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"relation_versions\".\"valid_to_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relations": {
+      "name": "relations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_space_id": {
+          "name": "from_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_version_id": {
+          "name": "from_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_entity_id": {
+          "name": "to_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_space_id": {
+          "name": "to_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_version_id": {
+          "name": "to_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "relations_entity_id_idx": {
+          "name": "relations_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_type_id_idx": {
+          "name": "relations_type_id_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_from_entity_id_idx": {
+          "name": "relations_from_entity_id_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_to_entity_id_idx": {
+          "name": "relations_to_entity_id_idx",
+          "columns": [
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_space_id_idx": {
+          "name": "relations_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_space_from_to_idx": {
+          "name": "relations_space_from_to_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_space_type_idx": {
+          "name": "relations_space_type_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_to_entity_space_idx": {
+          "name": "relations_to_entity_space_idx",
+          "columns": [
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_from_entity_space_idx": {
+          "name": "relations_from_entity_space_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_entity_type_space_idx": {
+          "name": "relations_entity_type_space_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_type_from_to_idx": {
+          "name": "relations_type_from_to_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.space_scores": {
+      "name": "space_scores",
+      "schema": "",
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.spaces": {
+      "name": "spaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "spaceTypes",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "spaces_topic_id_idx": {
+          "name": "spaces_topic_id_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "spaces_topic_id_entities_id_fk": {
+          "name": "spaces_topic_id_entities_id_fk",
+          "tableFrom": "spaces",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subspace_topics": {
+      "name": "subspace_topics",
+      "schema": "",
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "subspace_topics_space_id_idx": {
+          "name": "subspace_topics_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subspace_topics_topic_id_idx": {
+          "name": "subspace_topics_topic_id_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subspace_topics_space_id_spaces_id_fk": {
+          "name": "subspace_topics_space_id_spaces_id_fk",
+          "tableFrom": "subspace_topics",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "subspace_topics_topic_id_entities_id_fk": {
+          "name": "subspace_topics_topic_id_entities_id_fk",
+          "tableFrom": "subspace_topics",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "subspace_topics_space_id_topic_id_pk": {
+          "name": "subspace_topics_space_id_topic_id_pk",
+          "columns": [
+            "space_id",
+            "topic_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subspaces": {
+      "name": "subspaces",
+      "schema": "",
+      "columns": {
+        "parent_space_id": {
+          "name": "parent_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_space_id": {
+          "name": "child_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "subspaceType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'verified'"
+        }
+      },
+      "indexes": {
+        "subspaces_parent_space_id_idx": {
+          "name": "subspaces_parent_space_id_idx",
+          "columns": [
+            {
+              "expression": "parent_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subspaces_child_space_id_idx": {
+          "name": "subspaces_child_space_id_idx",
+          "columns": [
+            {
+              "expression": "child_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subspaces_parent_space_id_spaces_id_fk": {
+          "name": "subspaces_parent_space_id_spaces_id_fk",
+          "tableFrom": "subspaces",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "parent_space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "subspaces_child_space_id_spaces_id_fk": {
+          "name": "subspaces_child_space_id_spaces_id_fk",
+          "tableFrom": "subspaces",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "child_space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "subspaces_parent_space_id_child_space_id_type_pk": {
+          "name": "subspaces_parent_space_id_child_space_id_type_pk",
+          "columns": [
+            "parent_space_id",
+            "child_space_id",
+            "type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_votes": {
+      "name": "user_votes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voted_at": {
+          "name": "voted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_user_votes_object": {
+          "name": "idx_user_votes_object",
+          "columns": [
+            {
+              "expression": "object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_votes_user_id_object_id_object_type_space_id_unique": {
+          "name": "user_votes_user_id_object_id_object_type_space_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "object_id",
+            "object_type",
+            "space_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.value_versions": {
+      "name": "value_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from_key": {
+          "name": "valid_from_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_to_key": {
+          "name": "valid_to_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boolean": {
+          "name": "boolean",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integer": {
+          "name": "integer",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "float": {
+          "name": "float",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decimal": {
+          "name": "decimal",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime": {
+          "name": "datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "point": {
+          "name": "point",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rect": {
+          "name": "rect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_utc": {
+          "name": "time_utc",
+          "type": "time with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime_utc": {
+          "name": "datetime_utc",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_root_id": {
+          "name": "context_root_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_edge_type_id": {
+          "name": "context_edge_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "value_versions_entity_idx": {
+          "name": "value_versions_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_lookup_idx": {
+          "name": "value_versions_lookup_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_open_idx": {
+          "name": "value_versions_open_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"value_versions\".\"valid_to_key\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_range_idx": {
+          "name": "value_versions_range_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_entity_space_valid_to_idx": {
+          "name": "value_versions_entity_space_valid_to_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_to_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"value_versions\".\"valid_to_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.values": {
+      "name": "values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boolean": {
+          "name": "boolean",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integer": {
+          "name": "integer",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "float": {
+          "name": "float",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decimal": {
+          "name": "decimal",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime": {
+          "name": "datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "point": {
+          "name": "point",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rect": {
+          "name": "rect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_utc": {
+          "name": "time_utc",
+          "type": "time with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime_utc": {
+          "name": "datetime_utc",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "values_property_id_idx": {
+          "name": "values_property_id_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_entity_id_idx": {
+          "name": "values_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_space_id_idx": {
+          "name": "values_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_boolean_idx": {
+          "name": "values_boolean_idx",
+          "columns": [
+            {
+              "expression": "boolean",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_integer_idx": {
+          "name": "values_integer_idx",
+          "columns": [
+            {
+              "expression": "integer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_float_idx": {
+          "name": "values_float_idx",
+          "columns": [
+            {
+              "expression": "float",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_decimal_idx": {
+          "name": "values_decimal_idx",
+          "columns": [
+            {
+              "expression": "decimal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_text_idx": {
+          "name": "values_text_idx",
+          "columns": [
+            {
+              "expression": "text",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "length(\"values\".\"text\") <= 2000",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_date_idx": {
+          "name": "values_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_time_idx": {
+          "name": "values_time_idx",
+          "columns": [
+            {
+              "expression": "time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_datetime_idx": {
+          "name": "values_datetime_idx",
+          "columns": [
+            {
+              "expression": "datetime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_point_idx": {
+          "name": "values_point_idx",
+          "columns": [
+            {
+              "expression": "point",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_rect_idx": {
+          "name": "values_rect_idx",
+          "columns": [
+            {
+              "expression": "rect",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_entity_property_idx": {
+          "name": "values_entity_property_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_entity_space_idx": {
+          "name": "values_entity_space_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_property_space_idx": {
+          "name": "values_property_space_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_entity_property_space_idx": {
+          "name": "values_entity_property_space_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_language_idx": {
+          "name": "values_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_unit_idx": {
+          "name": "values_unit_idx",
+          "columns": [
+            {
+              "expression": "unit",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_time_utc_idx": {
+          "name": "values_time_utc_idx",
+          "columns": [
+            {
+              "expression": "time_utc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_datetime_utc_idx": {
+          "name": "values_datetime_utc_idx",
+          "columns": [
+            {
+              "expression": "datetime_utc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_timestamp": {
+          "name": "block_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_votes_voter_id": {
+          "name": "idx_votes_voter_id",
+          "columns": [
+            {
+              "expression": "voter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_votes_object_type_object_id_space_id": {
+          "name": "idx_votes_object_type_object_id_space_id",
+          "columns": [
+            {
+              "expression": "object_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes_count": {
+      "name": "votes_count",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upvotes": {
+          "name": "upvotes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "downvotes": {
+          "name": "downvotes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "votes_count_object_id_object_type_space_id_unique": {
+          "name": "votes_count_object_id_object_type_space_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "object_id",
+            "object_type",
+            "space_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.proposalActionType": {
+      "name": "proposalActionType",
+      "schema": "public",
+      "values": [
+        "AddMember",
+        "RemoveMember",
+        "AddEditor",
+        "RemoveEditor",
+        "UnflagEditor",
+        "Publish",
+        "Flag",
+        "Unflag",
+        "UpdateVotingSettings",
+        "Unknown",
+        "SubspaceVerified",
+        "SubspaceUnverified",
+        "SubspaceRelated",
+        "SubspaceUnrelated",
+        "SubspaceTopicDeclared",
+        "SubspaceTopicRemoved",
+        "SetTopic",
+        "UnsetTopic"
+      ]
+    },
+    "public.spaceTypes": {
+      "name": "spaceTypes",
+      "schema": "public",
+      "values": [
+        "DAO",
+        "Personal"
+      ]
+    },
+    "public.subspaceType": {
+      "name": "subspaceType",
+      "schema": "public",
+      "values": [
+        "verified",
+        "related"
+      ]
+    },
+    "public.voteOption": {
+      "name": "voteOption",
+      "schema": "public",
+      "values": [
+        "Yes",
+        "No",
+        "Abstain"
+      ]
+    },
+    "public.votingMode": {
+      "name": "votingMode",
+      "schema": "public",
+      "values": [
+        "Fast",
+        "Slow"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -400,6 +400,13 @@
       "when": 1776466400952,
       "tag": "0056_entities_ordered_by_score",
       "breakpoints": true
+    },
+    {
+      "idx": 57,
+      "version": "7",
+      "when": 1779459255335,
+      "tag": "0057_atlas_emission_baseline",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/services/storage/schema.ts
+++ b/api/src/services/storage/schema.ts
@@ -92,6 +92,7 @@ export const atlasCheckpoints = pgTable("atlas_checkpoints", {
 	rootSpaceId: text("root_space_id").notNull(),
 	schemaVersion: smallint("schema_version").notNull(),
 	graphStateBlob: jsonb("graph_state_blob").notNull(),
+	emissionBaselineBlob: bytea("emission_baseline_blob"),
 	updatedAt: timestamp("updated_at", {withTimezone: true, mode: "date"}).notNull().defaultNow(),
 })
 

--- a/atlas/src/graph/diff.rs
+++ b/atlas/src/graph/diff.rs
@@ -88,6 +88,26 @@ pub struct DiffTracker {
     scratch: Vec<(SpaceId, Position)>,
     /// Whether we've seen the first graph (for bootstrap detection)
     initialized: bool,
+    /// Set by [`DiffTracker::from_baseline`] and consumed by the first
+    /// [`DiffTracker::track`] call. Carries the persisted emission state
+    /// (`(space_id, distance, parent)` — no `EdgeType`, by design) so
+    /// the first diff after restart can be computed against what we last
+    /// told consumers rather than against an empty bootstrap baseline.
+    ///
+    /// Sorted by `space_id`, unique by `space_id` (closest-to-root wins on
+    /// duplicates — same rule [`track`] applies to in-memory positions).
+    pending_baseline: Option<Vec<(SpaceId, BaselinePos)>>,
+}
+
+/// Subset of [`Position`] that survives schema bumps. Used internally for the
+/// one-shot diff against a restored baseline; not exposed in the public diff
+/// output. Notably omits `edge_type` — see [`PersistedEmissionBaseline`].
+///
+/// [`PersistedEmissionBaseline`]: crate::persistence::PersistedEmissionBaseline
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct BaselinePos {
+    distance: u32,
+    parent: SpaceId,
 }
 
 impl DiffTracker {
@@ -105,12 +125,73 @@ impl DiffTracker {
             last_positions: Vec::with_capacity(capacity),
             scratch: Vec::with_capacity(capacity),
             initialized: false,
+            pending_baseline: None,
+        }
+    }
+
+    /// Prime the tracker from a persisted emission baseline.
+    ///
+    /// Used on startup so the first `track()` call produces the correct diff
+    /// against what was last emitted to consumers — typically across a deploy
+    /// that changes canonical rules and discards `GraphState`. The baseline
+    /// carries `(space_id, distance, parent)` only; `edge_type` is *not*
+    /// compared in the first diff, because the persisted shape intentionally
+    /// drops it to remain schema-stable (see
+    /// [`PersistedEmissionBaseline`]).
+    ///
+    /// Implications for the first track:
+    /// - REMOVED is emitted for any space in the baseline but not in the new
+    ///   canonical graph.
+    /// - MOVED is emitted only when `distance` or `parent` changes (an
+    ///   `edge_type`-only change is not enough to qualify, since we do not
+    ///   know the old `edge_type` — assuming "unchanged" is the conservative
+    ///   choice that minimises spurious events).
+    /// - ADDED is emitted for any space in the new graph but not in the
+    ///   baseline.
+    ///
+    /// Subsequent `track()` calls behave normally (full `Position` equality).
+    ///
+    /// [`PersistedEmissionBaseline`]: crate::persistence::PersistedEmissionBaseline
+    pub fn from_baseline(baseline: &crate::persistence::PersistedEmissionBaseline) -> Self {
+        let mut entries: Vec<(SpaceId, BaselinePos)> = baseline
+            .nodes()
+            .iter()
+            .map(|n| {
+                (
+                    n.space_id,
+                    BaselinePos {
+                        distance: n.distance,
+                        parent: n.parent,
+                    },
+                )
+            })
+            .collect();
+        // `PersistedEmissionBaseline::from_nodes` already sorts and dedups,
+        // but a hand-built baseline (or a future shape that doesn't enforce
+        // the invariant) might not — so normalise defensively. The merge-join
+        // diff below relies on unique-and-sorted-by-SpaceId on both sides.
+        entries.sort_unstable_by(|(id_a, pos_a), (id_b, pos_b)| {
+            id_a.cmp(id_b)
+                .then_with(|| pos_a.distance.cmp(&pos_b.distance))
+        });
+        entries.dedup_by_key(|(id, _)| *id);
+
+        let capacity = entries.len();
+        Self {
+            last_positions: Vec::with_capacity(capacity),
+            scratch: Vec::with_capacity(capacity),
+            // Treat the tracker as initialized so the next `track()` doesn't
+            // fall into the bootstrap-all-ADDED branch.
+            initialized: true,
+            pending_baseline: Some(entries),
         }
     }
 
     /// Track a new graph and compute diff from previous state.
     ///
-    /// On first call (bootstrap), returns a diff with all nodes as ADDED.
+    /// On first call (bootstrap), returns a diff with all nodes as ADDED —
+    /// unless the tracker was constructed via [`DiffTracker::from_baseline`],
+    /// in which case the first call diffs against the restored baseline.
     /// On subsequent calls, returns changes between previous and current state.
     ///
     /// When a SpaceId appears at multiple positions in the tree (e.g., via
@@ -141,7 +222,13 @@ impl DiffTracker {
         // The merge-join diff requires unique SpaceIds.
         self.scratch.dedup_by_key(|(id, _)| *id);
 
-        let diff = if self.initialized {
+        let diff = if let Some(baseline) = self.pending_baseline.take() {
+            // One-shot path: compare against the restored baseline, which has
+            // no edge_type. After this call, last_positions carries the full
+            // current Position (including edge_type), so subsequent diffs go
+            // through the regular compute_diff path.
+            compute_diff_against_baseline(&baseline, &self.scratch)
+        } else if self.initialized {
             compute_diff(&self.last_positions, &self.scratch)
         } else {
             self.initialized = true;
@@ -161,11 +248,65 @@ impl DiffTracker {
         self.last_positions.clear();
         self.scratch.clear();
         self.initialized = false;
+        self.pending_baseline = None;
     }
 
     /// Returns the number of positions currently tracked
     pub fn position_count(&self) -> usize {
         self.last_positions.len()
+    }
+
+    /// Iterate the tracker's current emission state as
+    /// `(space_id, distance, parent)` triples — the persistable shape of a
+    /// [`PersistedEmissionBaseline`]. Order matches `last_positions`
+    /// (sorted by `space_id`, unique).
+    ///
+    /// Returns `None` when nothing has been tracked yet *and* no baseline has
+    /// been primed (i.e. there is no contract with consumers to persist).
+    /// When a baseline has been primed but `track()` hasn't been called yet,
+    /// returns the pending baseline so the force-write path on startup can
+    /// re-persist what was already on disk without losing data.
+    ///
+    /// [`PersistedEmissionBaseline`]: crate::persistence::PersistedEmissionBaseline
+    pub fn iter_emission_state(&self) -> Option<EmissionStateIter<'_>> {
+        if let Some(baseline) = self.pending_baseline.as_deref() {
+            Some(EmissionStateIter {
+                inner: EmissionStateIterInner::Pending(baseline.iter()),
+            })
+        } else if self.initialized {
+            Some(EmissionStateIter {
+                inner: EmissionStateIterInner::Live(self.last_positions.iter()),
+            })
+        } else {
+            None
+        }
+    }
+}
+
+/// Iterator over a [`DiffTracker`]'s current emission state. The internal
+/// variant is intentionally opaque so the in-memory `BaselinePos` shape (and
+/// `Position`'s `edge_type`) stay implementation details.
+pub struct EmissionStateIter<'a> {
+    inner: EmissionStateIterInner<'a>,
+}
+
+enum EmissionStateIterInner<'a> {
+    Pending(std::slice::Iter<'a, (SpaceId, BaselinePos)>),
+    Live(std::slice::Iter<'a, (SpaceId, Position)>),
+}
+
+impl<'a> Iterator for EmissionStateIter<'a> {
+    type Item = (SpaceId, u32, SpaceId);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match &mut self.inner {
+            EmissionStateIterInner::Pending(it) => {
+                it.next().map(|(id, pos)| (*id, pos.distance, pos.parent))
+            }
+            EmissionStateIterInner::Live(it) => {
+                it.next().map(|(id, pos)| (*id, pos.distance, pos.parent))
+            }
+        }
     }
 }
 
@@ -192,6 +333,79 @@ fn build_position_vec_into(tree: &TreeNode, vec: &mut Vec<(SpaceId, Position)>) 
             stack.push((child, distance + 1, node.space_id));
         }
     }
+}
+
+/// One-shot merge-join diff between a restored baseline (no `edge_type`) and
+/// the current canonical positions. Used by [`DiffTracker::track`] on the
+/// first call when the tracker was constructed with
+/// [`DiffTracker::from_baseline`].
+///
+/// Differs from [`compute_diff`] in exactly one place: the MOVED check
+/// compares only `distance` + `parent`, never `edge_type`. The persisted
+/// baseline drops `edge_type` for schema stability, so we can't know what it
+/// was previously — and "edge_type-only change" would otherwise be flagged
+/// as MOVED for every restored node, which is exactly the spurious-event
+/// storm we are trying to avoid.
+fn compute_diff_against_baseline(
+    old: &[(SpaceId, BaselinePos)],
+    new: &[(SpaceId, Position)],
+) -> GraphDiff {
+    let mut changes = Vec::new();
+    let mut old_iter = old.iter().peekable();
+    let mut new_iter = new.iter().peekable();
+
+    loop {
+        match (old_iter.peek(), new_iter.peek()) {
+            (None, None) => break,
+            (Some(_), None) => {
+                let (space_id, _) = old_iter.next().unwrap();
+                changes.push(NodeChange {
+                    space_id: *space_id,
+                    change_type: ChangeType::Removed,
+                    position: None,
+                });
+            }
+            (None, Some(_)) => {
+                let (space_id, pos) = new_iter.next().unwrap();
+                changes.push(NodeChange {
+                    space_id: *space_id,
+                    change_type: ChangeType::Added,
+                    position: Some(*pos),
+                });
+            }
+            (Some((old_id, _)), Some((new_id, _))) => match old_id.cmp(new_id) {
+                std::cmp::Ordering::Less => {
+                    let (space_id, _) = old_iter.next().unwrap();
+                    changes.push(NodeChange {
+                        space_id: *space_id,
+                        change_type: ChangeType::Removed,
+                        position: None,
+                    });
+                }
+                std::cmp::Ordering::Greater => {
+                    let (space_id, pos) = new_iter.next().unwrap();
+                    changes.push(NodeChange {
+                        space_id: *space_id,
+                        change_type: ChangeType::Added,
+                        position: Some(*pos),
+                    });
+                }
+                std::cmp::Ordering::Equal => {
+                    let (space_id, old_pos) = old_iter.next().unwrap();
+                    let (_, new_pos) = new_iter.next().unwrap();
+                    if old_pos.distance != new_pos.distance || old_pos.parent != new_pos.parent {
+                        changes.push(NodeChange {
+                            space_id: *space_id,
+                            change_type: ChangeType::Moved,
+                            position: Some(*new_pos),
+                        });
+                    }
+                }
+            },
+        }
+    }
+
+    GraphDiff { changes }
 }
 
 /// Compute diff between old and new position slices using merge-join.
@@ -706,5 +920,231 @@ mod tests {
         assert_eq!(pos.edge_type, EdgeType::Verified);
 
         assert_eq!(tracker.position_count(), 2);
+    }
+
+    // ------------------------------------------------------------------
+    // from_baseline / pending_baseline behaviour (GEO-645)
+    // ------------------------------------------------------------------
+
+    use crate::persistence::{BaselineNode, PersistedEmissionBaseline};
+
+    fn baseline_with(nodes: &[(u8, u32, u8)]) -> PersistedEmissionBaseline {
+        PersistedEmissionBaseline::from_nodes(nodes.iter().map(|(s, d, p)| BaselineNode {
+            space_id: make_space_id(*s),
+            distance: *d,
+            parent: make_space_id(*p),
+        }))
+    }
+
+    fn one_node_graph(child: u8, edge: EdgeType) -> CanonicalGraph {
+        let mut root = TreeNode::new_root(make_space_id(0x01));
+        root.add_child(TreeNode::new(make_space_id(child), edge));
+        CanonicalGraph::new(
+            make_space_id(0x01),
+            root,
+            [make_space_id(0x01), make_space_id(child)]
+                .into_iter()
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn from_baseline_first_track_emits_removed_for_orphans() {
+        // Models the GEO-645 happy path: baseline contains a space that the
+        // new rules no longer treat as canonical (e.g. previously reachable
+        // only via a Member edge, which v2 removes). The first track() must
+        // emit REMOVED for that orphan, not silently drop it.
+        let baseline = baseline_with(&[
+            (0x0A, 1, 0x01), // still canonical
+            (0x0B, 1, 0x01), // orphaned in the new rules
+        ]);
+        let mut tracker = DiffTracker::from_baseline(&baseline);
+
+        let graph = one_node_graph(0x0A, EdgeType::Verified);
+        let diff = tracker.track(&graph);
+
+        // Only B should appear in the diff, and as REMOVED.
+        assert_eq!(diff.len(), 1);
+        let removed = &diff.changes[0];
+        assert_eq!(removed.space_id, make_space_id(0x0B));
+        assert_eq!(removed.change_type, ChangeType::Removed);
+        assert!(removed.position.is_none());
+    }
+
+    #[test]
+    fn from_baseline_first_track_emits_added_for_new() {
+        let baseline = baseline_with(&[(0x0A, 1, 0x01)]);
+        let mut tracker = DiffTracker::from_baseline(&baseline);
+
+        // Graph now has A + a brand-new C (was not in baseline).
+        let mut root = TreeNode::new_root(make_space_id(0x01));
+        root.add_child(TreeNode::new(make_space_id(0x0A), EdgeType::Verified));
+        root.add_child(TreeNode::new(make_space_id(0x0C), EdgeType::Verified));
+        let graph = CanonicalGraph::new(
+            make_space_id(0x01),
+            root,
+            [
+                make_space_id(0x01),
+                make_space_id(0x0A),
+                make_space_id(0x0C),
+            ]
+            .into_iter()
+            .collect(),
+        );
+
+        let diff = tracker.track(&graph);
+        assert_eq!(diff.len(), 1);
+        assert_eq!(diff.changes[0].space_id, make_space_id(0x0C));
+        assert_eq!(diff.changes[0].change_type, ChangeType::Added);
+    }
+
+    #[test]
+    fn from_baseline_emits_moved_only_on_distance_or_parent_change() {
+        // Baseline says A is at distance 1, parent = root.
+        let baseline = baseline_with(&[(0x0A, 1, 0x01)]);
+
+        // Case 1: distance/parent unchanged, edge_type differs — must NOT
+        // emit MOVED. The baseline has no edge_type by design (schema
+        // stability), so we cannot know whether edge_type changed. The
+        // conservative choice is to suppress the event.
+        {
+            let mut tracker = DiffTracker::from_baseline(&baseline);
+            let graph = one_node_graph(0x0A, EdgeType::Related); // edge_type differs
+            let diff = tracker.track(&graph);
+            assert!(
+                diff.is_empty(),
+                "edge_type-only delta against a baseline must not produce MOVED, got: {:?}",
+                diff.changes
+            );
+        }
+
+        // Case 2: distance changes — MOVED.
+        {
+            let mut tracker = DiffTracker::from_baseline(&baseline);
+            // Build graph where A is now at distance 2 (root -> B -> A).
+            let mut root = TreeNode::new_root(make_space_id(0x01));
+            let mut b = TreeNode::new(make_space_id(0x0B), EdgeType::Verified);
+            b.add_child(TreeNode::new(make_space_id(0x0A), EdgeType::Verified));
+            root.add_child(b);
+            let graph = CanonicalGraph::new(
+                make_space_id(0x01),
+                root,
+                [
+                    make_space_id(0x01),
+                    make_space_id(0x0A),
+                    make_space_id(0x0B),
+                ]
+                .into_iter()
+                .collect(),
+            );
+            let diff = tracker.track(&graph);
+            let a_change = diff
+                .changes
+                .iter()
+                .find(|c| c.space_id == make_space_id(0x0A))
+                .expect("A must appear in diff after distance change");
+            assert_eq!(a_change.change_type, ChangeType::Moved);
+            assert_eq!(a_change.position.unwrap().distance, 2);
+        }
+
+        // Case 3: parent changes (distance same).
+        {
+            // Build graph where A is still distance 1 but parent is now B.
+            // (Forced by making B the root via a sibling — simulate by having
+            // A attached to a new parent with distance 1. To do this with
+            // distance 1, the parent must be root, so this case overlaps
+            // with the baseline. Instead simulate by changing the baseline
+            // parent and showing parent change at the same distance.)
+            let baseline2 = baseline_with(&[(0x0A, 1, 0x0B)]); // claim A had parent=B
+            let mut tracker2 = DiffTracker::from_baseline(&baseline2);
+            let graph = one_node_graph(0x0A, EdgeType::Verified); // actual parent = root (0x01)
+            let diff = tracker2.track(&graph);
+            let a_change = diff
+                .changes
+                .iter()
+                .find(|c| c.space_id == make_space_id(0x0A))
+                .expect("A must appear in diff after parent change");
+            assert_eq!(a_change.change_type, ChangeType::Moved);
+            assert_eq!(a_change.position.unwrap().parent, make_space_id(0x01));
+        }
+    }
+
+    #[test]
+    fn from_baseline_second_track_uses_full_position_equality() {
+        // After the one-shot baseline-aware diff, subsequent track() calls
+        // must include edge_type in MOVED detection (regular compute_diff
+        // semantics). This guards against accidentally leaving the
+        // edge_type-blind comparison in place forever.
+        let baseline = baseline_with(&[(0x0A, 1, 0x01)]);
+        let mut tracker = DiffTracker::from_baseline(&baseline);
+
+        // First track: edge_type-only change is suppressed (as established
+        // above).
+        let graph_v1 = one_node_graph(0x0A, EdgeType::Verified);
+        let diff = tracker.track(&graph_v1);
+        assert!(diff.is_empty());
+
+        // Second track: change edge_type only. compute_diff (not the
+        // baseline variant) should now flag this as MOVED.
+        let graph_v2 = one_node_graph(0x0A, EdgeType::Related);
+        let diff = tracker.track(&graph_v2);
+        assert_eq!(diff.len(), 1);
+        assert_eq!(diff.changes[0].change_type, ChangeType::Moved);
+        assert_eq!(
+            diff.changes[0].position.unwrap().edge_type,
+            EdgeType::Related
+        );
+    }
+
+    #[test]
+    fn iter_emission_state_returns_pending_baseline_before_first_track() {
+        // Force-write-on-startup path: when a tracker is freshly primed but
+        // no track() has run, iter_emission_state must still expose the
+        // baseline so it can be re-persisted (idempotent rewrite).
+        let baseline = baseline_with(&[(0x0A, 1, 0x01), (0x0B, 2, 0x0A)]);
+        let tracker = DiffTracker::from_baseline(&baseline);
+        let collected: Vec<_> = tracker.iter_emission_state().unwrap().collect();
+        assert_eq!(collected.len(), 2);
+        assert!(collected.contains(&(make_space_id(0x0A), 1, make_space_id(0x01))));
+        assert!(collected.contains(&(make_space_id(0x0B), 2, make_space_id(0x0A))));
+    }
+
+    #[test]
+    fn iter_emission_state_returns_none_when_uninitialized() {
+        // A brand-new tracker (no baseline, no track) has no contract with
+        // consumers to persist — iter_emission_state must signal this so the
+        // caller doesn't write an empty baseline by accident.
+        let tracker = DiffTracker::new();
+        assert!(tracker.iter_emission_state().is_none());
+    }
+
+    #[test]
+    fn iter_emission_state_reflects_live_positions_after_track() {
+        let mut tracker = DiffTracker::new();
+        let graph = one_node_graph(0x0A, EdgeType::Verified);
+        let _ = tracker.track(&graph);
+
+        let collected: Vec<_> = tracker.iter_emission_state().unwrap().collect();
+        assert_eq!(
+            collected,
+            vec![(make_space_id(0x0A), 1, make_space_id(0x01))]
+        );
+    }
+
+    #[test]
+    fn from_baseline_no_op_when_baseline_matches_current() {
+        // Sanity: priming from a baseline that exactly matches the next
+        // canonical graph must produce zero events. This is the steady-state
+        // restart case (Phase 1 restart, no rules change between deploys).
+        let baseline = baseline_with(&[(0x0A, 1, 0x01)]);
+        let mut tracker = DiffTracker::from_baseline(&baseline);
+
+        let graph = one_node_graph(0x0A, EdgeType::Verified);
+        let diff = tracker.track(&graph);
+        assert!(
+            diff.is_empty(),
+            "baseline matching current must emit no events, got: {:?}",
+            diff.changes
+        );
     }
 }

--- a/atlas/src/graph/mod.rs
+++ b/atlas/src/graph/mod.rs
@@ -17,7 +17,7 @@ mod transitive;
 mod tree;
 
 pub use canonical::{CanonicalGraph, CanonicalProcessor};
-pub use diff::{ChangeType, DiffTracker, GraphDiff, NodeChange, Position};
+pub use diff::{ChangeType, DiffTracker, EmissionStateIter, GraphDiff, NodeChange, Position};
 pub use hash::hash_tree;
 pub use state::GraphState;
 pub use transitive::{TransitiveGraph, TransitiveProcessor};

--- a/atlas/src/main.rs
+++ b/atlas/src/main.rs
@@ -37,7 +37,10 @@ use atlas::convert::convert_action;
 use atlas::events::{BlockMetadata, SpaceId, SpaceTopologyEvent, SpaceTopologyPayload};
 use atlas::graph::{CanonicalProcessor, DiffTracker, GraphState, TransitiveProcessor};
 use atlas::kafka::{AtlasProducer, CanonicalGraphEmitter};
-use atlas::persistence::{CheckpointConfig, CheckpointManager, PersistedGraphState};
+use atlas::persistence::{
+    CheckpointConfig, CheckpointManager, PersistedEmissionBaseline, PersistedGraphState,
+    RestoredCheckpoint,
+};
 use hermes_instrumentation::{debug, info, info_span, Instrument};
 use hermes_relay::{Actions, HermesModule, Sink, StreamSource};
 use prost::Message;
@@ -54,6 +57,11 @@ struct PipelineState {
     diff_tracker: DiffTracker,
     event_count: usize,
     emit_count: usize,
+    /// True until atlas has persisted an emission baseline at least once.
+    /// Drives the "force-write on first canonical compute" requirement: a
+    /// quiet startup must still leave a baseline on disk so the next deploy
+    /// has something to load. See GEO-645.
+    baseline_force_write_pending: bool,
 }
 
 /// Atlas topology processor that implements the hermes-relay Sink trait.
@@ -69,25 +77,63 @@ struct AtlasSink {
 impl AtlasSink {
     async fn new(root_space: SpaceId, emitter: CanonicalGraphEmitter) -> anyhow::Result<Self> {
         let mut checkpoint_manager = CheckpointManager::from_env(root_space, 1)?;
-        let restored_state = checkpoint_manager.restore_checkpoint_on_startup().await?;
+        let RestoredCheckpoint {
+            graph_state,
+            baseline,
+        } = checkpoint_manager.restore_checkpoint_on_startup().await?;
 
-        let graph = restored_state.unwrap_or_else(GraphState::new);
+        let graph = graph_state.unwrap_or_else(GraphState::new);
         let mut transitive = TransitiveProcessor::new();
         let mut canonical = CanonicalProcessor::new(root_space);
-        let mut diff_tracker = DiffTracker::new();
+
+        // If we restored a baseline, prime DiffTracker from it — the first
+        // post-restart track() will diff against what consumers last saw,
+        // emitting REMOVED for orphans across a rules change. Otherwise the
+        // tracker starts empty; we'll fall back to "warm from restored
+        // canonical" below (legacy behaviour) and mark a force-write so the
+        // baseline gets persisted ASAP.
+        let baseline_initially_present = baseline.is_some();
+        let mut diff_tracker = match &baseline {
+            Some(b) => {
+                info!(
+                    baseline_node_count = b.len(),
+                    "DiffTracker primed from persisted emission baseline"
+                );
+                DiffTracker::from_baseline(b)
+            }
+            None => DiffTracker::new(),
+        };
 
         if checkpoint_manager.restored_cursor().is_some() {
             if let Some(restored_graph) = canonical.compute_if_changed(&graph, &mut transitive) {
-                let _ = diff_tracker.track(&restored_graph);
-                info!(
-                    restored_cursor = checkpoint_manager.restored_cursor().is_some(),
-                    warmed_nodes = restored_graph.len(),
-                    "Warmed canonical/transitive/diff caches from restored checkpoint state"
-                );
+                if baseline.is_none() {
+                    // No persisted baseline. Use the just-computed canonical
+                    // as the emission baseline so we don't emit a spurious
+                    // bootstrap-all-ADDED diff on the next track(). This
+                    // matches the pre-GEO-645 behaviour for the
+                    // "checkpoint exists, no baseline column yet" case
+                    // (i.e. the first run after this migration ships).
+                    let _ = diff_tracker.track(&restored_graph);
+                    info!(
+                        warmed_nodes = restored_graph.len(),
+                        "Warmed DiffTracker from restored canonical (no persisted baseline yet)"
+                    );
+                } else {
+                    // Baseline already loaded; don't burn the one-shot
+                    // pending_baseline diff on the warming compute. The
+                    // first real per-block track() handles it.
+                    info!(
+                        restored_canonical_nodes = restored_graph.len(),
+                        baseline_node_count = baseline.as_ref().map(|b| b.len()).unwrap_or(0),
+                        "Restored canonical computed; DiffTracker stays primed from persisted baseline"
+                    );
+                }
             }
         }
 
-        Ok(Self {
+        let baseline_force_write_pending = !baseline_initially_present;
+
+        let mut sink = Self {
             state: Mutex::new(PipelineState {
                 graph,
                 transitive,
@@ -95,10 +141,68 @@ impl AtlasSink {
                 diff_tracker,
                 event_count: 0,
                 emit_count: 0,
+                baseline_force_write_pending,
             }),
             emitter,
             checkpoint_manager,
-        })
+        };
+
+        // Force-write on startup: if there's no baseline on disk yet but we
+        // already have an emission state (from warming above), persist it
+        // immediately. Without this, an atlas with no incoming events between
+        // startup and the next restart would never write a baseline, leaving
+        // the next rules-change deploy nothing to load. See GEO-645.
+        sink.force_write_baseline_if_pending().await;
+
+        Ok(sink)
+    }
+
+    /// Persist the current emission state as a baseline if one hasn't been
+    /// persisted yet. Idempotent — clears the pending flag on success and is
+    /// safe to call repeatedly. Skips if there is no restored cursor (fresh
+    /// start; the first per-block persist handles it instead).
+    async fn force_write_baseline_if_pending(&mut self) {
+        let needs_write = {
+            let state = self.state.lock().unwrap();
+            state.baseline_force_write_pending
+        };
+        if !needs_write {
+            return;
+        }
+        let Some(cursor) = self.checkpoint_manager.restored_cursor() else {
+            // Fresh start: no cursor yet, defer to the per-block persist path.
+            return;
+        };
+        let Some(block_number) = self.checkpoint_manager.restored_block_number() else {
+            return;
+        };
+
+        let (snapshot, baseline) = {
+            let state = self.state.lock().unwrap();
+            (
+                PersistedGraphState::from(&state.graph),
+                PersistedEmissionBaseline::from_diff_tracker(&state.diff_tracker),
+            )
+        };
+
+        let Some(baseline) = baseline else {
+            // Nothing to persist yet (no canonical compute has happened).
+            return;
+        };
+
+        info!(
+            block_number,
+            cursor = %cursor,
+            baseline_node_count = baseline.len(),
+            "Force-writing emission baseline on startup (none persisted before)"
+        );
+
+        self.checkpoint_manager
+            .persist_block_checkpoint(block_number, cursor, snapshot, Some(&baseline))
+            .await;
+
+        let mut state = self.state.lock().unwrap();
+        state.baseline_force_write_pending = false;
     }
 
     fn summary(&self) {
@@ -193,6 +297,11 @@ impl Sink for AtlasSink {
                 diff_tracker,
                 event_count,
                 emit_count,
+                // The force-write flag is read/written on the per-block
+                // persist path below, which re-locks the state — not in this
+                // event loop. Keeping it out of the destructure documents
+                // that intent.
+                baseline_force_write_pending: _,
             } = &mut *s;
 
             // Phase 1: Apply all events to graph state and transitive cache.
@@ -294,14 +403,44 @@ impl Sink for AtlasSink {
         .await?;
 
         if processed_events > 0 {
-            let persisted_snapshot = {
+            let (persisted_snapshot, emission_baseline) = {
                 let state = self.state.lock().unwrap();
-                PersistedGraphState::from(&state.graph)
+                (
+                    PersistedGraphState::from(&state.graph),
+                    PersistedEmissionBaseline::from_diff_tracker(&state.diff_tracker),
+                )
             };
 
+            // Atomicity: graph_state and baseline are written in the same
+            // INSERT, so they cannot diverge. If `emission_baseline` is None
+            // (no canonical compute has ever happened yet, e.g. on a
+            // fresh-start atlas waiting for the first canonical-affecting
+            // event), the SQL `COALESCE` preserves whatever baseline is
+            // already on disk — so we never overwrite a good baseline with
+            // NULL.
             self.checkpoint_manager
-                .persist_block_checkpoint(block_number, meta.cursor.clone(), persisted_snapshot)
+                .persist_block_checkpoint(
+                    block_number,
+                    meta.cursor.clone(),
+                    persisted_snapshot,
+                    emission_baseline.as_ref(),
+                )
                 .await;
+
+            // Clear the force-write flag once we've actually written a
+            // baseline. Cheap, idempotent — the flag exists only to drive
+            // the explicit startup force-write; once the per-block path
+            // is keeping the baseline current there's nothing further to do.
+            if let Some(baseline) = emission_baseline.as_ref() {
+                let mut state = self.state.lock().unwrap();
+                if state.baseline_force_write_pending {
+                    state.baseline_force_write_pending = false;
+                    info!(
+                        baseline_node_count = baseline.len(),
+                        block_number, "Emission baseline persisted for the first time"
+                    );
+                }
+            }
         }
 
         Ok(())

--- a/atlas/src/main.rs
+++ b/atlas/src/main.rs
@@ -41,7 +41,7 @@ use atlas::persistence::{
     CheckpointConfig, CheckpointManager, PersistedEmissionBaseline, PersistedGraphState,
     RestoredCheckpoint,
 };
-use hermes_instrumentation::{debug, info, info_span, Instrument};
+use hermes_instrumentation::{debug, info, info_span, warn, Instrument};
 use hermes_relay::{Actions, HermesModule, Sink, StreamSource};
 use prost::Message;
 
@@ -158,9 +158,14 @@ impl AtlasSink {
     }
 
     /// Persist the current emission state as a baseline if one hasn't been
-    /// persisted yet. Idempotent — clears the pending flag on success and is
-    /// safe to call repeatedly. Skips if there is no restored cursor (fresh
-    /// start; the first per-block persist handles it instead).
+    /// persisted yet. Idempotent — clears the pending flag only on a
+    /// confirmed successful DB write, and is safe to call repeatedly. Skips
+    /// if there is no restored cursor (fresh start; the first per-block
+    /// persist handles it instead).
+    ///
+    /// On persist failure the pending flag stays `true` so the per-block
+    /// retry path in `process_block_scoped_data` can try again on a quiet
+    /// stream, even when no canonical-affecting events arrive.
     async fn force_write_baseline_if_pending(&mut self) {
         let needs_write = {
             let state = self.state.lock().unwrap();
@@ -197,12 +202,31 @@ impl AtlasSink {
             "Force-writing emission baseline on startup (none persisted before)"
         );
 
-        self.checkpoint_manager
+        match self
+            .checkpoint_manager
             .persist_block_checkpoint(block_number, cursor, snapshot, Some(&baseline))
-            .await;
-
-        let mut state = self.state.lock().unwrap();
-        state.baseline_force_write_pending = false;
+            .await
+        {
+            Ok(()) => {
+                let mut state = self.state.lock().unwrap();
+                state.baseline_force_write_pending = false;
+                info!(
+                    block_number,
+                    baseline_node_count = baseline.len(),
+                    "Emission baseline persisted for the first time"
+                );
+            }
+            Err(err) => {
+                // Keep `baseline_force_write_pending = true` so the per-block
+                // retry path can try again. CheckpointManager has already
+                // recorded the failure for fail-open accounting.
+                warn!(
+                    block_number,
+                    reason = %err,
+                    "Startup force-write of emission baseline failed; will retry on next block"
+                );
+            }
+        }
     }
 
     fn summary(&self) {
@@ -418,7 +442,8 @@ impl Sink for AtlasSink {
             // event), the SQL `COALESCE` preserves whatever baseline is
             // already on disk — so we never overwrite a good baseline with
             // NULL.
-            self.checkpoint_manager
+            let persist_result = self
+                .checkpoint_manager
                 .persist_block_checkpoint(
                     block_number,
                     meta.cursor.clone(),
@@ -427,18 +452,88 @@ impl Sink for AtlasSink {
                 )
                 .await;
 
-            // Clear the force-write flag once we've actually written a
-            // baseline. Cheap, idempotent — the flag exists only to drive
-            // the explicit startup force-write; once the per-block path
-            // is keeping the baseline current there's nothing further to do.
-            if let Some(baseline) = emission_baseline.as_ref() {
-                let mut state = self.state.lock().unwrap();
-                if state.baseline_force_write_pending {
-                    state.baseline_force_write_pending = false;
+            // Clear the force-write flag only after a confirmed successful
+            // write. Cheap, idempotent — the flag exists to drive the
+            // explicit startup force-write; once the per-block path has
+            // actually persisted a baseline there's nothing further to do.
+            // On failure we leave the flag set so a subsequent quiet block
+            // (handled below) or the next eventful block can retry.
+            if persist_result.is_ok() {
+                if let Some(baseline) = emission_baseline.as_ref() {
+                    let mut state = self.state.lock().unwrap();
+                    if state.baseline_force_write_pending {
+                        state.baseline_force_write_pending = false;
+                        info!(
+                            baseline_node_count = baseline.len(),
+                            block_number, "Emission baseline persisted for the first time"
+                        );
+                    }
+                }
+            }
+        } else {
+            // Quiet block: per-block persist is gated on processed_events > 0,
+            // so the startup force-write is the only persistence attempt in
+            // a fully quiet stream. If the force-write failed (e.g. transient
+            // DB outage) the pending flag is still true and the baseline is
+            // still NULL on disk — without this retry path, a quiet stream
+            // would never recover until an eventful block arrived.
+            //
+            // We reuse the restored cursor / block_number because the cursor
+            // has not advanced on a quiet block. Only attempt this when an
+            // emission baseline is available (canonical compute has run at
+            // least once during startup warming).
+            let (needs_retry, snapshot_and_baseline, retry_cursor, retry_block_number) = {
+                let state = self.state.lock().unwrap();
+                if !state.baseline_force_write_pending {
+                    (false, None, None, None)
+                } else {
+                    let baseline =
+                        PersistedEmissionBaseline::from_diff_tracker(&state.diff_tracker);
+                    let snapshot = PersistedGraphState::from(&state.graph);
+                    (
+                        baseline.is_some(),
+                        baseline.map(|b| (snapshot, b)),
+                        self.checkpoint_manager.restored_cursor(),
+                        self.checkpoint_manager.restored_block_number(),
+                    )
+                }
+            };
+
+            if needs_retry {
+                if let (Some((snapshot, baseline)), Some(cursor), Some(retry_block)) =
+                    (snapshot_and_baseline, retry_cursor, retry_block_number)
+                {
                     info!(
+                        block_number = retry_block,
+                        cursor = %cursor,
                         baseline_node_count = baseline.len(),
-                        block_number, "Emission baseline persisted for the first time"
+                        "Retrying force-write of emission baseline on quiet block"
                     );
+
+                    match self
+                        .checkpoint_manager
+                        .persist_block_checkpoint(retry_block, cursor, snapshot, Some(&baseline))
+                        .await
+                    {
+                        Ok(()) => {
+                            let mut state = self.state.lock().unwrap();
+                            if state.baseline_force_write_pending {
+                                state.baseline_force_write_pending = false;
+                                info!(
+                                    block_number = retry_block,
+                                    baseline_node_count = baseline.len(),
+                                    "Emission baseline persisted for the first time"
+                                );
+                            }
+                        }
+                        Err(err) => {
+                            warn!(
+                                block_number = retry_block,
+                                reason = %err,
+                                "Quiet-block retry of emission baseline force-write failed; will retry on next block"
+                            );
+                        }
+                    }
                 }
             }
         }

--- a/atlas/src/main.rs
+++ b/atlas/src/main.rs
@@ -240,6 +240,76 @@ impl AtlasSink {
             "Processing complete"
         );
     }
+
+    /// Per-block retry of the GEO-645 baseline force-write.
+    ///
+    /// Runs on every incoming block (empty-output blocks, quiet blocks with no
+    /// decoded actions, and quiet blocks where `processed_events == 0`) so a
+    /// fully quiet stream can still recover from a transient DB failure that
+    /// caused the startup force-write (and any earlier per-block writes) to
+    /// fail. Without this hoist, a stream that produced no events after a
+    /// failed startup force-write would never persist a baseline.
+    ///
+    /// The current block's `block_number` / `cursor` are passed in so the
+    /// persisted checkpoint cursor matches the in-memory graph_state +
+    /// baseline snapshot we are writing — using `restored_cursor` /
+    /// `restored_block_number` here would rewind the resume cursor on disk
+    /// even though earlier blocks may have mutated the graph (fail-open).
+    ///
+    /// Semantics:
+    /// - No-op when `baseline_force_write_pending` is already false.
+    /// - No-op when no emission baseline is available yet (canonical compute
+    ///   has not produced output, so `from_diff_tracker` returns None).
+    /// - On success: clears the flag and logs
+    ///   `"Emission baseline persisted for the first time"`.
+    /// - On failure: leaves the flag set; the next block will try again.
+    async fn retry_force_write_baseline(&self, block_number: u64, cursor: &str) {
+        let (snapshot, baseline) = {
+            let state = self.state.lock().unwrap();
+            if !state.baseline_force_write_pending {
+                return;
+            }
+            let baseline = PersistedEmissionBaseline::from_diff_tracker(&state.diff_tracker);
+            let Some(baseline) = baseline else {
+                // No canonical compute yet — nothing to persist.
+                return;
+            };
+            let snapshot = PersistedGraphState::from(&state.graph);
+            (snapshot, baseline)
+        };
+
+        info!(
+            block_number,
+            cursor = %cursor,
+            baseline_node_count = baseline.len(),
+            "Retrying force-write of emission baseline on quiet block"
+        );
+
+        match self
+            .checkpoint_manager
+            .persist_block_checkpoint(block_number, cursor.to_string(), snapshot, Some(&baseline))
+            .await
+        {
+            Ok(()) => {
+                let mut state = self.state.lock().unwrap();
+                if state.baseline_force_write_pending {
+                    state.baseline_force_write_pending = false;
+                    info!(
+                        block_number,
+                        baseline_node_count = baseline.len(),
+                        "Emission baseline persisted for the first time"
+                    );
+                }
+            }
+            Err(err) => {
+                warn!(
+                    block_number,
+                    reason = %err,
+                    "Quiet-block retry of emission baseline force-write failed; will retry on next block"
+                );
+            }
+        }
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -292,6 +362,12 @@ impl Sink for AtlasSink {
             .unwrap_or(&[]);
 
         if output.is_empty() {
+            // Empty-output block: no decoded actions at all. Still attempt the
+            // baseline force-write retry so a fully quiet stream can recover
+            // from a failed startup force-write without waiting for an
+            // eventful block.
+            self.retry_force_write_baseline(block_number, &meta.cursor)
+                .await;
             return Ok(());
         }
 
@@ -471,71 +547,14 @@ impl Sink for AtlasSink {
                 }
             }
         } else {
-            // Quiet block: per-block persist is gated on processed_events > 0,
-            // so the startup force-write is the only persistence attempt in
-            // a fully quiet stream. If the force-write failed (e.g. transient
-            // DB outage) the pending flag is still true and the baseline is
-            // still NULL on disk — without this retry path, a quiet stream
-            // would never recover until an eventful block arrived.
-            //
-            // We reuse the restored cursor / block_number because the cursor
-            // has not advanced on a quiet block. Only attempt this when an
-            // emission baseline is available (canonical compute has run at
-            // least once during startup warming).
-            let (needs_retry, snapshot_and_baseline, retry_cursor, retry_block_number) = {
-                let state = self.state.lock().unwrap();
-                if !state.baseline_force_write_pending {
-                    (false, None, None, None)
-                } else {
-                    let baseline =
-                        PersistedEmissionBaseline::from_diff_tracker(&state.diff_tracker);
-                    let snapshot = PersistedGraphState::from(&state.graph);
-                    (
-                        baseline.is_some(),
-                        baseline.map(|b| (snapshot, b)),
-                        self.checkpoint_manager.restored_cursor(),
-                        self.checkpoint_manager.restored_block_number(),
-                    )
-                }
-            };
-
-            if needs_retry {
-                if let (Some((snapshot, baseline)), Some(cursor), Some(retry_block)) =
-                    (snapshot_and_baseline, retry_cursor, retry_block_number)
-                {
-                    info!(
-                        block_number = retry_block,
-                        cursor = %cursor,
-                        baseline_node_count = baseline.len(),
-                        "Retrying force-write of emission baseline on quiet block"
-                    );
-
-                    match self
-                        .checkpoint_manager
-                        .persist_block_checkpoint(retry_block, cursor, snapshot, Some(&baseline))
-                        .await
-                    {
-                        Ok(()) => {
-                            let mut state = self.state.lock().unwrap();
-                            if state.baseline_force_write_pending {
-                                state.baseline_force_write_pending = false;
-                                info!(
-                                    block_number = retry_block,
-                                    baseline_node_count = baseline.len(),
-                                    "Emission baseline persisted for the first time"
-                                );
-                            }
-                        }
-                        Err(err) => {
-                            warn!(
-                                block_number = retry_block,
-                                reason = %err,
-                                "Quiet-block retry of emission baseline force-write failed; will retry on next block"
-                            );
-                        }
-                    }
-                }
-            }
+            // Quiet block (decoded actions present but none were convertible):
+            // per-block persist is gated on `processed_events > 0`, so without
+            // this retry a fully quiet stream that hit a transient DB failure
+            // during the startup force-write would never recover. The helper
+            // uses the CURRENT block's cursor/number to match the in-memory
+            // snapshot it persists.
+            self.retry_force_write_baseline(block_number, &meta.cursor)
+                .await;
         }
 
         Ok(())

--- a/atlas/src/persistence.rs
+++ b/atlas/src/persistence.rs
@@ -668,15 +668,29 @@ impl CheckpointManager {
         }
     }
 
+    /// Persist a per-block checkpoint. Returns `Ok(())` on a confirmed
+    /// successful DB write, `Err(_)` if every retry failed.
+    ///
+    /// Fail-open semantics are unchanged: failures still go through
+    /// `record_persist_failure` (which feeds the consecutive-failure counter,
+    /// pause logic, and pending checkpoint). Callers that don't care about
+    /// the result can ignore the returned `Result` — this is the case on
+    /// the per-block hot path, where the next block's persist would anyway
+    /// supersede this one.
+    ///
+    /// The signal exists for callers that need to know whether a baseline
+    /// actually reached disk (e.g. the GEO-645 startup force-write and its
+    /// quiet-stream retry) before clearing pending flags or emitting a
+    /// "persisted for the first time" log.
     pub async fn persist_block_checkpoint(
         &self,
         block_number: u64,
         cursor: String,
         graph_state_blob: PersistedGraphState,
         emission_baseline: Option<&PersistedEmissionBaseline>,
-    ) {
+    ) -> Result<(), CheckpointError> {
         if self.config.store.is_none() {
-            return;
+            return Ok(());
         }
 
         let checkpoint = Checkpoint::new(
@@ -693,9 +707,11 @@ impl CheckpointManager {
         match self.try_persist_with_retries(&checkpoint).await {
             Ok(()) => {
                 self.record_persist_success();
+                Ok(())
             }
             Err(err) => {
                 self.record_persist_failure(block_number, &checkpoint, &err);
+                Err(CheckpointError::Io(err))
             }
         }
     }

--- a/atlas/src/persistence.rs
+++ b/atlas/src/persistence.rs
@@ -155,7 +155,25 @@ impl PersistedEmissionBaseline {
         count_bytes.copy_from_slice(&bytes[9..13]);
         let count = u32::from_le_bytes(count_bytes) as usize;
 
-        let expected_len = BASELINE_HEADER_LEN + count * BASELINE_NODE_LEN;
+        // Use checked arithmetic so a corrupted `count` header on a 32-bit
+        // target (or a pathological value on 64-bit) cannot wrap or trigger
+        // an OOM-sized allocation attempt before we get to the
+        // length-vs-payload check below. On overflow we surface
+        // `CheckpointError::Serialization`, which the startup path treats as
+        // a recoverable "no baseline" condition rather than a panic.
+        let expected_payload =
+            count
+                .checked_mul(BASELINE_NODE_LEN)
+                .ok_or_else(|| {
+                    CheckpointError::Serialization(format!(
+                        "baseline blob header count {count} overflows usize when multiplied by node size {BASELINE_NODE_LEN}"
+                    ))
+                })?;
+        let expected_len = BASELINE_HEADER_LEN.checked_add(expected_payload).ok_or_else(|| {
+            CheckpointError::Serialization(format!(
+                "baseline blob header count {count} overflows usize when added to header size {BASELINE_HEADER_LEN}"
+            ))
+        })?;
         if bytes.len() != expected_len {
             return Err(CheckpointError::Serialization(format!(
                 "baseline blob length {} does not match header count {} (expected {})",
@@ -1821,6 +1839,32 @@ mod tests {
         assert!(
             matches!(err, CheckpointError::Serialization(ref msg) if msg.contains("does not match header count")),
             "expected length-mismatch error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn baseline_rejects_count_that_would_overflow_or_overallocate() {
+        // A corrupted header with `count = u32::MAX` would, on a 32-bit
+        // target, wrap `count * BASELINE_NODE_LEN` past `usize::MAX`, and on
+        // a 64-bit target would request a ~140 GB allocation. The decode
+        // path must reject this with `CheckpointError::Serialization`
+        // rather than panicking or hitting the allocator. We hand-build a
+        // header with the pathological count and a truncated body so the
+        // arithmetic / length-mismatch check fires before any slice indexing
+        // into the (absent) node payload.
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(BASELINE_MAGIC);
+        bytes.push(BASELINE_FORMAT_VERSION);
+        bytes.extend_from_slice(&u32::MAX.to_le_bytes());
+        // Intentionally no node payload follows.
+        let err = PersistedEmissionBaseline::decode(&bytes).unwrap_err();
+        // On 32-bit `usize`, this hits the `checked_mul` overflow branch;
+        // on 64-bit, it falls through to the length-vs-payload mismatch.
+        // Either way the contract is the same: surface as `Serialization`
+        // (never panic / OOM) so the startup path can recover.
+        assert!(
+            matches!(err, CheckpointError::Serialization(_)),
+            "expected Serialization error, got: {err:?}"
         );
     }
 

--- a/atlas/src/persistence.rs
+++ b/atlas/src/persistence.rs
@@ -7,6 +7,186 @@ use hermes_instrumentation::{error, info, warn};
 use serde::{Deserialize, Serialize};
 use sqlx::{postgres::PgPoolOptions, PgPool, Row};
 
+/// Persisted shape of atlas's emission contract: every (non-root) canonical
+/// node we last told consumers about, as a `(space_id, distance, parent)`
+/// triple.
+///
+/// This is the part of the checkpoint that must survive `GraphState` /
+/// `EdgeType` schema bumps. It is encoded as a length-prefixed flat binary
+/// blob with no field names, no enum tags, no edge-type identifier — only
+/// consumer-observable primitives — so a future change to internal graph
+/// types cannot break baseline restore.
+///
+/// On startup, `DiffTracker::from_baseline(...)` uses this to prime the
+/// emission state so the first `track()` call after a rules change produces
+/// the correct `REMOVED` events for orphaned spaces and `MOVED` events for
+/// repositioned ones. See GEO-645 for the failure mode this guards against.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct PersistedEmissionBaseline {
+    /// Sorted by `space_id`, unique by `space_id` (the closest-to-root entry
+    /// wins on duplicates, matching `DiffTracker`'s collapse semantics).
+    nodes: Vec<BaselineNode>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BaselineNode {
+    pub space_id: SpaceId,
+    pub distance: u32,
+    pub parent: SpaceId,
+}
+
+// Magic prefix isolates baseline blobs from any other bytea we might store on
+// the row in the future. The trailing `\x01` is the format version: bumping it
+// is the contract for "the on-disk shape of this blob changed in a
+// non-backwards-compatible way", and old atlas builds must reject anything
+// they don't recognise rather than silently misread.
+const BASELINE_MAGIC: &[u8; 8] = b"ATLBL\x00\x00\x01";
+const BASELINE_FORMAT_VERSION: u8 = 1;
+// magic (8) + version (1) + node count u32 LE (4)
+const BASELINE_HEADER_LEN: usize = 13;
+// space_id (16) + distance u32 LE (4) + parent space_id (16)
+const BASELINE_NODE_LEN: usize = 36;
+
+impl PersistedEmissionBaseline {
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    pub fn len(&self) -> usize {
+        self.nodes.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+    }
+
+    pub fn nodes(&self) -> &[BaselineNode] {
+        &self.nodes
+    }
+
+    /// Build a baseline from an arbitrary iterator of node entries. The
+    /// constructor sorts by `space_id` and deduplicates, picking the entry
+    /// with the smallest `distance` on collisions — same "closest to root
+    /// wins" rule `DiffTracker` applies to in-memory positions.
+    pub fn from_nodes<I: IntoIterator<Item = BaselineNode>>(nodes: I) -> Self {
+        let mut nodes: Vec<BaselineNode> = nodes.into_iter().collect();
+        nodes.sort_unstable_by(|a, b| {
+            a.space_id
+                .cmp(&b.space_id)
+                .then_with(|| a.distance.cmp(&b.distance))
+        });
+        nodes.dedup_by_key(|n| n.space_id);
+        Self { nodes }
+    }
+
+    /// Snapshot a diff tracker's current emission state as a persistable
+    /// baseline. Returns `None` if the tracker has nothing to persist (no
+    /// canonical compute has ever produced output and no prior baseline was
+    /// loaded), in which case the caller should not write a baseline column —
+    /// writing an empty baseline would let a fresh-start atlas advertise
+    /// "consumers have nothing canonical" and force a spurious wipe on the
+    /// next restart.
+    pub fn from_diff_tracker(tracker: &crate::graph::DiffTracker) -> Option<Self> {
+        let iter = tracker.iter_emission_state()?;
+        let nodes: Vec<BaselineNode> = iter
+            .map(|(space_id, distance, parent)| BaselineNode {
+                space_id,
+                distance,
+                parent,
+            })
+            .collect();
+        // The tracker's emission state is already sorted+deduped by SpaceId,
+        // so skip the normalisation cost.
+        Some(Self { nodes })
+    }
+
+    /// Encode as a flat little-endian binary blob.
+    ///
+    /// Layout (header followed by `count` fixed-size node entries):
+    ///   bytes  0..8  : magic `ATLBL\0\0\x01`
+    ///   byte   8     : format version (currently 1)
+    ///   bytes  9..13 : node count, u32 LE
+    ///   for each node (36 bytes):
+    ///       16 bytes : space_id
+    ///        4 bytes : distance, u32 LE
+    ///       16 bytes : parent space_id
+    pub fn encode(&self) -> Vec<u8> {
+        let mut out =
+            Vec::with_capacity(BASELINE_HEADER_LEN + self.nodes.len() * BASELINE_NODE_LEN);
+        out.extend_from_slice(BASELINE_MAGIC);
+        out.push(BASELINE_FORMAT_VERSION);
+        let count: u32 = self
+            .nodes
+            .len()
+            .try_into()
+            .expect("baseline node count fits in u32");
+        out.extend_from_slice(&count.to_le_bytes());
+        for node in &self.nodes {
+            out.extend_from_slice(&node.space_id);
+            out.extend_from_slice(&node.distance.to_le_bytes());
+            out.extend_from_slice(&node.parent);
+        }
+        out
+    }
+
+    /// Decode a baseline blob. Rejects unknown magic / version / truncated
+    /// payloads explicitly so a corrupted column can't be silently misread.
+    pub fn decode(bytes: &[u8]) -> Result<Self, CheckpointError> {
+        if bytes.len() < BASELINE_HEADER_LEN {
+            return Err(CheckpointError::Serialization(format!(
+                "baseline blob too short: {} bytes, expected at least {}",
+                bytes.len(),
+                BASELINE_HEADER_LEN
+            )));
+        }
+        if &bytes[0..8] != BASELINE_MAGIC {
+            return Err(CheckpointError::Serialization(format!(
+                "baseline blob magic mismatch: {:02x?}",
+                &bytes[0..8]
+            )));
+        }
+        let version = bytes[8];
+        if version != BASELINE_FORMAT_VERSION {
+            return Err(CheckpointError::Serialization(format!(
+                "unsupported baseline format version: {version}"
+            )));
+        }
+        let mut count_bytes = [0u8; 4];
+        count_bytes.copy_from_slice(&bytes[9..13]);
+        let count = u32::from_le_bytes(count_bytes) as usize;
+
+        let expected_len = BASELINE_HEADER_LEN + count * BASELINE_NODE_LEN;
+        if bytes.len() != expected_len {
+            return Err(CheckpointError::Serialization(format!(
+                "baseline blob length {} does not match header count {} (expected {})",
+                bytes.len(),
+                count,
+                expected_len
+            )));
+        }
+
+        let mut nodes = Vec::with_capacity(count);
+        let mut offset = BASELINE_HEADER_LEN;
+        for _ in 0..count {
+            let mut space_id = [0u8; 16];
+            space_id.copy_from_slice(&bytes[offset..offset + 16]);
+            let mut dist_bytes = [0u8; 4];
+            dist_bytes.copy_from_slice(&bytes[offset + 16..offset + 20]);
+            let distance = u32::from_le_bytes(dist_bytes);
+            let mut parent = [0u8; 16];
+            parent.copy_from_slice(&bytes[offset + 20..offset + 36]);
+            nodes.push(BaselineNode {
+                space_id,
+                distance,
+                parent,
+            });
+            offset += BASELINE_NODE_LEN;
+        }
+
+        Ok(Self { nodes })
+    }
+}
+
 const CHECKPOINT_SCHEMA_VERSION: u32 = 1;
 const FAIL_OPEN_BOUND_DEFAULT: u64 = 10;
 const FAIL_OPEN_BOUND_MIN: u64 = 1;
@@ -192,6 +372,19 @@ pub struct CheckpointManager {
     config: CheckpointConfig,
     fail_open: std::sync::Mutex<FailOpenState>,
     restored_cursor: Option<String>,
+    restored_block_number: Option<u64>,
+}
+
+/// Result of `CheckpointManager::restore_checkpoint_on_startup`.
+///
+/// `graph_state` and `baseline` decode independently. In particular, a
+/// missing/invalid `graph_state` (marker mismatch, unknown enum variant,
+/// fresh-start) must not suppress a valid `baseline` — that's how a
+/// rules-change deploy gets the contract from the previous deploy.
+#[derive(Debug, Default)]
+pub struct RestoredCheckpoint {
+    pub graph_state: Option<GraphState>,
+    pub baseline: Option<PersistedEmissionBaseline>,
 }
 
 #[derive(Debug, Default)]
@@ -208,6 +401,7 @@ impl CheckpointManager {
             config,
             fail_open: std::sync::Mutex::new(FailOpenState::default()),
             restored_cursor: None,
+            restored_block_number: None,
         }
     }
 
@@ -225,16 +419,78 @@ impl CheckpointManager {
         self.restored_cursor.clone()
     }
 
+    /// Block number associated with the restored checkpoint cursor, when
+    /// one was loaded. Used by the force-write-on-startup path to write a
+    /// baseline using the existing checkpoint coordinates rather than
+    /// inventing a synthetic one.
+    pub fn restored_block_number(&self) -> Option<u64> {
+        self.restored_block_number
+    }
+
+    /// Restore graph state and the persisted emission baseline.
+    ///
+    /// The two are independently decoded so that a `GraphState` schema bump
+    /// (runtime marker mismatch, unknown enum variant in the JSON blob) does
+    /// *not* prevent the baseline from being restored — that's the whole
+    /// point of the schema-stable baseline shape. See GEO-645.
+    ///
+    /// Returns `(graph_state, baseline)`. Either side can be `None`:
+    /// - `graph_state` is `None` on fresh-start (no checkpoint, marker
+    ///   mismatch with `ATLAS_CHECKPOINT_ALLOW_FRESH_START`, or unreadable
+    ///   graph blob with the same env flag set).
+    /// - `baseline` is `None` for a brand-new indexer that has never written
+    ///   one, or when the baseline column is `NULL` on the existing row
+    ///   (e.g. the first time this code runs against a pre-existing
+    ///   checkpoint). Callers should force-write a baseline once they have
+    ///   one to persist.
     pub async fn restore_checkpoint_on_startup(
         &mut self,
-    ) -> Result<Option<GraphState>, CheckpointError> {
+    ) -> Result<RestoredCheckpoint, CheckpointError> {
         let Some(store) = &self.config.store else {
             info!("Checkpoint persistence disabled (no ATLAS_CHECKPOINT_DATABASE_URL)");
-            return Ok(None);
+            return Ok(RestoredCheckpoint::default());
         };
 
         match store.load(&self.config.indexer_id).await {
             Ok(Some(checkpoint)) => {
+                // Decode the baseline first and unconditionally — even when
+                // the graph_state path bails out, the caller still needs the
+                // baseline so DiffTracker can be primed.
+                let baseline = match checkpoint.emission_baseline() {
+                    Ok(Some(baseline)) => {
+                        info!(
+                            indexer_id = %self.config.indexer_id,
+                            root_space_id = %encode_id(self.config.root_space_id),
+                            baseline_node_count = baseline.len(),
+                            block_number = checkpoint.block_number,
+                            cursor = %checkpoint.cursor,
+                            "Emission baseline restored"
+                        );
+                        Some(baseline)
+                    }
+                    Ok(None) => {
+                        info!(
+                            indexer_id = %self.config.indexer_id,
+                            block_number = checkpoint.block_number,
+                            "No emission baseline on existing checkpoint; will force-write on first canonical compute"
+                        );
+                        None
+                    }
+                    Err(err) => {
+                        // A bad baseline blob is a serious operational
+                        // signal — surface it, but don't block startup.
+                        // Treating it as "no baseline" triggers the
+                        // force-write path on next compute, which will
+                        // replace the bad blob with a known-good one.
+                        error!(
+                            indexer_id = %self.config.indexer_id,
+                            reason = %err,
+                            "Emission baseline failed to decode; proceeding without prime (will force-write)"
+                        );
+                        None
+                    }
+                };
+
                 if let Err(err) = checkpoint.validate_compatibility(
                     &self.config.indexer_id,
                     &self.config.runtime_compatibility_marker,
@@ -249,9 +505,13 @@ impl CheckpointManager {
                             reason = %err,
                             block_number = checkpoint.block_number,
                             cursor = %checkpoint.cursor,
-                            "Checkpoint rejected; ATLAS_CHECKPOINT_ALLOW_FRESH_START enabled, starting fresh"
+                            baseline_node_count = baseline.as_ref().map(|b| b.len()).unwrap_or(0),
+                            "Checkpoint rejected; ATLAS_CHECKPOINT_ALLOW_FRESH_START enabled, starting fresh (baseline retained if present)"
                         );
-                        return Ok(None);
+                        return Ok(RestoredCheckpoint {
+                            graph_state: None,
+                            baseline,
+                        });
                     }
 
                     error!(
@@ -277,9 +537,13 @@ impl CheckpointManager {
                                 reason = %err,
                                 block_number = checkpoint.block_number,
                                 cursor = %checkpoint.cursor,
-                                "Checkpoint graph state unreadable; ATLAS_CHECKPOINT_ALLOW_FRESH_START enabled, starting fresh"
+                                baseline_node_count = baseline.as_ref().map(|b| b.len()).unwrap_or(0),
+                                "Checkpoint graph state unreadable; ATLAS_CHECKPOINT_ALLOW_FRESH_START enabled, starting fresh (baseline retained if present)"
                             );
-                            return Ok(None);
+                            return Ok(RestoredCheckpoint {
+                                graph_state: None,
+                                baseline,
+                            });
                         }
 
                         error!(
@@ -296,6 +560,7 @@ impl CheckpointManager {
                 };
 
                 self.restored_cursor = Some(checkpoint.cursor.clone());
+                self.restored_block_number = Some(checkpoint.block_number);
                 info!(
                     indexer_id = %self.config.indexer_id,
                     root_space_id = %encode_id(self.config.root_space_id),
@@ -304,7 +569,10 @@ impl CheckpointManager {
                     cursor = %checkpoint.cursor,
                     "Checkpoint restored"
                 );
-                Ok(Some(graph_state))
+                Ok(RestoredCheckpoint {
+                    graph_state: Some(graph_state),
+                    baseline,
+                })
             }
             Ok(None) => {
                 info!(
@@ -313,7 +581,7 @@ impl CheckpointManager {
                     graph_state_version = self.config.graph_state_version,
                     "No checkpoint found; starting fresh"
                 );
-                Ok(None)
+                Ok(RestoredCheckpoint::default())
             }
             Err(err) => {
                 error!(
@@ -405,6 +673,7 @@ impl CheckpointManager {
         block_number: u64,
         cursor: String,
         graph_state_blob: PersistedGraphState,
+        emission_baseline: Option<&PersistedEmissionBaseline>,
     ) {
         if self.config.store.is_none() {
             return;
@@ -415,6 +684,7 @@ impl CheckpointManager {
             cursor,
             block_number,
             graph_state_blob,
+            emission_baseline,
             self.config.graph_state_version,
             self.config.runtime_compatibility_marker.clone(),
             self.config.root_space_id,
@@ -598,7 +868,8 @@ impl PostgresCheckpointStore {
                 graph_state_blob,
                 graph_state_version,
                 runtime_compatibility_marker,
-                root_space_id
+                root_space_id,
+                emission_baseline_blob
              FROM atlas_checkpoints
              WHERE indexer_id = $1",
         )
@@ -621,6 +892,18 @@ impl PostgresCheckpointStore {
                 CheckpointError::Serialization(format!("decode graph_state_blob: {err}"))
             })?
             .0;
+
+        // Baseline column is nullable: pre-existing rows from before this
+        // migration shipped will return None here, which triggers the
+        // force-write-on-startup path on the caller. Decoding is lazy
+        // (`Checkpoint::emission_baseline()`) for the same reason graph
+        // state decode is lazy — keep raw bytes here so a bad blob doesn't
+        // prevent the rest of the checkpoint from loading.
+        let emission_baseline_blob: Option<Vec<u8>> = row
+            .try_get::<Option<Vec<u8>>, _>("emission_baseline_blob")
+            .map_err(|err| {
+                CheckpointError::Serialization(format!("decode emission_baseline_blob: {err}"))
+            })?;
 
         let schema_version_i16 = row.try_get::<i16, _>("schema_version").map_err(|err| {
             CheckpointError::Serialization(format!("decode schema_version: {err}"))
@@ -672,6 +955,7 @@ impl PostgresCheckpointStore {
             root_space_id: row.try_get("root_space_id").map_err(|err| {
                 CheckpointError::Serialization(format!("decode root_space_id: {err}"))
             })?,
+            emission_baseline_blob,
         }))
     }
 
@@ -700,6 +984,10 @@ impl PostgresCheckpointStore {
             ))
         })?;
 
+        // The baseline column is written in the *same* INSERT as the graph
+        // state, so they cannot diverge — they share the row's transaction.
+        // Passing `None` (when the caller has no baseline yet) preserves any
+        // existing value, since COALESCE keeps the prior row's bytes.
         let row = sqlx::query(
             "INSERT INTO atlas_checkpoints (
                 indexer_id,
@@ -710,8 +998,9 @@ impl PostgresCheckpointStore {
                 runtime_compatibility_marker,
                 root_space_id,
                 schema_version,
+                emission_baseline_blob,
                 updated_at
-            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW())
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW())
             ON CONFLICT (indexer_id) DO UPDATE SET
                 cursor = EXCLUDED.cursor,
                 block_number = EXCLUDED.block_number,
@@ -720,8 +1009,10 @@ impl PostgresCheckpointStore {
                 runtime_compatibility_marker = EXCLUDED.runtime_compatibility_marker,
                 root_space_id = EXCLUDED.root_space_id,
                 schema_version = EXCLUDED.schema_version,
+                emission_baseline_blob = COALESCE(EXCLUDED.emission_baseline_blob, atlas_checkpoints.emission_baseline_blob),
                 updated_at = NOW()
-            RETURNING pg_column_size(graph_state_blob) AS snapshot_size_bytes",
+            RETURNING pg_column_size(graph_state_blob) AS snapshot_size_bytes,
+                      pg_column_size(emission_baseline_blob) AS baseline_size_bytes",
         )
         .bind(&checkpoint.indexer_id)
         .bind(&checkpoint.cursor)
@@ -731,6 +1022,7 @@ impl PostgresCheckpointStore {
         .bind(&checkpoint.runtime_compatibility_marker)
         .bind(&checkpoint.root_space_id)
         .bind(db_schema_version)
+        .bind(checkpoint.emission_baseline_blob.as_deref())
         .fetch_one(&self.pool)
         .await
         .map_err(|err| CheckpointError::Io(format!("save checkpoint: {err}")))?;
@@ -766,6 +1058,13 @@ pub struct Checkpoint {
     pub graph_state_version: u32,
     pub runtime_compatibility_marker: String,
     pub root_space_id: String,
+    // Raw bytes of the persisted emission baseline (see
+    // `PersistedEmissionBaseline`). Stored as a separate column so a
+    // `graph_state_blob` decode failure cannot prevent the baseline from
+    // loading. `None` for indexers that haven't written one yet (either
+    // pre-migration rows or a brand-new fresh-start).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub emission_baseline_blob: Option<Vec<u8>>,
 }
 
 impl Checkpoint {
@@ -775,6 +1074,7 @@ impl Checkpoint {
         cursor: String,
         block_number: u64,
         graph_state_blob: PersistedGraphState,
+        emission_baseline: Option<&PersistedEmissionBaseline>,
         graph_state_version: u32,
         runtime_compatibility_marker: String,
         root_space_id: SpaceId,
@@ -783,6 +1083,7 @@ impl Checkpoint {
         // so serialization to `serde_json::Value` cannot fail in practice.
         let graph_state_blob = serde_json::to_value(graph_state_blob)
             .expect("PersistedGraphState always serializes to valid JSON");
+        let emission_baseline_blob = emission_baseline.map(|b| b.encode());
         Self {
             schema_version: CHECKPOINT_SCHEMA_VERSION,
             indexer_id,
@@ -792,6 +1093,7 @@ impl Checkpoint {
             graph_state_version,
             runtime_compatibility_marker,
             root_space_id: encode_id(root_space_id),
+            emission_baseline_blob,
         }
     }
 
@@ -801,6 +1103,7 @@ impl Checkpoint {
         cursor: String,
         block_number: u64,
         graph_state: &GraphState,
+        emission_baseline: Option<&PersistedEmissionBaseline>,
         graph_state_version: u32,
         runtime_compatibility_marker: String,
         root_space_id: SpaceId,
@@ -810,6 +1113,7 @@ impl Checkpoint {
             cursor,
             block_number,
             PersistedGraphState::from(graph_state),
+            emission_baseline,
             graph_state_version,
             runtime_compatibility_marker,
             root_space_id,
@@ -822,6 +1126,18 @@ impl Checkpoint {
                 CheckpointError::Serialization(format!("decode graph_state_blob: {err}"))
             })?;
         persisted.to_graph_state()
+    }
+
+    /// Lazily decode the persisted emission baseline. Returns `Ok(None)` when
+    /// the column is `NULL` (no baseline persisted yet). Decode failures are
+    /// returned as `Err` so the caller can choose whether to abort or treat
+    /// the row as "no baseline" (the startup path takes the latter approach
+    /// and force-writes a fresh one).
+    pub fn emission_baseline(&self) -> Result<Option<PersistedEmissionBaseline>, CheckpointError> {
+        let Some(blob) = self.emission_baseline_blob.as_deref() else {
+            return Ok(None);
+        };
+        PersistedEmissionBaseline::decode(blob).map(Some)
     }
 
     pub fn validate_compatibility(
@@ -1228,6 +1544,7 @@ mod tests {
             format!("cursor-{block_number}"),
             block_number,
             &GraphState::new(),
+            None,
             1,
             "atlas-v2".to_string(),
             make_space_id(1),
@@ -1282,6 +1599,7 @@ mod tests {
             "cursor-10".to_string(),
             10,
             &GraphState::new(),
+            None,
             1,
             "atlas-v2".to_string(),
             make_space_id(1),
@@ -1330,6 +1648,7 @@ mod tests {
             graph_state_version: 1,
             runtime_compatibility_marker: "atlas-v1".to_string(),
             root_space_id: encode_id(make_space_id(1)),
+            emission_baseline_blob: None,
         };
 
         // Marker validation runs against the in-memory marker field — no decode
@@ -1392,5 +1711,171 @@ mod tests {
         assert_eq!(state.consecutive_uncheckpointed_blocks, 0);
         assert!(!state.paused);
         assert!(state.pending_checkpoint.is_none());
+    }
+
+    // ------------------------------------------------------------------
+    // PersistedEmissionBaseline (GEO-645)
+    // ------------------------------------------------------------------
+
+    fn baseline_node(space: u8, distance: u32, parent: u8) -> BaselineNode {
+        BaselineNode {
+            space_id: make_space_id(space),
+            distance,
+            parent: make_space_id(parent),
+        }
+    }
+
+    #[test]
+    fn baseline_round_trips_through_encode_decode() {
+        let baseline = PersistedEmissionBaseline::from_nodes([
+            baseline_node(0x0A, 1, 0x01),
+            baseline_node(0x0B, 2, 0x0A),
+            baseline_node(0x0C, 1, 0x01),
+        ]);
+        let bytes = baseline.encode();
+        let decoded = PersistedEmissionBaseline::decode(&bytes).unwrap();
+        assert_eq!(decoded, baseline);
+        // Ordering invariant: sorted by space_id.
+        let ids: Vec<u8> = decoded.nodes().iter().map(|n| n.space_id[15]).collect();
+        assert_eq!(ids, vec![0x0A, 0x0B, 0x0C]);
+    }
+
+    #[test]
+    fn baseline_empty_encoding_is_just_header() {
+        let bytes = PersistedEmissionBaseline::empty().encode();
+        // 8 magic + 1 version + 4 count
+        assert_eq!(bytes.len(), 13);
+        let decoded = PersistedEmissionBaseline::decode(&bytes).unwrap();
+        assert!(decoded.is_empty());
+    }
+
+    #[test]
+    fn baseline_byte_pinned_layout() {
+        // Pin the on-disk layout against a hand-built expected byte sequence.
+        // If this test fails, a future change has broken the schema-stable
+        // promise — bump BASELINE_FORMAT_VERSION and write a compat reader
+        // before merging.
+        let baseline =
+            PersistedEmissionBaseline::from_nodes([baseline_node(0x0A, 0x01020304, 0x0B)]);
+        let bytes = baseline.encode();
+
+        let mut expected = Vec::new();
+        // magic: ATLBL\0\0\x01
+        expected.extend_from_slice(b"ATLBL\x00\x00\x01");
+        // version byte
+        expected.push(1);
+        // count = 1, LE
+        expected.extend_from_slice(&1u32.to_le_bytes());
+        // node: space_id (0x0A in last byte), distance LE, parent (0x0B in last byte)
+        expected.extend_from_slice(&make_space_id(0x0A));
+        expected.extend_from_slice(&0x01020304u32.to_le_bytes());
+        expected.extend_from_slice(&make_space_id(0x0B));
+
+        assert_eq!(bytes, expected);
+    }
+
+    #[test]
+    fn baseline_rejects_bad_magic() {
+        let mut bytes = PersistedEmissionBaseline::empty().encode();
+        bytes[0] = b'X';
+        let err = PersistedEmissionBaseline::decode(&bytes).unwrap_err();
+        assert!(
+            matches!(err, CheckpointError::Serialization(ref msg) if msg.contains("magic mismatch")),
+            "expected magic mismatch, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn baseline_rejects_unknown_version() {
+        let mut bytes = PersistedEmissionBaseline::empty().encode();
+        bytes[8] = 2; // pretend a future version wrote this
+        let err = PersistedEmissionBaseline::decode(&bytes).unwrap_err();
+        assert!(
+            matches!(err, CheckpointError::Serialization(ref msg) if msg.contains("unsupported baseline format version")),
+            "expected version error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn baseline_rejects_truncated_payload() {
+        let baseline = PersistedEmissionBaseline::from_nodes([baseline_node(0x0A, 1, 0x01)]);
+        let mut bytes = baseline.encode();
+        bytes.pop(); // drop one byte from the node payload
+        let err = PersistedEmissionBaseline::decode(&bytes).unwrap_err();
+        assert!(
+            matches!(err, CheckpointError::Serialization(ref msg) if msg.contains("does not match header count")),
+            "expected length-mismatch error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn baseline_dedupe_keeps_smallest_distance() {
+        // Same space_id appearing twice at different distances: the smaller
+        // distance must win (closest-to-root rule, matches DiffTracker).
+        let baseline = PersistedEmissionBaseline::from_nodes([
+            baseline_node(0x0B, 5, 0x0A),
+            baseline_node(0x0B, 1, 0x01),
+        ]);
+        assert_eq!(baseline.len(), 1);
+        let node = &baseline.nodes()[0];
+        assert_eq!(node.distance, 1);
+        assert_eq!(node.parent, make_space_id(0x01));
+    }
+
+    #[test]
+    fn checkpoint_carries_baseline_through_struct_constructor() {
+        let baseline = PersistedEmissionBaseline::from_nodes([baseline_node(0x0A, 1, 0x01)]);
+        let cp = Checkpoint::from_graph_state(
+            "idx-test".to_string(),
+            "cursor-1".to_string(),
+            1,
+            &GraphState::new(),
+            Some(&baseline),
+            1,
+            "atlas-v2".to_string(),
+            make_space_id(1),
+        );
+        let restored = cp
+            .emission_baseline()
+            .expect("baseline decodes")
+            .expect("baseline present");
+        assert_eq!(restored, baseline);
+    }
+
+    #[test]
+    fn checkpoint_omits_baseline_when_none() {
+        let cp = Checkpoint::from_graph_state(
+            "idx-test".to_string(),
+            "cursor-1".to_string(),
+            1,
+            &GraphState::new(),
+            None,
+            1,
+            "atlas-v2".to_string(),
+            make_space_id(1),
+        );
+        assert!(cp.emission_baseline_blob.is_none());
+        assert!(cp.emission_baseline().unwrap().is_none());
+    }
+
+    #[test]
+    fn baseline_decode_failure_surfaces_serialization_error() {
+        // A `Checkpoint` with a corrupted baseline blob must report the
+        // failure as `Serialization` so the startup path can route it
+        // through the "treat as no baseline, force-write" fallback rather
+        // than aborting.
+        let cp = Checkpoint {
+            schema_version: CHECKPOINT_SCHEMA_VERSION,
+            indexer_id: "idx-test".to_string(),
+            cursor: "cursor-1".to_string(),
+            block_number: 1,
+            graph_state_blob: serde_json::Value::Null,
+            graph_state_version: 1,
+            runtime_compatibility_marker: "atlas-v2".to_string(),
+            root_space_id: encode_id(make_space_id(1)),
+            emission_baseline_blob: Some(b"not a baseline".to_vec()),
+        };
+        let err = cp.emission_baseline().unwrap_err();
+        assert!(matches!(err, CheckpointError::Serialization(_)));
     }
 }

--- a/atlas/tests/e2e.rs
+++ b/atlas/tests/e2e.rs
@@ -25,6 +25,7 @@ use atlas::graph::{
     CanonicalGraph, CanonicalProcessor, ChangeType, DiffTracker, EdgeType, GraphDiff, GraphState,
     TransitiveProcessor,
 };
+use atlas::persistence::{BaselineNode, PersistedEmissionBaseline};
 use hermes_relay::source::mock_events::test_topology::{
     ROOT_SPACE_ID, SPACE_A, SPACE_B, SPACE_C, SPACE_D, SPACE_E, SPACE_F, SPACE_G, SPACE_H, SPACE_I,
     SPACE_J, SPACE_P, SPACE_Q, SPACE_S, SPACE_W, SPACE_X, SPACE_Y, SPACE_Z,
@@ -1550,4 +1551,156 @@ fn test_e2e_diff_tracker_reset() {
             "After reset, should produce bootstrap-like diff"
         );
     }
+}
+
+// =============================================================================
+// Deploy-flow simulation (GEO-645)
+// =============================================================================
+//
+// Models the load-bearing rollout from the issue: phase 1 atlas writes a
+// baseline reflecting v1 canonical rules; phase 2 atlas — with smaller
+// canonical rules — primes its DiffTracker from that persisted baseline and
+// emits REMOVED for every space that was canonical under v1 but is not
+// canonical under v2.
+//
+// The atlas crate on this branch already runs the "v2" rules (Member/Editor
+// edges no longer grant canonical inclusion). To simulate the deploy, we
+// build a baseline that includes spaces that *would* have been canonical
+// under v1 — including a synthetic orphan that the current pipeline cannot
+// reach — and assert the first track() after restart REMOVEs them all.
+
+/// Build a canonical graph from a topology and pull its current positions
+/// out as a persistable baseline. Mirrors what an atlas would persist after
+/// a steady run: every space that was canonical *and* its position.
+fn baseline_from_canonical(graph: &CanonicalGraph) -> PersistedEmissionBaseline {
+    let mut tracker = DiffTracker::new();
+    let _ = tracker.track(graph);
+    PersistedEmissionBaseline::from_diff_tracker(&tracker)
+        .expect("freshly-tracked tracker must have emission state")
+}
+
+#[test]
+fn test_e2e_baseline_simulation_phase2_removes_orphans() {
+    // Phase 1 (simulated): build a baseline reflecting v1 canonical rules.
+    // We piggy-back on the existing v2 test topology to seed a realistic
+    // canonical set, then inject a synthetic "orphan" space — modelling a
+    // node that v1 considered canonical (via Member/Editor) but v2 does not.
+    let v1_actions = test_topology::generate();
+    let (_v1_state, _v1_transitive, _v1_canonical, _v1_tracker, _v1_diffs, v1_last_graph) =
+        process_with_canonical(&v1_actions, ROOT_SPACE_ID);
+    let v1_graph = v1_last_graph.expect("v1 simulation must produce a canonical graph");
+
+    // Pull the v1 baseline out and add a synthetic orphan that the v2
+    // pipeline will *not* re-discover. This represents a space that was
+    // canonical only through edges v2 has removed.
+    let orphan = make_orphan_space(0xEE);
+    let baseline = {
+        let mut snapshot = baseline_from_canonical(&v1_graph);
+        // Push the orphan in via a fresh `from_nodes` call so the sort/dedup
+        // invariants are preserved.
+        let mut nodes: Vec<BaselineNode> = snapshot.nodes().to_vec();
+        nodes.push(BaselineNode {
+            space_id: orphan,
+            distance: 1,
+            parent: ROOT_SPACE_ID,
+        });
+        snapshot = PersistedEmissionBaseline::from_nodes(nodes);
+        // Sanity: encode/decode round-trips through the schema-stable shape,
+        // so this is genuinely modelling "loaded back from the DB".
+        let bytes = snapshot.encode();
+        PersistedEmissionBaseline::decode(&bytes).expect("baseline round-trips")
+    };
+    assert!(
+        baseline.nodes().iter().any(|n| n.space_id == orphan),
+        "test setup: orphan must be in the baseline before phase 2"
+    );
+
+    // Phase 2: a fresh atlas starts up with the same v2 topology. Its
+    // DiffTracker is primed from the (v1) baseline above. The first track()
+    // against the v2 canonical must emit REMOVED for the orphan because it
+    // is no longer reachable; all other v1 canonical spaces are still in
+    // the v2 set, so they should emit nothing (positions unchanged).
+    let mut state = GraphState::new();
+    let mut transitive = TransitiveProcessor::new();
+    let mut canonical = CanonicalProcessor::new(ROOT_SPACE_ID);
+    let mut tracker = DiffTracker::from_baseline(&baseline);
+
+    for (i, action) in v1_actions.iter().enumerate() {
+        let meta = make_meta(i as u64);
+        if let Some(event) = convert_action(action, &meta) {
+            transitive.handle_event(&event, &state);
+            state.apply_event(&event);
+        }
+    }
+
+    let v2_graph = canonical
+        .compute_if_changed(&state, &mut transitive)
+        .expect("v2 canonical compute must produce a graph");
+
+    let diff = tracker.track(&v2_graph);
+
+    // The orphan must be removed. Nothing else should be — every v1
+    // canonical space (other than the orphan) is also v2 canonical because
+    // the topology generator's edges all happen to be Verified/Related/Topic
+    // (no Member/Editor in test_topology). Position-stable spaces emit no
+    // event because the baseline-aware diff path drops `edge_type` from the
+    // MOVED check.
+    let removed_ids: Vec<SpaceId> = diff
+        .changes
+        .iter()
+        .filter(|c| c.change_type == ChangeType::Removed)
+        .map(|c| c.space_id)
+        .collect();
+    assert!(
+        removed_ids.contains(&orphan),
+        "orphan must be REMOVED; diff was: {:?}",
+        diff.changes
+    );
+
+    // No spurious ADDED for spaces that were already in the baseline at the
+    // same (distance, parent). This is the key correctness property: the
+    // restored baseline suppresses bootstrap-all-ADDED.
+    for change in &diff.changes {
+        if change.change_type == ChangeType::Added {
+            // Anything ADDED here would mean we lost the contract with
+            // consumers — they'd see ADDED for spaces they already think are
+            // canonical. Fail loudly.
+            panic!(
+                "no ADDED expected, but got space {:?} as ADDED",
+                change.space_id
+            );
+        }
+    }
+}
+
+#[test]
+fn test_e2e_baseline_simulation_steady_state_restart_emits_nothing() {
+    // The flip side of the deploy test: a routine restart (no rules change)
+    // loads a baseline that exactly matches what the new compute produces.
+    // First track must emit zero events — otherwise restart would
+    // continuously churn consumer state.
+    let actions = test_topology::generate();
+    let (_, _, _, _, _, last_graph) = process_with_canonical(&actions, ROOT_SPACE_ID);
+    let graph = last_graph.expect("topology must produce a canonical graph");
+
+    let baseline = baseline_from_canonical(&graph);
+    // Round-trip through the persisted bytes — restart loads from disk.
+    let baseline = PersistedEmissionBaseline::decode(&baseline.encode())
+        .expect("baseline round-trips through encode/decode");
+
+    let mut tracker = DiffTracker::from_baseline(&baseline);
+    let diff = tracker.track(&graph);
+    assert!(
+        diff.is_empty(),
+        "steady-state restart must emit zero events, got: {:?}",
+        diff.changes
+    );
+}
+
+// Tiny helper so the simulation test stays self-contained without exposing
+// crate-internal test_utils.
+fn make_orphan_space(last: u8) -> SpaceId {
+    let mut id = [0u8; 16];
+    id[15] = last;
+    id
 }


### PR DESCRIPTION
## Summary

Closes [GEO-645](https://linear.app/defi-wonderland/issue/GEO-645/atlas-persist-emission-baseline-so-rules-change-deploys-emit-correct).

Atlas was emitting incorrect diffs after a canonical-rules change. When PR #198 (atlas-v1 → atlas-v2) shipped, downstream consumers ended up with stale state because the diff baseline was *derived* from `GraphState` each startup — so the post-deploy baseline reflected the *new* rules, not what was last emitted, and the `REMOVED` events for orphaned spaces were never sent.

This PR makes the emission baseline atlas's contract with consumers — what we last told them is canonical — and persists it in a schema-stable shape next to the checkpoint, in its own independently-decodable column. A `GraphState` decode failure (marker bump, removed enum variant) can no longer prevent the baseline from loading, which is the whole point.

- **`PersistedEmissionBaseline`** (`atlas/src/persistence.rs`): flat binary blob, magic + version + LE u32 count + 36-byte `(SpaceId, u32 distance, SpaceId parent)` records. Consumer-observable primitives only; no `EdgeType` (the part of the storage shape most prone to schema churn). Byte-pinned in a unit test so future schema bumps are deliberate.
- **`DiffTracker::from_baseline`** + `compute_diff_against_baseline`: one-shot diff path that drops `edge_type` from MOVED comparison, since the baseline intentionally doesn't carry it. After the first track, the tracker uses regular full-`Position` equality again.
- **DB column** (`api/drizzle/0057_atlas_emission_baseline.sql`): `emission_baseline_blob bytea NULL`. Atomic with the existing checkpoint write — `COALESCE(EXCLUDED.emission_baseline_blob, atlas_checkpoints.emission_baseline_blob)` in the upsert so a `None` on the Rust side preserves any existing baseline rather than wiping it.
- **Force-write-on-startup**: if a restored checkpoint has no baseline column yet, atlas writes one immediately so the next restart isn't left with nothing to load. Fresh starts wait for the first per-block persist (next block).
- **Per-block persist** always carries the latest emission state — graph_state and baseline can never diverge.
- **Observability**: dedicated log lines on prime (`"DiffTracker primed from persisted emission baseline"`), force-write (`"Force-writing emission baseline on startup"`), and first persist (`"Emission baseline persisted for the first time"`) so the rollout gate (issue text: "log line `'baseline persisted, N nodes'` observed in staging and prod") is checkable.

## Test plan

- [x] `cargo test -p atlas --lib` — 104/104 (18 new: byte-pinned layout, bad-magic / unknown-version / truncated-payload rejection, dedupe semantics, baseline-decode-failure surfaces serialization error, `from_baseline` REMOVED-for-orphans / ADDED-for-new / MOVED only on distance/parent / edge_type-only delta suppressed / regular comparison resumes after first track, `iter_emission_state` semantics).
- [x] `cargo test -p atlas --test e2e -- --skip test_e2e_scaling_performance` — 42/42 (2 new: `test_e2e_baseline_simulation_phase2_removes_orphans` covers the GEO-645 deploy-flow simulation; `test_e2e_baseline_simulation_steady_state_restart_emits_nothing` covers the routine-restart no-op).
- [x] `cargo fmt -p atlas --check` clean.
- [x] `cargo clippy -p atlas --all-targets --no-deps -- -D warnings` clean.
- [ ] Staging deploy: confirm `emission_baseline_blob IS NOT NULL` and node count matches the live canonical set in `scoring_topology_distances`.
- [ ] Staging deploy: confirm specifically that the orphan `ba958c57…` from the GEO-618 incident is present in the baseline.
- [ ] Production deploy.

## Out of scope

- `git revert 2b64456` (PR A in the issue's two-phase plan). This branch is stacked on `geo-618-remove-member-edges` directly, so PR A's revert is not needed here — the v2 changes are kept and the baseline persistence makes the next rules-change deploy safe.
- Doc updates to `atlas/README.md` / `atlas/docs/graph-concepts.md` describing the baseline as part of the consumer contract — Phase 2 deliverable in the issue; can land as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)