### PR TITLE
feat(notification-indexer): comment + bounty-created notifications (2a/2b/3a)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4023,6 +4023,7 @@ dependencies = [
  "hex",
  "prost 0.13.5",
  "rdkafka 0.38.0",
+ "sdk",
  "serde",
  "serde_json",
  "sha2",

--- a/api/drizzle/0058_notification_outbox_rejected_idx.sql
+++ b/api/drizzle/0058_notification_outbox_rejected_idx.sql
@@ -1,0 +1,6 @@
+-- Backs notification-indexer's rejection poller (find_expired_proposals):
+-- the LEFT JOIN ... ON (payload->>'proposal_id')::uuid = p.id WHERE o.id IS NULL
+-- otherwise sequentially scans the whole (unbounded) outbox every poll.
+CREATE INDEX IF NOT EXISTS "idx_outbox_rejected_proposal"
+    ON "notification_outbox" (((payload->>'proposal_id')::uuid))
+    WHERE event_type = 'proposal_rejected';

--- a/api/drizzle/meta/0058_snapshot.json
+++ b/api/drizzle/meta/0058_snapshot.json
@@ -1,0 +1,3314 @@
+{
+  "id": "5f2062fd-0c7a-4082-b86e-45327b6b7923",
+  "prevId": "35d7f3c5-6562-4096-955a-4543c4479274",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.app_webhooks": {
+      "name": "app_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "app_name": {
+          "name": "app_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_webhooks_app_name_unique": {
+          "name": "app_webhooks_app_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "app_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.atlas_checkpoints": {
+      "name": "atlas_checkpoints",
+      "schema": "",
+      "columns": {
+        "indexer_id": {
+          "name": "indexer_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph_state_version": {
+          "name": "graph_state_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_compatibility_marker": {
+          "name": "runtime_compatibility_marker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_space_id": {
+          "name": "root_space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph_state_blob": {
+          "name": "graph_state_blob",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emission_baseline_blob": {
+          "name": "emission_baseline_blob",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.edit_versions": {
+      "name": "edit_versions",
+      "schema": "",
+      "columns": {
+        "edit_id": {
+          "name": "edit_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_key": {
+          "name": "version_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "edit_versions_version_key_idx": {
+          "name": "edit_versions_version_key_idx",
+          "columns": [
+            {
+              "expression": "version_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "edit_versions_block_sequence_unique": {
+          "name": "edit_versions_block_sequence_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "block_number",
+            "sequence"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.editors": {
+      "name": "editors",
+      "schema": "",
+      "columns": {
+        "member_space_id": {
+          "name": "member_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "editors_space_id_idx": {
+          "name": "editors_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "editors_member_space_id_space_id_pk": {
+          "name": "editors_member_space_id_space_id_pk",
+          "columns": [
+            "member_space_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_block": {
+          "name": "created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at_block": {
+          "name": "updated_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "entities_updated_at_idx": {
+          "name": "entities_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entities_updated_at_id_idx": {
+          "name": "entities_updated_at_id_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entities_created_at_id_idx": {
+          "name": "entities_created_at_id_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.global_scores": {
+      "name": "global_scores",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ipfs_cache": {
+      "name": "ipfs_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_errored": {
+          "name": "is_errored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "block": {
+          "name": "block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space": {
+          "name": "space",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ipfs_cache_uri_unique": {
+          "name": "ipfs_cache_uri_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uri"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.local_scores": {
+      "name": "local_scores",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_local_scores_space_id": {
+          "name": "idx_local_scores_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_local_scores_entity_id": {
+          "name": "idx_local_scores_entity_id",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_local_scores_space_score": {
+          "name": "idx_local_scores_space_score",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "local_scores_entity_id_space_id_pk": {
+          "name": "local_scores_entity_id_space_id_pk",
+          "columns": [
+            "entity_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "member_space_id": {
+          "name": "member_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "members_space_id_idx": {
+          "name": "members_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "members_member_space_id_space_id_pk": {
+          "name": "members_member_space_id_space_id_pk",
+          "columns": [
+            "member_space_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta": {
+      "name": "meta",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_deliveries": {
+      "name": "notification_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "outbox_id": {
+          "name": "outbox_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_deliveries_pending": {
+          "name": "idx_deliveries_pending",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_deliveries_outbox_id_notification_outbox_id_fk": {
+          "name": "notification_deliveries_outbox_id_notification_outbox_id_fk",
+          "tableFrom": "notification_deliveries",
+          "tableTo": "notification_outbox",
+          "columnsFrom": [
+            "outbox_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_deliveries_webhook_id_app_webhooks_id_fk": {
+          "name": "notification_deliveries_webhook_id_app_webhooks_id_fk",
+          "tableFrom": "notification_deliveries",
+          "tableTo": "app_webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_deliveries_outbox_id_webhook_id_unique": {
+          "name": "notification_deliveries_outbox_id_webhook_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "outbox_id",
+            "webhook_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_outbox": {
+      "name": "notification_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_outbox_idempotency_key_unique": {
+          "name": "notification_outbox_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_actions": {
+      "name": "proposal_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "proposalActionType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_uri": {
+          "name": "content_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quorum": {
+          "name": "quorum",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fast_threshold": {
+          "name": "fast_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slow_threshold": {
+          "name": "slow_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "proposal_actions_proposal_id_idx": {
+          "name": "proposal_actions_proposal_id_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_actions_action_type_idx": {
+          "name": "proposal_actions_action_type_idx",
+          "columns": [
+            {
+              "expression": "action_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_actions_proposal_action_target_idx": {
+          "name": "proposal_actions_proposal_action_target_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_actions_proposal_id_proposals_id_fk": {
+          "name": "proposal_actions_proposal_id_proposals_id_fk",
+          "tableFrom": "proposal_actions",
+          "tableTo": "proposals",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_tally_queue": {
+      "name": "proposal_tally_queue",
+      "schema": "",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "proposal_tally_queue_proposal_id_proposals_id_fk": {
+          "name": "proposal_tally_queue_proposal_id_proposals_id_fk",
+          "tableFrom": "proposal_tally_queue",
+          "tableTo": "proposals",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_votes": {
+      "name": "proposal_votes",
+      "schema": "",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "voteOption",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_block": {
+          "name": "created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "proposal_votes_space_id_idx": {
+          "name": "proposal_votes_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_votes_voter_id_idx": {
+          "name": "proposal_votes_voter_id_idx",
+          "columns": [
+            {
+              "expression": "voter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_votes_vote_idx": {
+          "name": "proposal_votes_vote_idx",
+          "columns": [
+            {
+              "expression": "vote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_votes_proposal_id_proposals_id_fk": {
+          "name": "proposal_votes_proposal_id_proposals_id_fk",
+          "tableFrom": "proposal_votes",
+          "tableTo": "proposals",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "proposal_votes_space_id_spaces_id_fk": {
+          "name": "proposal_votes_space_id_spaces_id_fk",
+          "tableFrom": "proposal_votes",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "proposal_votes_proposal_id_voter_id_pk": {
+          "name": "proposal_votes_proposal_id_voter_id_pk",
+          "columns": [
+            "proposal_id",
+            "voter_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposals": {
+      "name": "proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by": {
+          "name": "proposed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voting_mode": {
+          "name": "voting_mode",
+          "type": "votingMode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quorum": {
+          "name": "quorum",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_block": {
+          "name": "created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yes_count": {
+          "name": "yes_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "no_count": {
+          "name": "no_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "abstain_count": {
+          "name": "abstain_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "proposals_space_id_idx": {
+          "name": "proposals_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_proposed_by_idx": {
+          "name": "proposals_proposed_by_idx",
+          "columns": [
+            {
+              "expression": "proposed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_created_at_idx": {
+          "name": "proposals_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_space_created_at_idx": {
+          "name": "proposals_space_created_at_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_space_end_time_idx": {
+          "name": "proposals_space_end_time_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_space_start_time_idx": {
+          "name": "proposals_space_start_time_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposals_space_id_spaces_id_fk": {
+          "name": "proposals_space_id_spaces_id_fk",
+          "tableFrom": "proposals",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relation_versions": {
+      "name": "relation_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "relation_id": {
+          "name": "relation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_space_id": {
+          "name": "from_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_entity_id": {
+          "name": "to_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_space_id": {
+          "name": "to_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_from_key": {
+          "name": "valid_from_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_to_key": {
+          "name": "valid_to_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_root_id": {
+          "name": "context_root_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_edge_type_id": {
+          "name": "context_edge_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "relation_versions_relation_idx": {
+          "name": "relation_versions_relation_idx",
+          "columns": [
+            {
+              "expression": "relation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_entity_idx": {
+          "name": "relation_versions_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_open_idx": {
+          "name": "relation_versions_open_idx",
+          "columns": [
+            {
+              "expression": "relation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"relation_versions\".\"valid_to_key\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_range_idx": {
+          "name": "relation_versions_range_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_from_entity_type_idx": {
+          "name": "relation_versions_from_entity_type_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_from_entity_valid_to_idx": {
+          "name": "relation_versions_from_entity_valid_to_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_to_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"relation_versions\".\"valid_to_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relations": {
+      "name": "relations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_space_id": {
+          "name": "from_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_version_id": {
+          "name": "from_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_entity_id": {
+          "name": "to_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_space_id": {
+          "name": "to_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_version_id": {
+          "name": "to_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "relations_entity_id_idx": {
+          "name": "relations_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_type_id_idx": {
+          "name": "relations_type_id_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_from_entity_id_idx": {
+          "name": "relations_from_entity_id_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_to_entity_id_idx": {
+          "name": "relations_to_entity_id_idx",
+          "columns": [
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_space_id_idx": {
+          "name": "relations_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_space_from_to_idx": {
+          "name": "relations_space_from_to_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_space_type_idx": {
+          "name": "relations_space_type_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_to_entity_space_idx": {
+          "name": "relations_to_entity_space_idx",
+          "columns": [
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_from_entity_space_idx": {
+          "name": "relations_from_entity_space_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_entity_type_space_idx": {
+          "name": "relations_entity_type_space_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_type_from_to_idx": {
+          "name": "relations_type_from_to_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.space_scores": {
+      "name": "space_scores",
+      "schema": "",
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.spaces": {
+      "name": "spaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "spaceTypes",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "spaces_topic_id_idx": {
+          "name": "spaces_topic_id_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "spaces_topic_id_entities_id_fk": {
+          "name": "spaces_topic_id_entities_id_fk",
+          "tableFrom": "spaces",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subspace_topics": {
+      "name": "subspace_topics",
+      "schema": "",
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "subspace_topics_space_id_idx": {
+          "name": "subspace_topics_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subspace_topics_topic_id_idx": {
+          "name": "subspace_topics_topic_id_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subspace_topics_space_id_spaces_id_fk": {
+          "name": "subspace_topics_space_id_spaces_id_fk",
+          "tableFrom": "subspace_topics",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "subspace_topics_topic_id_entities_id_fk": {
+          "name": "subspace_topics_topic_id_entities_id_fk",
+          "tableFrom": "subspace_topics",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "subspace_topics_space_id_topic_id_pk": {
+          "name": "subspace_topics_space_id_topic_id_pk",
+          "columns": [
+            "space_id",
+            "topic_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subspaces": {
+      "name": "subspaces",
+      "schema": "",
+      "columns": {
+        "parent_space_id": {
+          "name": "parent_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_space_id": {
+          "name": "child_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "subspaceType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'verified'"
+        }
+      },
+      "indexes": {
+        "subspaces_parent_space_id_idx": {
+          "name": "subspaces_parent_space_id_idx",
+          "columns": [
+            {
+              "expression": "parent_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subspaces_child_space_id_idx": {
+          "name": "subspaces_child_space_id_idx",
+          "columns": [
+            {
+              "expression": "child_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subspaces_parent_space_id_spaces_id_fk": {
+          "name": "subspaces_parent_space_id_spaces_id_fk",
+          "tableFrom": "subspaces",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "parent_space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "subspaces_child_space_id_spaces_id_fk": {
+          "name": "subspaces_child_space_id_spaces_id_fk",
+          "tableFrom": "subspaces",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "child_space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "subspaces_parent_space_id_child_space_id_type_pk": {
+          "name": "subspaces_parent_space_id_child_space_id_type_pk",
+          "columns": [
+            "parent_space_id",
+            "child_space_id",
+            "type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_votes": {
+      "name": "user_votes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voted_at": {
+          "name": "voted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_user_votes_object": {
+          "name": "idx_user_votes_object",
+          "columns": [
+            {
+              "expression": "object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_votes_user_id_object_id_object_type_space_id_unique": {
+          "name": "user_votes_user_id_object_id_object_type_space_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "object_id",
+            "object_type",
+            "space_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.value_versions": {
+      "name": "value_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from_key": {
+          "name": "valid_from_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_to_key": {
+          "name": "valid_to_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boolean": {
+          "name": "boolean",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integer": {
+          "name": "integer",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "float": {
+          "name": "float",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decimal": {
+          "name": "decimal",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime": {
+          "name": "datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "point": {
+          "name": "point",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rect": {
+          "name": "rect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_utc": {
+          "name": "time_utc",
+          "type": "time with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime_utc": {
+          "name": "datetime_utc",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_root_id": {
+          "name": "context_root_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_edge_type_id": {
+          "name": "context_edge_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "value_versions_entity_idx": {
+          "name": "value_versions_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_lookup_idx": {
+          "name": "value_versions_lookup_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_open_idx": {
+          "name": "value_versions_open_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"value_versions\".\"valid_to_key\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_range_idx": {
+          "name": "value_versions_range_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_entity_space_valid_to_idx": {
+          "name": "value_versions_entity_space_valid_to_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_to_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"value_versions\".\"valid_to_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.values": {
+      "name": "values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boolean": {
+          "name": "boolean",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integer": {
+          "name": "integer",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "float": {
+          "name": "float",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decimal": {
+          "name": "decimal",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime": {
+          "name": "datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "point": {
+          "name": "point",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rect": {
+          "name": "rect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_utc": {
+          "name": "time_utc",
+          "type": "time with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime_utc": {
+          "name": "datetime_utc",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "values_property_id_idx": {
+          "name": "values_property_id_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_entity_id_idx": {
+          "name": "values_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_space_id_idx": {
+          "name": "values_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_boolean_idx": {
+          "name": "values_boolean_idx",
+          "columns": [
+            {
+              "expression": "boolean",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_integer_idx": {
+          "name": "values_integer_idx",
+          "columns": [
+            {
+              "expression": "integer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_float_idx": {
+          "name": "values_float_idx",
+          "columns": [
+            {
+              "expression": "float",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_decimal_idx": {
+          "name": "values_decimal_idx",
+          "columns": [
+            {
+              "expression": "decimal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_text_idx": {
+          "name": "values_text_idx",
+          "columns": [
+            {
+              "expression": "text",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "length(\"values\".\"text\") <= 2000",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_date_idx": {
+          "name": "values_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_time_idx": {
+          "name": "values_time_idx",
+          "columns": [
+            {
+              "expression": "time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_datetime_idx": {
+          "name": "values_datetime_idx",
+          "columns": [
+            {
+              "expression": "datetime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_point_idx": {
+          "name": "values_point_idx",
+          "columns": [
+            {
+              "expression": "point",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_rect_idx": {
+          "name": "values_rect_idx",
+          "columns": [
+            {
+              "expression": "rect",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_entity_property_idx": {
+          "name": "values_entity_property_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_entity_space_idx": {
+          "name": "values_entity_space_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_property_space_idx": {
+          "name": "values_property_space_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_entity_property_space_idx": {
+          "name": "values_entity_property_space_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_language_idx": {
+          "name": "values_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_unit_idx": {
+          "name": "values_unit_idx",
+          "columns": [
+            {
+              "expression": "unit",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_time_utc_idx": {
+          "name": "values_time_utc_idx",
+          "columns": [
+            {
+              "expression": "time_utc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_datetime_utc_idx": {
+          "name": "values_datetime_utc_idx",
+          "columns": [
+            {
+              "expression": "datetime_utc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_timestamp": {
+          "name": "block_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_votes_voter_id": {
+          "name": "idx_votes_voter_id",
+          "columns": [
+            {
+              "expression": "voter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_votes_object_type_object_id_space_id": {
+          "name": "idx_votes_object_type_object_id_space_id",
+          "columns": [
+            {
+              "expression": "object_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes_count": {
+      "name": "votes_count",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upvotes": {
+          "name": "upvotes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "downvotes": {
+          "name": "downvotes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "votes_count_object_id_object_type_space_id_unique": {
+          "name": "votes_count_object_id_object_type_space_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "object_id",
+            "object_type",
+            "space_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.proposalActionType": {
+      "name": "proposalActionType",
+      "schema": "public",
+      "values": [
+        "AddMember",
+        "RemoveMember",
+        "AddEditor",
+        "RemoveEditor",
+        "UnflagEditor",
+        "Publish",
+        "Flag",
+        "Unflag",
+        "UpdateVotingSettings",
+        "Unknown",
+        "SubspaceVerified",
+        "SubspaceUnverified",
+        "SubspaceRelated",
+        "SubspaceUnrelated",
+        "SubspaceTopicDeclared",
+        "SubspaceTopicRemoved",
+        "SetTopic",
+        "UnsetTopic"
+      ]
+    },
+    "public.spaceTypes": {
+      "name": "spaceTypes",
+      "schema": "public",
+      "values": [
+        "DAO",
+        "Personal"
+      ]
+    },
+    "public.subspaceType": {
+      "name": "subspaceType",
+      "schema": "public",
+      "values": [
+        "verified",
+        "related"
+      ]
+    },
+    "public.voteOption": {
+      "name": "voteOption",
+      "schema": "public",
+      "values": [
+        "Yes",
+        "No",
+        "Abstain"
+      ]
+    },
+    "public.votingMode": {
+      "name": "votingMode",
+      "schema": "public",
+      "values": [
+        "Fast",
+        "Slow"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -407,6 +407,13 @@
       "when": 1779459255335,
       "tag": "0057_atlas_emission_baseline",
       "breakpoints": true
+    },
+    {
+      "idx": 58,
+      "version": "7",
+      "when": 1780517292041,
+      "tag": "0058_notification_outbox_rejected_idx",
+      "breakpoints": true
     }
   ]
 }

--- a/notification-service/e2e-tests/setup.sql
+++ b/notification-service/e2e-tests/setup.sql
@@ -30,6 +30,15 @@ CREATE TABLE IF NOT EXISTS editors (
 );
 CREATE INDEX IF NOT EXISTS editors_space_id_idx ON editors (space_id);
 
+-- Required by notification-indexer's proposal-comment membership gate
+-- (is_member_or_editor). Simplified version of the full members table.
+CREATE TABLE IF NOT EXISTS members (
+    member_space_id uuid NOT NULL,
+    space_id uuid NOT NULL,
+    PRIMARY KEY (member_space_id, space_id)
+);
+CREATE INDEX IF NOT EXISTS members_space_id_idx ON members (space_id);
+
 -- Required by notification-indexer to resolve prior voters of a proposal
 -- (recipients of "a new version of a proposal you voted on was submitted").
 -- Simplified version of the full proposal_votes table. voter_id is the voter's

--- a/notification-service/e2e-tests/src/main.rs
+++ b/notification-service/e2e-tests/src/main.rs
@@ -96,6 +96,19 @@ const PAYOUT_TYPE_BYTES: [u8; 16] = [
     0xfd, 0xda, 0xca, 0xae, 0x85, 0x13, 0x8a, 0x43, 0xec, 0x1a, 0x50, 0xff, 0x71, 0x56, 0x4d, 0x42,
 ];
 
+// Phase 3a — bounty created: a NEW bounty entity created in the bounty space.
+const NEW_BOUNTY_ENTITY_BYTES: [u8; 16] = [0xBC; 16];
+
+// Phase 2a — proposal comment fixtures (isolated in their own space so the
+// 3-editor space counts are unaffected).
+const COMMENT_SPACE_BYTES: [u8; 16] = [0x71; 16];
+const COMMENT_PROPOSAL_BYTES: [u8; 16] = [0x72; 16];
+const COMMENT_PROPOSER_BYTES: [u8; 16] = [0x73; 16]; // recipient of the comment notification
+const COMMENT_MEMBER_BYTES: [u8; 16] = [0x74; 16]; // member of COMMENT_SPACE (allowed commenter)
+const COMMENT_NONMEMBER_BYTES: [u8; 16] = [0x75; 16]; // NOT a member (commenter must be filtered out)
+const COMMENT_ENTITY_BYTES: [u8; 16] = [0x76; 16]; // the comment entity (allowed)
+const COMMENT_ENTITY_2_BYTES: [u8; 16] = [0x78; 16]; // the comment entity (non-member, filtered)
+
 const GOVERNANCE_TOPIC: &str = "space.governance";
 const KNOWLEDGE_EDITS_TOPIC: &str = "knowledge.edits";
 const NUM_WEBHOOKS: usize = 3;
@@ -113,10 +126,14 @@ const NUM_WEBHOOKS: usize = 3;
 // Bounty interest:  1 event × 2 editors × 3 = 6
 // Bounty allocated: 1 event × 1 curator × 3 = 3
 // Bounty payout:    1 event × 1 curator × 3 = 3
+// Bounty created:   1 event × 2 bounty editors × 3 = 6   (Phase 3a)
+// Proposal comment: 1 event × 1 proposer × 3 = 3         (Phase 2a; the non-member
+//                   comment is filtered out and produces 0 calls)
 //
-// The proposer (0x02) and the prior voter (0x0B) are intentionally NOT editors,
-// so these counts also prove targeted delivery reaches non-editors.
-const EXPECTED_CALLS: usize = 66 + 3 + 6 + 3 + 3;
+// The proposer (0x02), prior voter (0x0B), and comment proposer (0x73) are
+// intentionally NOT editors, so these counts also prove targeted delivery
+// reaches non-editors.
+const EXPECTED_CALLS: usize = 66 + 3 + 6 + 3 + 3 + 6 + 3;
 
 const GOVERNANCE_EVENT_TYPES: &[&str] = &[
     "proposal_created",
@@ -137,6 +154,8 @@ const ALL_EVENT_TYPES: &[&str] = &[
     "bounty_interest",
     "bounty_allocated",
     "bounty_payout",
+    "bounty_created",
+    "proposal_comment",
 ];
 
 // ---------------------------------------------------------------------------
@@ -392,6 +411,31 @@ async fn seed_database(
     )
     .bind(curator_space)
     .bind(curator_space)
+    .execute(pool)
+    .await?;
+
+    // Phase 2a: a proposal in its own space for the comment test. end_time in the
+    // future so the rejection poller ignores it. The recipient is the proposer.
+    sqlx::query(
+        "INSERT INTO proposals (id, space_id, proposed_by, start_time, end_time, created_at, created_at_block) \
+         VALUES ($1, $2, $3, $4, $5, '0', '0') ON CONFLICT DO NOTHING",
+    )
+    .bind(Uuid::from_bytes(COMMENT_PROPOSAL_BYTES))
+    .bind(Uuid::from_bytes(COMMENT_SPACE_BYTES))
+    .bind(Uuid::from_bytes(COMMENT_PROPOSER_BYTES))
+    .bind(now - 3600)
+    .bind(now + 3600)
+    .execute(pool)
+    .await?;
+
+    // The allowed commenter is a *member* (not editor) of the proposal's space,
+    // exercising the members branch of is_member_or_editor.
+    sqlx::query(
+        "INSERT INTO members (member_space_id, space_id) VALUES ($1, $2) \
+         ON CONFLICT DO NOTHING",
+    )
+    .bind(Uuid::from_bytes(COMMENT_MEMBER_BYTES))
+    .bind(Uuid::from_bytes(COMMENT_SPACE_BYTES))
     .execute(pool)
     .await?;
 
@@ -658,6 +702,78 @@ async fn produce_test_events(kafka_broker: &str) -> Result<(), Box<dyn std::erro
         .await
         .map_err(|(e, _)| e)?;
 
+    // Phase 3a: a NEW bounty created in the bounty space (entity → Types → Bounty).
+    let types_bytes = Uuid::parse_str("8f151ba4-de20-4e3c-9cb4-99ddf96f48f1")
+        .expect("valid Types id")
+        .into_bytes();
+    let bounty_type_bytes = Uuid::parse_str("808af0ba-d588-4e33-91f0-9dd4b25e18be")
+        .expect("valid Bounty type id")
+        .into_bytes();
+    let bounty_created_edit = make_bounty_hermes_edit(
+        [0xBD; 16],
+        types_bytes,
+        NEW_BOUNTY_ENTITY_BYTES,
+        bounty_type_bytes,
+        BOUNTY_SPACE_BYTES,
+        None,
+        40004,
+        1700033000,
+        4,
+    );
+    let headers = rdkafka::message::OwnedHeaders::new();
+    producer
+        .send(
+            FutureRecord::to(&ke_topic)
+                .payload(&bounty_created_edit.encode_to_vec())
+                .key("bounty-created")
+                .headers(headers),
+            Duration::from_secs(10),
+        )
+        .await
+        .map_err(|(e, _)| e)?;
+
+    // Phase 2a: a comment on COMMENT_PROPOSAL by a member (allowed → proposer
+    // notified) and by a non-member (must be filtered out → no notification).
+    let comment_allowed = make_comment_hermes_edit(
+        COMMENT_ENTITY_BYTES,
+        COMMENT_PROPOSAL_BYTES,
+        COMMENT_MEMBER_BYTES,
+        40005,
+        1700034000,
+        5,
+    );
+    let headers = rdkafka::message::OwnedHeaders::new();
+    producer
+        .send(
+            FutureRecord::to(&ke_topic)
+                .payload(&comment_allowed.encode_to_vec())
+                .key("comment-allowed")
+                .headers(headers),
+            Duration::from_secs(10),
+        )
+        .await
+        .map_err(|(e, _)| e)?;
+
+    let comment_blocked = make_comment_hermes_edit(
+        COMMENT_ENTITY_2_BYTES,
+        COMMENT_PROPOSAL_BYTES,
+        COMMENT_NONMEMBER_BYTES,
+        40006,
+        1700035000,
+        6,
+    );
+    let headers = rdkafka::message::OwnedHeaders::new();
+    producer
+        .send(
+            FutureRecord::to(&ke_topic)
+                .payload(&comment_blocked.encode_to_vec())
+                .key("comment-blocked")
+                .headers(headers),
+            Duration::from_secs(10),
+        )
+        .await
+        .map_err(|(e, _)| e)?;
+
     Ok(())
 }
 
@@ -706,6 +822,79 @@ fn make_bounty_hermes_edit(
         authors: vec![from.to_vec()],
         language: None,
         space_id: space_id.to_vec(),
+        is_canonical: true,
+        meta: Some(hermes_schema::pb::blockchain_metadata::BlockchainMetadata {
+            created_at,
+            created_by: vec![],
+            block_number,
+            cursor: String::new(),
+            sequence,
+            is_last: false,
+        }),
+    }
+}
+
+/// Build a HermesEdit for a comment: a Comment entity (`Types → Comment`) that
+/// replies to `parent` (`Reply to → parent`), published from `commenter_space`.
+fn make_comment_hermes_edit(
+    comment_entity: [u8; 16],
+    parent: [u8; 16],
+    commenter_space: [u8; 16],
+    block_number: u64,
+    created_at: u64,
+    sequence: u32,
+) -> hermes_schema::pb::knowledge::HermesEdit {
+    use std::borrow::Cow;
+
+    let types = Uuid::parse_str("8f151ba4-de20-4e3c-9cb4-99ddf96f48f1")
+        .expect("valid Types id")
+        .into_bytes();
+    let comment_type = Uuid::parse_str("82f6123a-0323-4c6c-a811-701c5bc026e9")
+        .expect("valid Comment type id")
+        .into_bytes();
+    let reply_to = Uuid::parse_str("310d4a24-0e5b-451c-b215-1bfce40d0fe6")
+        .expect("valid Reply-to id")
+        .into_bytes();
+
+    let mk = |id: [u8; 16], rt: [u8; 16], from: [u8; 16], to: [u8; 16]| {
+        grc_20::Op::CreateRelation(grc_20::CreateRelation {
+            id,
+            relation_type: rt,
+            from,
+            from_is_value_ref: false,
+            to,
+            to_is_value_ref: false,
+            from_space: None,
+            from_version: None,
+            to_space: None,
+            to_version: None,
+            entity: None,
+            position: None,
+            context: None,
+        })
+    };
+
+    let edit = grc_20::Edit {
+        id: comment_entity,
+        name: Cow::Borrowed("comment edit"),
+        authors: vec![commenter_space],
+        created_at: created_at as i64,
+        ops: vec![
+            // Comment entity is typed as Comment...
+            mk([0xA1; 16], types, comment_entity, comment_type),
+            // ...and replies to its parent.
+            mk([0xA2; 16], reply_to, comment_entity, parent),
+        ],
+    };
+    let payload = grc_20::encode_edit(&edit).expect("GRC-20 encode should succeed");
+
+    hermes_schema::pb::knowledge::HermesEdit {
+        id: comment_entity.to_vec(),
+        name: "comment edit".into(),
+        payload,
+        authors: vec![commenter_space.to_vec()],
+        language: None,
+        space_id: commenter_space.to_vec(),
         is_canonical: true,
         meta: Some(hermes_schema::pb::blockchain_metadata::BlockchainMetadata {
             created_at,
@@ -894,6 +1083,8 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
     let bounty_editor_1 = Uuid::from_bytes(BOUNTY_EDITOR_1_BYTES).to_string();
     let bounty_editor_2 = Uuid::from_bytes(BOUNTY_EDITOR_2_BYTES).to_string();
     let curator_space = Uuid::from_bytes(CURATOR_SPACE_BYTES).to_string();
+    // Phase 2a: the proposal-comment recipient (the proposer; not an editor).
+    let comment_proposer = Uuid::from_bytes(COMMENT_PROPOSER_BYTES).to_string();
 
     let all_known: Vec<String> = editors_3e
         .iter()
@@ -904,6 +1095,8 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
         // Phase 1 targeted recipients (non-editors):
         .chain(std::iter::once(&proposer_uid))
         .chain(std::iter::once(&update_voter_uid))
+        // Phase 2a: proposal-comment recipient (proposer):
+        .chain(std::iter::once(&comment_proposer))
         .cloned()
         .collect();
 
@@ -994,8 +1187,10 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
         // Bounty interest: 1 event × 2 editors = 2
         // Bounty allocated: 1 event × 1 curator = 1
         // Bounty payout: 1 event × 1 curator = 1
-        // Total: 27
-        keys.len() == 27
+        // Bounty created: 1 event × 2 bounty editors = 2
+        // Proposal comment: 1 event × 1 proposer = 1
+        // Total: 30
+        keys.len() == 30
     });
 
     // ===================================================================
@@ -1499,6 +1694,75 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
         r.check(
             "bounty_payout: curator is recipient",
             call.body["user_space_id"].as_str() == Some(curator_space.as_str()),
+        );
+    }
+
+    // --- Phase 3a: bounty_created — 2 bounty-space editors × 3 webhooks = 6 ---
+    let new_bounty_entity = Uuid::from_bytes(NEW_BOUNTY_ENTITY_BYTES).to_string();
+    let bounty_space = Uuid::from_bytes(BOUNTY_SPACE_BYTES).to_string();
+    let created_calls: Vec<_> = calls
+        .iter()
+        .filter(|c| c.body["event_type"].as_str() == Some("bounty_created"))
+        .collect();
+    r.check(
+        "bounty_created: 6 calls (2 bounty editors x 3 webhooks)",
+        created_calls.len() == 6,
+    );
+    if let Some(call) = created_calls.first() {
+        r.check(
+            "bounty_created: category is 'bounty'",
+            call.body["category"].as_str() == Some("bounty"),
+        );
+        r.check(
+            "bounty_created: correct bounty_entity_id",
+            call.body["bounty_entity_id"].as_str() == Some(new_bounty_entity.as_str()),
+        );
+        r.check(
+            "bounty_created: correct bounty_space_id",
+            call.body["bounty_space_id"].as_str() == Some(bounty_space.as_str()),
+        );
+    }
+    for editor in [&bounty_editor_1, &bounty_editor_2] {
+        let n = created_calls
+            .iter()
+            .filter(|c| c.body["user_space_id"].as_str() == Some(editor.as_str()))
+            .count();
+        r.check(
+            &format!("bounty_created: editor {}.. got 3 deliveries", &editor[..8]),
+            n == 3,
+        );
+    }
+
+    // --- Phase 2a: proposal_comment — proposer × 3 webhooks = 3, and the
+    //     non-member comment is filtered out (exactly 3 total proves it). ---
+    let comment_proposal = Uuid::from_bytes(COMMENT_PROPOSAL_BYTES).to_string();
+    let comment_member = Uuid::from_bytes(COMMENT_MEMBER_BYTES).to_string();
+    let comment_calls: Vec<_> = calls
+        .iter()
+        .filter(|c| c.body["event_type"].as_str() == Some("proposal_comment"))
+        .collect();
+    r.check(
+        "proposal_comment: exactly 3 calls (proposer x 3; non-member comment filtered out)",
+        comment_calls.len() == 3,
+    );
+    r.check(
+        "proposal_comment: all delivered to the proposer",
+        comment_calls
+            .iter()
+            .all(|c| c.body["user_space_id"].as_str() == Some(comment_proposer.as_str())),
+    );
+    if let Some(call) = comment_calls.first() {
+        r.check(
+            "proposal_comment: category is 'comment'",
+            call.body["category"].as_str() == Some("comment"),
+        );
+        r.check(
+            "proposal_comment: correct proposal_id",
+            call.body["proposal_id"].as_str() == Some(comment_proposal.as_str()),
+        );
+        r.check(
+            "proposal_comment: commenter_space_id is the member commenter",
+            call.body["commenter_space_id"].as_str() == Some(comment_member.as_str()),
         );
     }
 

--- a/notification-service/e2e-tests/src/main.rs
+++ b/notification-service/e2e-tests/src/main.rs
@@ -98,6 +98,10 @@ const PAYOUT_TYPE_BYTES: [u8; 16] = [
 
 // Phase 3a — bounty created: a NEW bounty entity created in the bounty space.
 const NEW_BOUNTY_ENTITY_BYTES: [u8; 16] = [0xBC; 16];
+// A SECOND bounty created in the *same* HermesEdit as the first. This is the
+// idempotency regression fixture: both bounties share (block, sequence), so a
+// per-instance idempotency key is required for both notifications to survive.
+const SECOND_NEW_BOUNTY_ENTITY_BYTES: [u8; 16] = [0xBE; 16];
 
 // Phase 2a — proposal comment fixtures (isolated in their own space so the
 // 3-editor space counts are unaffected).
@@ -135,7 +139,8 @@ const NUM_WEBHOOKS: usize = 3;
 // Bounty interest:  1 event × 2 editors × 3 = 6
 // Bounty allocated: 1 event × 1 curator × 3 = 3
 // Bounty payout:    1 event × 1 curator × 3 = 3
-// Bounty created:   1 event × 2 bounty editors × 3 = 6   (Phase 3a)
+// Bounty created:   2 bounties (one edit) × 2 bounty editors × 3 = 12  (Phase 3a;
+//                   both survive only because idempotency keys are per-bounty)
 // Proposal comment: 1 event × 1 proposer × 3 = 3         (Phase 2a; the non-member
 //                   comment is filtered out and produces 0 calls)
 // Comment thread:   1 reply × 2 recipients × 3 = 6       (Phase 2b; prior participant
@@ -144,7 +149,7 @@ const NUM_WEBHOOKS: usize = 3;
 // The proposer (0x02), prior voter (0x0B), and comment proposer (0x73) are
 // intentionally NOT editors, so these counts also prove targeted delivery
 // reaches non-editors.
-const EXPECTED_CALLS: usize = 66 + 3 + 6 + 3 + 3 + 6 + 3 + 6;
+const EXPECTED_CALLS: usize = 66 + 3 + 6 + 3 + 3 + 12 + 3 + 6;
 
 const GOVERNANCE_EVENT_TYPES: &[&str] = &[
     "proposal_created",
@@ -750,13 +755,14 @@ async fn produce_test_events(kafka_broker: &str) -> Result<(), Box<dyn std::erro
     let bounty_type_bytes = Uuid::parse_str("808af0ba-d588-4e33-91f0-9dd4b25e18be")
         .expect("valid Bounty type id")
         .into_bytes();
-    let bounty_created_edit = make_bounty_hermes_edit(
-        [0xBD; 16],
+    // Two bounties created in ONE edit (shared block/sequence) — exercises the
+    // idempotency-key fix: without per-bounty keys the second would be dropped.
+    let bounty_created_edit = make_two_bounty_created_hermes_edit(
         types_bytes,
         NEW_BOUNTY_ENTITY_BYTES,
+        SECOND_NEW_BOUNTY_ENTITY_BYTES,
         bounty_type_bytes,
         BOUNTY_SPACE_BYTES,
-        None,
         40004,
         1700033000,
         4,
@@ -884,6 +890,70 @@ fn make_bounty_hermes_edit(
         name: "bounty edit".into(),
         payload,
         authors: vec![from.to_vec()],
+        language: None,
+        space_id: space_id.to_vec(),
+        is_canonical: true,
+        meta: Some(hermes_schema::pb::blockchain_metadata::BlockchainMetadata {
+            created_at,
+            created_by: vec![],
+            block_number,
+            cursor: String::new(),
+            sequence,
+            is_last: false,
+        }),
+    }
+}
+
+/// Build a HermesEdit that creates *two* bounties (two `Types → Bounty`
+/// relations) in a single edit. Both ops share the edit's (block, sequence),
+/// which is exactly the condition under which the old `{block}:{seq}:bounty_created`
+/// idempotency key collided and silently dropped the second notification.
+#[allow(clippy::too_many_arguments)]
+fn make_two_bounty_created_hermes_edit(
+    relation_type: [u8; 16],
+    bounty_a: [u8; 16],
+    bounty_b: [u8; 16],
+    bounty_type: [u8; 16],
+    space_id: [u8; 16],
+    block_number: u64,
+    created_at: u64,
+    sequence: u32,
+) -> hermes_schema::pb::knowledge::HermesEdit {
+    use std::borrow::Cow;
+
+    let mk_op = |entity: [u8; 16], rel_id: [u8; 16]| {
+        grc_20::Op::CreateRelation(grc_20::CreateRelation {
+            id: rel_id,
+            relation_type,
+            from: entity,
+            from_is_value_ref: false,
+            to: bounty_type,
+            to_is_value_ref: false,
+            from_space: None,
+            from_version: None,
+            to_space: None,
+            to_version: None,
+            entity: None,
+            position: None,
+            context: None,
+        })
+    };
+
+    let edit_id = [0xBF; 16];
+    let edit = grc_20::Edit {
+        id: edit_id,
+        name: Cow::Borrowed("two bounty edit"),
+        authors: vec![bounty_a],
+        created_at: created_at as i64,
+        ops: vec![mk_op(bounty_a, [0xD1; 16]), mk_op(bounty_b, [0xD2; 16])],
+    };
+    let payload = grc_20::encode_edit(&edit).expect("GRC-20 encode should succeed");
+
+    hermes_schema::pb::knowledge::HermesEdit {
+        id: edit_id.to_vec(),
+        name: "two bounty edit".into(),
+        payload,
+        authors: vec![bounty_a.to_vec()],
         language: None,
         space_id: space_id.to_vec(),
         is_canonical: true,
@@ -1257,11 +1327,11 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
         // Bounty interest: 1 event × 2 editors = 2
         // Bounty allocated: 1 event × 1 curator = 1
         // Bounty payout: 1 event × 1 curator = 1
-        // Bounty created: 1 event × 2 bounty editors = 2
+        // Bounty created: 2 bounties (one edit) × 2 bounty editors = 4
         // Proposal comment: 1 event × 1 proposer = 1
         // Comment thread: 1 reply × 2 recipients = 2
-        // Total: 32
-        keys.len() == 32
+        // Total: 34
+        keys.len() == 34
     });
 
     // ===================================================================
@@ -1768,16 +1838,19 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
         );
     }
 
-    // --- Phase 3a: bounty_created — 2 bounty-space editors × 3 webhooks = 6 ---
+    // --- Phase 3a: bounty_created — TWO bounties in one edit, 2 bounty-space
+    //     editors × 3 webhooks each = 12. Both bounties surviving proves the
+    //     per-bounty idempotency key fix (the old key dropped the second). ---
     let new_bounty_entity = Uuid::from_bytes(NEW_BOUNTY_ENTITY_BYTES).to_string();
+    let second_bounty_entity = Uuid::from_bytes(SECOND_NEW_BOUNTY_ENTITY_BYTES).to_string();
     let bounty_space = Uuid::from_bytes(BOUNTY_SPACE_BYTES).to_string();
     let created_calls: Vec<_> = calls
         .iter()
         .filter(|c| c.body["event_type"].as_str() == Some("bounty_created"))
         .collect();
     r.check(
-        "bounty_created: 6 calls (2 bounty editors x 3 webhooks)",
-        created_calls.len() == 6,
+        "bounty_created: 12 calls (2 bounties x 2 editors x 3 webhooks)",
+        created_calls.len() == 12,
     );
     if let Some(call) = created_calls.first() {
         r.check(
@@ -1785,12 +1858,22 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
             call.body["category"].as_str() == Some("bounty"),
         );
         r.check(
-            "bounty_created: correct bounty_entity_id",
-            call.body["bounty_entity_id"].as_str() == Some(new_bounty_entity.as_str()),
-        );
-        r.check(
             "bounty_created: correct bounty_space_id",
             call.body["bounty_space_id"].as_str() == Some(bounty_space.as_str()),
+        );
+    }
+    // Both bounties from the single edit must each produce notifications.
+    for (label, entity) in [
+        ("first", &new_bounty_entity),
+        ("second", &second_bounty_entity),
+    ] {
+        let n = created_calls
+            .iter()
+            .filter(|c| c.body["bounty_entity_id"].as_str() == Some(entity.as_str()))
+            .count();
+        r.check(
+            &format!("bounty_created: {label} bounty delivered (2 editors x 3 webhooks = 6)"),
+            n == 6,
         );
     }
     for editor in [&bounty_editor_1, &bounty_editor_2] {
@@ -1799,8 +1882,11 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
             .filter(|c| c.body["user_space_id"].as_str() == Some(editor.as_str()))
             .count();
         r.check(
-            &format!("bounty_created: editor {}.. got 3 deliveries", &editor[..8]),
-            n == 3,
+            &format!(
+                "bounty_created: editor {}.. got 6 deliveries (2 bounties x 3)",
+                &editor[..8]
+            ),
+            n == 6,
         );
     }
 

--- a/notification-service/e2e-tests/src/main.rs
+++ b/notification-service/e2e-tests/src/main.rs
@@ -109,6 +109,15 @@ const COMMENT_NONMEMBER_BYTES: [u8; 16] = [0x75; 16]; // NOT a member (commenter
 const COMMENT_ENTITY_BYTES: [u8; 16] = [0x76; 16]; // the comment entity (allowed)
 const COMMENT_ENTITY_2_BYTES: [u8; 16] = [0x78; 16]; // the comment entity (non-member, filtered)
 
+// Phase 2b — general comment thread fixtures (a reply into a seeded thread).
+const THREAD_ROOT_BYTES: [u8; 16] = [0x86; 16]; // the (non-proposal) thing being commented on
+const THREAD_HOME_SPACE_BYTES: [u8; 16] = [0x87; 16]; // root's home space == creator (recipient)
+const THREAD_GENERIC_TYPE_BYTES: [u8; 16] = [0x8F; 16]; // an arbitrary (non-bounty) type for the root
+const EXISTING_COMMENT_BYTES: [u8; 16] = [0x88; 16]; // a prior comment on the root (seeded)
+const THREAD_PARTICIPANT_SPACE_BYTES: [u8; 16] = [0x89; 16]; // author of the prior comment (recipient)
+const REPLY_COMMENT_BYTES: [u8; 16] = [0x8a; 16]; // the NEW reply (produced)
+const REPLY_AUTHOR_SPACE_BYTES: [u8; 16] = [0x8b; 16]; // author of the reply (must NOT be notified)
+
 const GOVERNANCE_TOPIC: &str = "space.governance";
 const KNOWLEDGE_EDITS_TOPIC: &str = "knowledge.edits";
 const NUM_WEBHOOKS: usize = 3;
@@ -129,11 +138,13 @@ const NUM_WEBHOOKS: usize = 3;
 // Bounty created:   1 event × 2 bounty editors × 3 = 6   (Phase 3a)
 // Proposal comment: 1 event × 1 proposer × 3 = 3         (Phase 2a; the non-member
 //                   comment is filtered out and produces 0 calls)
+// Comment thread:   1 reply × 2 recipients × 3 = 6       (Phase 2b; prior participant
+//                   + root creator; the reply author is excluded)
 //
 // The proposer (0x02), prior voter (0x0B), and comment proposer (0x73) are
 // intentionally NOT editors, so these counts also prove targeted delivery
 // reaches non-editors.
-const EXPECTED_CALLS: usize = 66 + 3 + 6 + 3 + 3 + 6 + 3;
+const EXPECTED_CALLS: usize = 66 + 3 + 6 + 3 + 3 + 6 + 3 + 6;
 
 const GOVERNANCE_EVENT_TYPES: &[&str] = &[
     "proposal_created",
@@ -156,6 +167,7 @@ const ALL_EVENT_TYPES: &[&str] = &[
     "bounty_payout",
     "bounty_created",
     "proposal_comment",
+    "comment",
 ];
 
 // ---------------------------------------------------------------------------
@@ -436,6 +448,35 @@ async fn seed_database(
     )
     .bind(Uuid::from_bytes(COMMENT_MEMBER_BYTES))
     .bind(Uuid::from_bytes(COMMENT_SPACE_BYTES))
+    .execute(pool)
+    .await?;
+
+    // Phase 2b: seed an existing comment thread. The notification-indexer reads
+    // these relations to resolve the thread root and its participants (kg-indexer
+    // isn't running in the e2e, so we seed the relations directly).
+    // (a) The thread root's Types relation → gives it a home space (== creator).
+    sqlx::query(
+        "INSERT INTO relations (id, space_id, type_id, from_entity_id, to_entity_id) \
+         VALUES ($1, $2, '8f151ba4-de20-4e3c-9cb4-99ddf96f48f1'::uuid, $3, $4) \
+         ON CONFLICT DO NOTHING",
+    )
+    .bind(Uuid::new_v4())
+    .bind(Uuid::from_bytes(THREAD_HOME_SPACE_BYTES))
+    .bind(Uuid::from_bytes(THREAD_ROOT_BYTES))
+    .bind(Uuid::from_bytes(THREAD_GENERIC_TYPE_BYTES))
+    .execute(pool)
+    .await?;
+    // (b) A prior comment on the root, authored from a participant's space
+    //     (Reply-to → root). Its space_id is that participant.
+    sqlx::query(
+        "INSERT INTO relations (id, space_id, type_id, from_entity_id, to_entity_id) \
+         VALUES ($1, $2, '310d4a24-0e5b-451c-b215-1bfce40d0fe6'::uuid, $3, $4) \
+         ON CONFLICT DO NOTHING",
+    )
+    .bind(Uuid::new_v4())
+    .bind(Uuid::from_bytes(THREAD_PARTICIPANT_SPACE_BYTES))
+    .bind(Uuid::from_bytes(EXISTING_COMMENT_BYTES))
+    .bind(Uuid::from_bytes(THREAD_ROOT_BYTES))
     .execute(pool)
     .await?;
 
@@ -774,6 +815,29 @@ async fn produce_test_events(kafka_broker: &str) -> Result<(), Box<dyn std::erro
         .await
         .map_err(|(e, _)| e)?;
 
+    // Phase 2b: a reply into the seeded thread (reply → EXISTING_COMMENT). The
+    // indexer walks to the root, notifying the prior participant + the root's
+    // creator (home space), but NOT the reply's own author.
+    let thread_reply = make_comment_hermes_edit(
+        REPLY_COMMENT_BYTES,
+        EXISTING_COMMENT_BYTES,
+        REPLY_AUTHOR_SPACE_BYTES,
+        40007,
+        1700036000,
+        7,
+    );
+    let headers = rdkafka::message::OwnedHeaders::new();
+    producer
+        .send(
+            FutureRecord::to(&ke_topic)
+                .payload(&thread_reply.encode_to_vec())
+                .key("comment-thread-reply")
+                .headers(headers),
+            Duration::from_secs(10),
+        )
+        .await
+        .map_err(|(e, _)| e)?;
+
     Ok(())
 }
 
@@ -1085,6 +1149,9 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
     let curator_space = Uuid::from_bytes(CURATOR_SPACE_BYTES).to_string();
     // Phase 2a: the proposal-comment recipient (the proposer; not an editor).
     let comment_proposer = Uuid::from_bytes(COMMENT_PROPOSER_BYTES).to_string();
+    // Phase 2b: comment-thread recipients (prior participant + root creator).
+    let thread_participant = Uuid::from_bytes(THREAD_PARTICIPANT_SPACE_BYTES).to_string();
+    let thread_home = Uuid::from_bytes(THREAD_HOME_SPACE_BYTES).to_string();
 
     let all_known: Vec<String> = editors_3e
         .iter()
@@ -1097,6 +1164,9 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
         .chain(std::iter::once(&update_voter_uid))
         // Phase 2a: proposal-comment recipient (proposer):
         .chain(std::iter::once(&comment_proposer))
+        // Phase 2b: comment-thread recipients (participant + root creator):
+        .chain(std::iter::once(&thread_participant))
+        .chain(std::iter::once(&thread_home))
         .cloned()
         .collect();
 
@@ -1189,8 +1259,9 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
         // Bounty payout: 1 event × 1 curator = 1
         // Bounty created: 1 event × 2 bounty editors = 2
         // Proposal comment: 1 event × 1 proposer = 1
-        // Total: 30
-        keys.len() == 30
+        // Comment thread: 1 reply × 2 recipients = 2
+        // Total: 32
+        keys.len() == 32
     });
 
     // ===================================================================
@@ -1765,6 +1836,50 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
             call.body["commenter_space_id"].as_str() == Some(comment_member.as_str()),
         );
     }
+
+    // --- Phase 2b: comment thread — a reply notifies the prior participant and
+    //     the root's creator (home space), but NOT the reply's author. ---
+    let thread_root = Uuid::from_bytes(THREAD_ROOT_BYTES).to_string();
+    let reply_author = Uuid::from_bytes(REPLY_AUTHOR_SPACE_BYTES).to_string();
+    let comment_calls: Vec<_> = calls
+        .iter()
+        .filter(|c| c.body["event_type"].as_str() == Some("comment"))
+        .collect();
+    r.check(
+        "comment: 6 calls (prior participant + root creator) x 3 webhooks",
+        comment_calls.len() == 6,
+    );
+    if let Some(call) = comment_calls.first() {
+        r.check(
+            "comment: category is 'comment'",
+            call.body["category"].as_str() == Some("comment"),
+        );
+        r.check(
+            "comment: correct thread root_id",
+            call.body["root_id"].as_str() == Some(thread_root.as_str()),
+        );
+    }
+    // The prior participant and the root's creator each get 3 (one per webhook).
+    for (label, who) in [
+        ("prior participant", &thread_participant),
+        ("root creator", &thread_home),
+    ] {
+        let n = comment_calls
+            .iter()
+            .filter(|c| c.body["user_space_id"].as_str() == Some(who.as_str()))
+            .count();
+        r.check(
+            &format!("comment: {} notified on 3 webhooks", label),
+            n == 3,
+        );
+    }
+    // The reply's own author must NOT be notified.
+    r.check(
+        "comment: reply author is not notified (self-exclusion)",
+        !comment_calls
+            .iter()
+            .any(|c| c.body["user_space_id"].as_str() == Some(reply_author.as_str())),
+    );
 
     r
 }

--- a/notification-service/e2e-tests/src/main.rs
+++ b/notification-service/e2e-tests/src/main.rs
@@ -101,7 +101,8 @@ const NEW_BOUNTY_ENTITY_BYTES: [u8; 16] = [0xBC; 16];
 // A SECOND bounty created in the *same* HermesEdit as the first. This is the
 // idempotency regression fixture: both bounties share (block, sequence), so a
 // per-instance idempotency key is required for both notifications to survive.
-const SECOND_NEW_BOUNTY_ENTITY_BYTES: [u8; 16] = [0xBE; 16];
+// Must differ from every other entity id (notably BOUNTY_ENTITY_BYTES = 0xBE).
+const SECOND_NEW_BOUNTY_ENTITY_BYTES: [u8; 16] = [0xCB; 16];
 
 // Phase 2a — proposal comment fixtures (isolated in their own space so the
 // 3-editor space counts are unaffected).
@@ -763,6 +764,7 @@ async fn produce_test_events(kafka_broker: &str) -> Result<(), Box<dyn std::erro
         SECOND_NEW_BOUNTY_ENTITY_BYTES,
         bounty_type_bytes,
         BOUNTY_SPACE_BYTES,
+        BOUNTY_EDITOR_1_BYTES, // actor/publisher space
         40004,
         1700033000,
         4,
@@ -915,6 +917,10 @@ fn make_two_bounty_created_hermes_edit(
     bounty_b: [u8; 16],
     bounty_type: [u8; 16],
     space_id: [u8; 16],
+    // The actor/publisher space of the edit, used for `authors` (matches the
+    // convention in the other fixtures, where authors is the publisher space —
+    // not the entity being created).
+    author_space: [u8; 16],
     block_number: u64,
     created_at: u64,
     sequence: u32,
@@ -943,7 +949,7 @@ fn make_two_bounty_created_hermes_edit(
     let edit = grc_20::Edit {
         id: edit_id,
         name: Cow::Borrowed("two bounty edit"),
-        authors: vec![bounty_a],
+        authors: vec![author_space],
         created_at: created_at as i64,
         ops: vec![mk_op(bounty_a, [0xD1; 16]), mk_op(bounty_b, [0xD2; 16])],
     };
@@ -953,7 +959,7 @@ fn make_two_bounty_created_hermes_edit(
         id: edit_id.to_vec(),
         name: "two bounty edit".into(),
         payload,
-        authors: vec![bounty_a.to_vec()],
+        authors: vec![author_space.to_vec()],
         language: None,
         space_id: space_id.to_vec(),
         is_canonical: true,
@@ -1287,18 +1293,35 @@ fn verify_calls(calls: &[WebhookCall], webhook_secret: &str) -> TestResults {
             );
         }
     }
-    // Bounty HMAC spot-checks
-    for et in &["bounty_interest", "bounty_allocated", "bounty_payout"] {
+    // Bounty + new-type (bounty_created / proposal_comment / comment) HMAC spot-checks
+    for et in &[
+        "bounty_interest",
+        "bounty_allocated",
+        "bounty_payout",
+        "bounty_created",
+        "proposal_comment",
+        "comment",
+    ] {
         if let Some(call) = calls
             .iter()
             .find(|c| c.body["event_type"].as_str() == Some(et))
         {
             r.check(
-                &format!("bounty {}: valid HMAC", et),
+                &format!("{}: valid HMAC", et),
                 verify_hmac(webhook_secret, &call.raw_body, &call.signature),
             );
         }
     }
+
+    // Blanket check: EVERY delivered webhook carries a valid signature. This is
+    // the root-cause guard — any current or future event type is covered, so a
+    // new type can't silently ship without signature verification.
+    r.check(
+        "all webhook calls have a valid HMAC signature",
+        calls
+            .iter()
+            .all(|c| verify_hmac(webhook_secret, &c.raw_body, &c.signature)),
+    );
 
     // ===================================================================
     // All calls have idempotency key (raw string format: base:user_space_id)

--- a/notification-service/notification-indexer/Cargo.toml
+++ b/notification-service/notification-indexer/Cargo.toml
@@ -8,6 +8,8 @@ description = "Notification indexer that consumes governance events from Kafka a
 hermes-schema = { path = "../../hermes-schema" }
 hermes-instrumentation = { path = "../../hermes-instrumentation" }
 hermes-kafka = { path = "../../hermes-kafka" }
+# Canonical knowledge-graph system/content IDs.
+sdk = { path = "../../sdk" }
 grc-20 = "0.4.1"
 rdkafka = { version = "0.38.0", features = ["cmake-build", "ssl", "zstd"] }
 tokio = { version = "1.42.0", features = ["macros", "rt-multi-thread", "sync", "time", "signal", "net"] }

--- a/notification-service/notification-indexer/Dockerfile
+++ b/notification-service/notification-indexer/Dockerfile
@@ -16,6 +16,8 @@ WORKDIR /app
 COPY hermes-schema ./hermes-schema
 COPY hermes-instrumentation ./hermes-instrumentation
 COPY hermes-kafka ./hermes-kafka
+# Canonical knowledge-graph IDs (sdk crate) — path dep of notification-indexer.
+COPY sdk ./sdk
 COPY notification-service/notification-indexer ./notification-service/notification-indexer
 
 # Build from the crate directory (standalone, not as workspace member)

--- a/notification-service/notification-indexer/src/ids.rs
+++ b/notification-service/notification-indexer/src/ids.rs
@@ -1,0 +1,62 @@
+//! Well-known knowledge-graph system IDs.
+//!
+//! Mirrored from the geo-sdk (`src/core/ids/{system,content}.ts`); the `grc-20`
+//! Rust crate does not yet export these as constants. Once it does, prefer
+//! importing from there. Stored as string consts with helpers that parse to a
+//! `Uuid` (these are protocol constants, so a parse failure is a programmer
+//! error and panics).
+
+use uuid::Uuid;
+
+/// "Types" relation type — entity → type membership (e.g. entity → Bounty type).
+pub const TYPES_RELATION_TYPE_ID: &str = "8f151ba4-de20-4e3c-9cb4-99ddf96f48f1";
+/// "Space" type entity — identifies space entities via Types relations.
+pub const SPACE_TYPE_ID: &str = "362c1dbd-dc64-44bb-a3c4-652f38a642d7";
+/// "Bounty" type entity.
+pub const BOUNTY_TYPE_ID: &str = "808af0ba-d588-4e33-91f0-9dd4b25e18be";
+/// "Comment" type entity.
+pub const COMMENT_TYPE_ID: &str = "82f6123a-0323-4c6c-a811-701c5bc026e9";
+/// "Reply to" property — the relation type linking a comment to the entity it
+/// replies to (comment → parent).
+pub const REPLY_TO_PROPERTY_ID: &str = "310d4a24-0e5b-451c-b215-1bfce40d0fe6";
+/// "Name" property — entity display name.
+pub const NAME_PROPERTY_ID: &str = "a126ca53-0c8e-48d5-b888-82c734c38935";
+
+macro_rules! id_fn {
+    ($fn_name:ident, $const_name:ident, $what:literal) => {
+        #[doc = concat!("Parse the ", $what, " system ID into a `Uuid`.")]
+        pub fn $fn_name() -> Uuid {
+            Uuid::parse_str($const_name).expect(concat!("valid ", $what, " system ID"))
+        }
+    };
+}
+
+id_fn!(
+    types_relation_type,
+    TYPES_RELATION_TYPE_ID,
+    "Types relation"
+);
+id_fn!(space_type, SPACE_TYPE_ID, "Space type");
+id_fn!(bounty_type, BOUNTY_TYPE_ID, "Bounty type");
+id_fn!(comment_type, COMMENT_TYPE_ID, "Comment type");
+id_fn!(reply_to_property, REPLY_TO_PROPERTY_ID, "Reply-to property");
+id_fn!(name_property, NAME_PROPERTY_ID, "Name property");
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_ids_parse() {
+        // Each helper panics on an invalid const, so calling them all validates
+        // every system ID compiles to a well-formed UUID.
+        let _ = (
+            types_relation_type(),
+            space_type(),
+            bounty_type(),
+            comment_type(),
+            reply_to_property(),
+            name_property(),
+        );
+    }
+}

--- a/notification-service/notification-indexer/src/ids.rs
+++ b/notification-service/notification-indexer/src/ids.rs
@@ -1,46 +1,36 @@
-//! Well-known knowledge-graph system IDs.
+//! `Uuid` helpers over the canonical knowledge-graph IDs.
 //!
-//! Mirrored from the geo-sdk (`src/core/ids/{system,content}.ts`); the `grc-20`
-//! Rust crate does not yet export these as constants. Once it does, prefer
-//! importing from there. Stored as string consts with helpers that parse to a
-//! `Uuid` (these are protocol constants, so a parse failure is a programmer
-//! error and panics).
+//! The ID *values* live in the `sdk` crate (`sdk::core::ids` for system IDs,
+//! `sdk::core::content_ids` for content-type IDs). This module just parses the
+//! ones the indexer needs into `Uuid`s (these are protocol constants, so a
+//! parse failure is a programmer error and panics).
 
+use sdk::core::{content_ids, ids as sdk_ids};
 use uuid::Uuid;
 
-/// "Types" relation type — entity → type membership (e.g. entity → Bounty type).
-pub const TYPES_RELATION_TYPE_ID: &str = "8f151ba4-de20-4e3c-9cb4-99ddf96f48f1";
-/// "Space" type entity — identifies space entities via Types relations.
-pub const SPACE_TYPE_ID: &str = "362c1dbd-dc64-44bb-a3c4-652f38a642d7";
-/// "Bounty" type entity.
-pub const BOUNTY_TYPE_ID: &str = "808af0ba-d588-4e33-91f0-9dd4b25e18be";
-/// "Comment" type entity.
-pub const COMMENT_TYPE_ID: &str = "82f6123a-0323-4c6c-a811-701c5bc026e9";
-/// "Reply to" property — the relation type linking a comment to the entity it
-/// replies to (comment → parent).
-pub const REPLY_TO_PROPERTY_ID: &str = "310d4a24-0e5b-451c-b215-1bfce40d0fe6";
-/// "Name" property — entity display name.
-pub const NAME_PROPERTY_ID: &str = "a126ca53-0c8e-48d5-b888-82c734c38935";
-
 macro_rules! id_fn {
-    ($fn_name:ident, $const_name:ident, $what:literal) => {
-        #[doc = concat!("Parse the ", $what, " system ID into a `Uuid`.")]
+    ($fn_name:ident, $const:expr, $what:literal) => {
+        #[doc = concat!("The ", $what, " ID as a `Uuid`.")]
         pub fn $fn_name() -> Uuid {
-            Uuid::parse_str($const_name).expect(concat!("valid ", $what, " system ID"))
+            Uuid::parse_str($const).expect(concat!("valid ", $what, " ID"))
         }
     };
 }
 
 id_fn!(
     types_relation_type,
-    TYPES_RELATION_TYPE_ID,
+    sdk_ids::TYPE_RELATION_TYPE_ID,
     "Types relation"
 );
-id_fn!(space_type, SPACE_TYPE_ID, "Space type");
-id_fn!(bounty_type, BOUNTY_TYPE_ID, "Bounty type");
-id_fn!(comment_type, COMMENT_TYPE_ID, "Comment type");
-id_fn!(reply_to_property, REPLY_TO_PROPERTY_ID, "Reply-to property");
-id_fn!(name_property, NAME_PROPERTY_ID, "Name property");
+id_fn!(name_property, sdk_ids::NAME_PROPERTY_ID, "Name property");
+id_fn!(space_type, content_ids::SPACE_TYPE_ID, "Space type");
+id_fn!(bounty_type, content_ids::BOUNTY_TYPE_ID, "Bounty type");
+id_fn!(comment_type, content_ids::COMMENT_TYPE_ID, "Comment type");
+id_fn!(
+    reply_to_property,
+    content_ids::REPLY_TO_PROPERTY_ID,
+    "Reply-to property"
+);
 
 #[cfg(test)]
 mod tests {
@@ -49,7 +39,7 @@ mod tests {
     #[test]
     fn all_ids_parse() {
         // Each helper panics on an invalid const, so calling them all validates
-        // every system ID compiles to a well-formed UUID.
+        // every ID sourced from the sdk crate is a well-formed UUID.
         let _ = (
             types_relation_type(),
             space_type(),

--- a/notification-service/notification-indexer/src/lib.rs
+++ b/notification-service/notification-indexer/src/lib.rs
@@ -7,5 +7,6 @@ pub mod consumer;
 pub mod consumer_lag;
 pub mod error;
 pub mod health;
+pub mod ids;
 pub mod models;
 pub mod storage;

--- a/notification-service/notification-indexer/src/main.rs
+++ b/notification-service/notification-indexer/src/main.rs
@@ -26,8 +26,9 @@ use notification_indexer::consumer::{
 use notification_indexer::consumer_lag::LagMonitor;
 use notification_indexer::error::IndexerError;
 use notification_indexer::models::{
-    build_rejection_event, extract_bounty_relations, handle_bounty_allocated,
-    handle_bounty_interest, handle_bounty_payout, handle_proposal_created,
+    build_rejection_event, extract_bounty_created, extract_bounty_relations,
+    extract_proposal_comments, handle_bounty_allocated, handle_bounty_created,
+    handle_bounty_interest, handle_bounty_payout, handle_proposal_comment, handle_proposal_created,
     handle_proposal_executed, handle_proposal_settings_updated, handle_proposal_updated,
     handle_proposal_voted, merge_recipients, BountyConfig, NotificationEventType,
     TargetedRecipients,
@@ -406,8 +407,36 @@ async fn async_main() -> Result<(), IndexerError> {
                                     }
                                 };
 
-                                if relations.is_empty() {
-                                    // No bounty relations in this edit — commit and continue
+                                // Also detect newly-created bounties (Phase 3a) and comments on
+                                // proposals (Phase 2a) in the same edit.
+                                let bounties_created = match extract_bounty_created(&hermes_edit) {
+                                    Ok(b) => b,
+                                    Err(e) => {
+                                        warn!(error = %e, partition = partition, offset = offset, "Failed to extract bounty-created, committing to skip");
+                                        ke_errors += 1;
+                                        if let Err(e) = kec.commit_message(&topic, partition, offset) {
+                                            error!(error = %e, "Failed to commit knowledge edits offset");
+                                        }
+                                        continue;
+                                    }
+                                };
+                                let comments = match extract_proposal_comments(&hermes_edit) {
+                                    Ok(c) => c,
+                                    Err(e) => {
+                                        warn!(error = %e, partition = partition, offset = offset, "Failed to extract proposal comments, committing to skip");
+                                        ke_errors += 1;
+                                        if let Err(e) = kec.commit_message(&topic, partition, offset) {
+                                            error!(error = %e, "Failed to commit knowledge edits offset");
+                                        }
+                                        continue;
+                                    }
+                                };
+
+                                if relations.is_empty()
+                                    && bounties_created.is_empty()
+                                    && comments.is_empty()
+                                {
+                                    // Nothing relevant in this edit — commit and continue
                                     if let Err(e) = kec.commit_message(&topic, partition, offset) {
                                         error!(error = %e, "Failed to commit knowledge edits offset");
                                     }
@@ -537,6 +566,92 @@ async fn async_main() -> Result<(), IndexerError> {
                                             }
                                         }
                                     }
+
+                                    // Phase 3a: newly-created bounties → notify the space's editors.
+                                    for info in bounties_created {
+                                        if ke_bd > 0 {
+                                            wait_for_kg_catchup(&ke_stor, info.block_number, ke_bd, ke_bd_timeout).await;
+                                        }
+                                        let mut event = handle_bounty_created(&info);
+                                        enrich_payload(&ke_stor, &mut event, info.space_id).await;
+                                        let editors = ke_stor.find_editors_for_space(info.space_id).await.map_err(|e| {
+                                            error!(error = %e, "DB error looking up editors for bounty_created, will retry");
+                                            ke_errors += 1;
+                                        })?;
+                                        if editors.is_empty() {
+                                            ke_processed += 1;
+                                            continue;
+                                        }
+                                        ke_stor.insert_notifications_for_users(&event, &editors).await.map(|count| {
+                                            if count > 0 {
+                                                info!(
+                                                    event_type = "bounty_created",
+                                                    space_id = %info.space_id,
+                                                    editors = editors.len(),
+                                                    inserted = count,
+                                                    "Inserted bounty_created notifications"
+                                                );
+                                            }
+                                            ke_processed += 1;
+                                        }).map_err(|e| {
+                                            error!(error = %e, "DB error inserting bounty_created notifications, will retry");
+                                            ke_errors += 1;
+                                        })?;
+                                    }
+
+                                    // Phase 2a: comments on a proposal → notify the proposer, but
+                                    // only when the commenter is a member/editor of the proposal's
+                                    // space. A reply whose parent is not a proposal is a general
+                                    // comment (out of scope here) and is skipped.
+                                    for mut info in comments {
+                                        if ke_bd > 0 {
+                                            wait_for_kg_catchup(&ke_stor, info.block_number, ke_bd, ke_bd_timeout).await;
+                                        }
+                                        let (proposer, proposal_space) = match ke_stor.find_proposal_proposer_and_space(info.proposal_id).await {
+                                            Ok(Some(pair)) => pair,
+                                            Ok(None) => {
+                                                ke_skipped += 1;
+                                                continue;
+                                            }
+                                            Err(e) => {
+                                                error!(error = %e, "DB error resolving proposal for comment, will retry");
+                                                ke_errors += 1;
+                                                return Err(());
+                                            }
+                                        };
+                                        let allowed = ke_stor.is_member_or_editor(proposal_space, info.commenter_space_id).await.map_err(|e| {
+                                            error!(error = %e, "DB error checking commenter membership, will retry");
+                                            ke_errors += 1;
+                                        })?;
+                                        if !allowed {
+                                            debug!(
+                                                proposal_id = %info.proposal_id,
+                                                commenter = %info.commenter_space_id,
+                                                "Comment author is not a member/editor of the proposal space, skipping"
+                                            );
+                                            ke_skipped += 1;
+                                            continue;
+                                        }
+                                        info.proposal_space_id = proposal_space;
+                                        let mut event = handle_proposal_comment(&info);
+                                        enrich_payload(&ke_stor, &mut event, proposal_space).await;
+                                        ke_stor.insert_notification_for_user(&event, proposer).await.map(|count| {
+                                            if count > 0 {
+                                                info!(
+                                                    event_type = "proposal_comment",
+                                                    proposal_id = %info.proposal_id,
+                                                    proposer = %proposer,
+                                                    inserted = count,
+                                                    "Inserted proposal_comment notification"
+                                                );
+                                            }
+                                            ke_processed += 1;
+                                        }).map_err(|e| {
+                                            error!(error = %e, "DB error inserting proposal_comment notification, will retry");
+                                            ke_errors += 1;
+                                        })?;
+                                    }
+
                                     Ok(())
                                 }.await;
 
@@ -1007,6 +1122,21 @@ async fn enrich_payload(
             // Curator display name
             if let Ok(cid) = uuid::Uuid::parse_str(&bounty.curator_space_id) {
                 bounty.curator_name = storage.lookup_entity_name(cid, cid).await;
+            }
+        }
+        NotificationData::BountyCreated(ref mut bc) => {
+            // Bounty entity name (looked up in the bounty's space).
+            if let (Ok(bid), Ok(bsid)) = (
+                uuid::Uuid::parse_str(&bc.bounty_entity_id),
+                uuid::Uuid::parse_str(&bc.bounty_space_id),
+            ) {
+                bc.bounty_name = storage.lookup_entity_name(bid, bsid).await;
+            }
+        }
+        NotificationData::Comment(ref mut comment) => {
+            // Proposal name (the proposal being commented on).
+            if let Ok(pid) = uuid::Uuid::parse_str(&comment.proposal_id) {
+                comment.proposal_name = storage.lookup_proposal_name(pid).await;
             }
         }
     }

--- a/notification-service/notification-indexer/src/main.rs
+++ b/notification-service/notification-indexer/src/main.rs
@@ -28,10 +28,10 @@ use notification_indexer::error::IndexerError;
 use notification_indexer::models::{
     build_rejection_event, extract_bounty_created, extract_bounty_relations,
     extract_proposal_comments, handle_bounty_allocated, handle_bounty_created,
-    handle_bounty_interest, handle_bounty_payout, handle_proposal_comment, handle_proposal_created,
-    handle_proposal_executed, handle_proposal_settings_updated, handle_proposal_updated,
-    handle_proposal_voted, merge_recipients, BountyConfig, NotificationEventType,
-    TargetedRecipients,
+    handle_bounty_interest, handle_bounty_payout, handle_comment, handle_proposal_comment,
+    handle_proposal_created, handle_proposal_executed, handle_proposal_settings_updated,
+    handle_proposal_updated, handle_proposal_voted, merge_recipients, BountyConfig,
+    CommentThreadInfo, NotificationEventType, TargetedRecipients,
 };
 use notification_indexer::storage::Storage;
 
@@ -599,10 +599,11 @@ async fn async_main() -> Result<(), IndexerError> {
                                         })?;
                                     }
 
-                                    // Phase 2a: comments on a proposal → notify the proposer, but
-                                    // only when the commenter is a member/editor of the proposal's
-                                    // space. A reply whose parent is not a proposal is a general
-                                    // comment (out of scope here) and is skipped.
+                                    // Comments. If the comment replies *directly* to a proposal,
+                                    // notify the proposer gated on member/editor (Phase 2a). Otherwise
+                                    // it's a general comment / reply in a thread: notify all thread
+                                    // participants plus the thread root's creator (Phase 2b).
+                                    // App servers handle per-user muting/snoozing.
                                     for mut info in comments {
                                         if ke_bd > 0 {
                                             wait_for_kg_catchup(&ke_stor, info.block_number, ke_bd, ke_bd_timeout).await;
@@ -610,7 +611,72 @@ async fn async_main() -> Result<(), IndexerError> {
                                         let (proposer, proposal_space) = match ke_stor.find_proposal_proposer_and_space(info.proposal_id).await {
                                             Ok(Some(pair)) => pair,
                                             Ok(None) => {
-                                                ke_skipped += 1;
+                                                // Phase 2b: general comment thread.
+                                                let root = ke_stor.resolve_thread_root(info.proposal_id).await.map_err(|e| {
+                                                    error!(error = %e, "DB error resolving comment thread root, will retry");
+                                                    ke_errors += 1;
+                                                })?;
+                                                let mut recipients = ke_stor.find_thread_participants(root).await.map_err(|e| {
+                                                    error!(error = %e, "DB error resolving thread participants, will retry");
+                                                    ke_errors += 1;
+                                                })?;
+                                                // Root creator: exact for proposals (proposer),
+                                                // best-effort home space otherwise.
+                                                let root_space = match ke_stor.find_proposal_proposer_and_space(root).await.map_err(|e| {
+                                                    error!(error = %e, "DB error resolving thread root proposal, will retry");
+                                                    ke_errors += 1;
+                                                })? {
+                                                    Some((root_proposer, space)) => {
+                                                        recipients.push(root_proposer);
+                                                        space
+                                                    }
+                                                    None => match ke_stor.find_entity_home_space(root).await.map_err(|e| {
+                                                        error!(error = %e, "DB error resolving thread root home space, will retry");
+                                                        ke_errors += 1;
+                                                    })? {
+                                                        Some(home) => {
+                                                            recipients.push(home);
+                                                            home
+                                                        }
+                                                        None => info.commenter_space_id,
+                                                    },
+                                                };
+                                                // Don't notify the comment's own author.
+                                                let recipients: Vec<uuid::Uuid> = merge_recipients(recipients, vec![])
+                                                    .into_iter()
+                                                    .filter(|r| *r != info.commenter_space_id)
+                                                    .collect();
+                                                if recipients.is_empty() {
+                                                    ke_processed += 1;
+                                                    continue;
+                                                }
+                                                let cinfo = CommentThreadInfo {
+                                                    comment_entity_id: info.comment_entity_id,
+                                                    parent_id: info.proposal_id,
+                                                    root_id: root,
+                                                    commenter_space_id: info.commenter_space_id,
+                                                    root_space_id: root_space,
+                                                    block_number: info.block_number,
+                                                    sequence: info.sequence,
+                                                    timestamp: info.timestamp,
+                                                };
+                                                let mut event = handle_comment(&cinfo);
+                                                enrich_payload(&ke_stor, &mut event, root_space).await;
+                                                ke_stor.insert_notifications_for_users(&event, &recipients).await.map(|count| {
+                                                    if count > 0 {
+                                                        info!(
+                                                            event_type = "comment",
+                                                            root_id = %root,
+                                                            recipients = recipients.len(),
+                                                            inserted = count,
+                                                            "Inserted comment thread notifications"
+                                                        );
+                                                    }
+                                                    ke_processed += 1;
+                                                }).map_err(|e| {
+                                                    error!(error = %e, "DB error inserting comment notifications, will retry");
+                                                    ke_errors += 1;
+                                                })?;
                                                 continue;
                                             }
                                             Err(e) => {
@@ -1137,6 +1203,12 @@ async fn enrich_payload(
             // Proposal name (the proposal being commented on).
             if let Ok(pid) = uuid::Uuid::parse_str(&comment.proposal_id) {
                 comment.proposal_name = storage.lookup_proposal_name(pid).await;
+            }
+        }
+        NotificationData::GeneralComment(ref mut c) => {
+            // Name of the thread root (looked up in its home space, == `space_id`).
+            if let Ok(rid) = uuid::Uuid::parse_str(&c.root_id) {
+                c.root_name = storage.lookup_entity_name(rid, space_id).await;
             }
         }
     }

--- a/notification-service/notification-indexer/src/main.rs
+++ b/notification-service/notification-indexer/src/main.rs
@@ -774,8 +774,13 @@ async fn async_main() -> Result<(), IndexerError> {
             }
 
             _ = heartbeat_timer.tick() => {
-                let outbox_total = sqlx::query_scalar::<_, i64>(
-                    "SELECT count(*) FROM notification_outbox"
+                // Approximate outbox size from planner statistics (reltuples) —
+                // an O(1) catalog lookup, rather than a count(*) seq-scan over
+                // the unbounded, ever-growing outbox on every heartbeat. The
+                // estimate is refreshed by autovacuum/ANALYZE; -1 before the
+                // first analyze, which is fine for a log gauge.
+                let outbox_total_approx = sqlx::query_scalar::<_, i64>(
+                    "SELECT reltuples::bigint FROM pg_class WHERE oid = 'notification_outbox'::regclass"
                 )
                 .fetch_one(storage.pool())
                 .await
@@ -788,7 +793,7 @@ async fn async_main() -> Result<(), IndexerError> {
                 info!(
                     processed = processed_count,
                     errors = error_count,
-                    outbox_total = outbox_total,
+                    outbox_total_approx = outbox_total_approx,
                     consumer_lag = consumer_lag,
                     pool_size = pool_size,
                     pool_idle = pool_idle,

--- a/notification-service/notification-indexer/src/models.rs
+++ b/notification-service/notification-indexer/src/models.rs
@@ -29,6 +29,8 @@ pub enum NotificationEventType {
     // Comment events
     /// A comment was posted on a proposal (from `knowledge.edits`).
     ProposalComment,
+    /// A comment or reply in a (non-proposal) thread (from `knowledge.edits`).
+    Comment,
 }
 
 impl NotificationEventType {
@@ -45,6 +47,7 @@ impl NotificationEventType {
             NotificationEventType::BountyPayout => "bounty_payout",
             NotificationEventType::BountyCreated => "bounty_created",
             NotificationEventType::ProposalComment => "proposal_comment",
+            NotificationEventType::Comment => "comment",
         }
     }
 
@@ -61,7 +64,7 @@ impl NotificationEventType {
             | NotificationEventType::BountyAllocated
             | NotificationEventType::BountyPayout
             | NotificationEventType::BountyCreated => "bounty",
-            NotificationEventType::ProposalComment => "comment",
+            NotificationEventType::ProposalComment | NotificationEventType::Comment => "comment",
         }
     }
 
@@ -153,6 +156,7 @@ pub enum NotificationData {
     Bounty(BountyData),
     BountyCreated(BountyCreatedData),
     Comment(CommentData),
+    GeneralComment(GeneralCommentData),
 }
 
 /// Governance-specific payload fields.
@@ -281,6 +285,23 @@ pub struct CommentData {
     pub proposal_name: Option<String>,
 }
 
+/// Payload fields for a comment/reply in a non-proposal thread (`comment`).
+#[derive(Debug, Clone, Serialize)]
+pub struct GeneralCommentData {
+    /// The comment entity that was created.
+    pub comment_entity_id: String,
+    /// The entity the comment directly replies to (a comment, for a reply, or the
+    /// commented-on entity for a top-level comment).
+    pub parent_id: String,
+    /// The thread root — the entity the whole thread hangs off of.
+    pub root_id: String,
+    /// The commenter's personal space (the `HermesEdit.space_id`).
+    pub commenter_space_id: String,
+    /// Human-readable name of the thread root (best-effort).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub root_name: Option<String>,
+}
+
 /// Result of handling a governance event: payload + idempotency key.
 #[derive(Debug)]
 pub struct NotificationEvent {
@@ -300,7 +321,8 @@ impl NotificationEvent {
             NotificationData::Governance(gov) => Uuid::parse_str(&gov.proposal_id).ok(),
             NotificationData::Bounty(_)
             | NotificationData::BountyCreated(_)
-            | NotificationData::Comment(_) => None,
+            | NotificationData::Comment(_)
+            | NotificationData::GeneralComment(_) => None,
         }
     }
 }
@@ -1188,6 +1210,58 @@ pub fn extract_proposal_comments(
         }
     }
     Ok(results)
+}
+
+// ---------------------------------------------------------------------------
+// General comment threads (Phase 2b) — comments/replies not directly on a proposal
+// ---------------------------------------------------------------------------
+
+/// A comment in a (non-proposal) thread, with the thread context resolved by the
+/// consumer. Recipients are the thread participants plus the root's creator.
+#[derive(Debug, Clone)]
+pub struct CommentThreadInfo {
+    pub comment_entity_id: Uuid,
+    /// The entity the comment directly replies to.
+    pub parent_id: Uuid,
+    /// The thread root (the "thing being commented on"), resolved by walking
+    /// `Reply to` up from `parent_id`.
+    pub root_id: Uuid,
+    /// The commenter's personal space (the edit's space).
+    pub commenter_space_id: Uuid,
+    /// The root's home/owning space — used as the payload `space_id` and for
+    /// name enrichment. Resolved by the consumer.
+    pub root_space_id: Uuid,
+    pub block_number: u64,
+    pub sequence: u64,
+    pub timestamp: u64,
+}
+
+/// Build a notification event for a comment/reply in a thread.
+pub fn handle_comment(info: &CommentThreadInfo) -> NotificationEvent {
+    let idempotency_base = format!("{}:{}:comment", info.block_number, info.sequence);
+
+    NotificationEvent {
+        event_type: NotificationEventType::Comment,
+        idempotency_key: idempotency_base,
+        payload: NotificationPayload {
+            version: PAYLOAD_VERSION,
+            event_type: NotificationEventType::Comment.as_str().to_string(),
+            category: NotificationEventType::Comment.category().to_string(),
+            space_id: info.root_space_id.to_string(),
+            user_space_id: None,
+            idempotency_key: None,
+            block_number: Some(info.block_number),
+            timestamp: Some(info.timestamp),
+            space_name: None,
+            data: NotificationData::GeneralComment(GeneralCommentData {
+                comment_entity_id: info.comment_entity_id.to_string(),
+                parent_id: info.parent_id.to_string(),
+                root_id: info.root_id.to_string(),
+                commenter_space_id: info.commenter_space_id.to_string(),
+                root_name: None,
+            }),
+        },
+    }
 }
 
 #[cfg(test)]
@@ -2860,5 +2934,36 @@ mod tests {
             json["commenter_space_id"],
             Uuid::from_bytes([0x11; 16]).to_string()
         );
+    }
+
+    #[test]
+    fn handle_comment_payload_structure() {
+        let info = CommentThreadInfo {
+            comment_entity_id: Uuid::from_bytes([0xC0; 16]),
+            parent_id: Uuid::from_bytes([0x91; 16]), // parent (a comment or entity)
+            root_id: Uuid::from_bytes([0x9A; 16]),
+            commenter_space_id: Uuid::from_bytes([0x11; 16]),
+            root_space_id: Uuid::from_bytes([0x5E; 16]),
+            block_number: 100,
+            sequence: 4,
+            timestamp: 1700000000,
+        };
+        let event = handle_comment(&info);
+        assert_eq!(event.event_type, NotificationEventType::Comment);
+        let json = serde_json::to_value(&event.payload).expect("serialize");
+        assert_eq!(json["event_type"], "comment");
+        assert_eq!(json["category"], "comment");
+        assert_eq!(json["space_id"], Uuid::from_bytes([0x5E; 16]).to_string()); // root's space
+        assert_eq!(json["root_id"], Uuid::from_bytes([0x9A; 16]).to_string());
+        assert_eq!(
+            json["comment_entity_id"],
+            Uuid::from_bytes([0xC0; 16]).to_string()
+        );
+        assert_eq!(
+            json["commenter_space_id"],
+            Uuid::from_bytes([0x11; 16]).to_string()
+        );
+        // not a governance/proposal payload
+        assert!(json.get("proposal_id").is_none());
     }
 }

--- a/notification-service/notification-indexer/src/models.rs
+++ b/notification-service/notification-indexer/src/models.rs
@@ -8,6 +8,7 @@ use serde::Serialize;
 use uuid::Uuid;
 
 use crate::error::HandlerError;
+use crate::ids;
 
 /// Notification event types sent to webhooks.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -23,6 +24,11 @@ pub enum NotificationEventType {
     BountyInterest,
     BountyAllocated,
     BountyPayout,
+    /// A new Bounty entity was created in a space (from `knowledge.edits`).
+    BountyCreated,
+    // Comment events
+    /// A comment was posted on a proposal (from `knowledge.edits`).
+    ProposalComment,
 }
 
 impl NotificationEventType {
@@ -37,6 +43,8 @@ impl NotificationEventType {
             NotificationEventType::BountyInterest => "bounty_interest",
             NotificationEventType::BountyAllocated => "bounty_allocated",
             NotificationEventType::BountyPayout => "bounty_payout",
+            NotificationEventType::BountyCreated => "bounty_created",
+            NotificationEventType::ProposalComment => "proposal_comment",
         }
     }
 
@@ -51,7 +59,9 @@ impl NotificationEventType {
             | NotificationEventType::ProposalRejected => "governance",
             NotificationEventType::BountyInterest
             | NotificationEventType::BountyAllocated
-            | NotificationEventType::BountyPayout => "bounty",
+            | NotificationEventType::BountyPayout
+            | NotificationEventType::BountyCreated => "bounty",
+            NotificationEventType::ProposalComment => "comment",
         }
     }
 
@@ -141,6 +151,8 @@ pub struct NotificationPayload {
 pub enum NotificationData {
     Governance(GovernanceData),
     Bounty(BountyData),
+    BountyCreated(BountyCreatedData),
+    Comment(CommentData),
 }
 
 /// Governance-specific payload fields.
@@ -242,6 +254,33 @@ pub struct BountyData {
     pub curator_name: Option<String>,
 }
 
+/// Payload fields for a newly-created bounty (`bounty_created`).
+#[derive(Debug, Clone, Serialize)]
+pub struct BountyCreatedData {
+    /// The new bounty entity.
+    pub bounty_entity_id: String,
+    /// The space the bounty was created in (recipients are its editors).
+    pub bounty_space_id: String,
+    /// Human-readable bounty name (best-effort, from KG values table).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bounty_name: Option<String>,
+}
+
+/// Payload fields for a comment on a proposal (`proposal_comment`).
+#[derive(Debug, Clone, Serialize)]
+pub struct CommentData {
+    /// The comment entity that was created.
+    pub comment_entity_id: String,
+    /// The proposal the comment replies to.
+    pub proposal_id: String,
+    /// The commenter's personal space (the `HermesEdit.space_id` the comment was
+    /// published from).
+    pub commenter_space_id: String,
+    /// Human-readable proposal name (best-effort, from proposals table).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proposal_name: Option<String>,
+}
+
 /// Result of handling a governance event: payload + idempotency key.
 #[derive(Debug)]
 pub struct NotificationEvent {
@@ -259,7 +298,9 @@ impl NotificationEvent {
     pub fn governance_proposal_id(&self) -> Option<Uuid> {
         match &self.payload.data {
             NotificationData::Governance(gov) => Uuid::parse_str(&gov.proposal_id).ok(),
-            NotificationData::Bounty(_) => None,
+            NotificationData::Bounty(_)
+            | NotificationData::BountyCreated(_)
+            | NotificationData::Comment(_) => None,
         }
     }
 }
@@ -950,6 +991,199 @@ pub fn extract_bounty_relations(
                     _ => continue,
                 };
                 results.push((info, event_type));
+            }
+        }
+    }
+    Ok(results)
+}
+
+// ---------------------------------------------------------------------------
+// Bounty created (Phase 3a) — a new Bounty entity created in a space
+// ---------------------------------------------------------------------------
+
+/// A new bounty detected in a `HermesEdit` (entity → Types → Bounty).
+#[derive(Debug, Clone)]
+pub struct BountyCreatedInfo {
+    pub bounty_entity_id: Uuid,
+    /// The space the bounty was created in (the edit's space). Recipients are
+    /// this space's editors.
+    pub space_id: Uuid,
+    pub block_number: u64,
+    pub sequence: u64,
+    pub timestamp: u64,
+}
+
+/// Build a notification event for a newly-created bounty.
+pub fn handle_bounty_created(info: &BountyCreatedInfo) -> NotificationEvent {
+    let idempotency_base = format!("{}:{}:bounty_created", info.block_number, info.sequence);
+
+    NotificationEvent {
+        event_type: NotificationEventType::BountyCreated,
+        idempotency_key: idempotency_base,
+        payload: NotificationPayload {
+            version: PAYLOAD_VERSION,
+            event_type: NotificationEventType::BountyCreated.as_str().to_string(),
+            category: NotificationEventType::BountyCreated.category().to_string(),
+            space_id: info.space_id.to_string(),
+            user_space_id: None,
+            idempotency_key: None,
+            block_number: Some(info.block_number),
+            timestamp: Some(info.timestamp),
+            space_name: None,
+            data: NotificationData::BountyCreated(BountyCreatedData {
+                bounty_entity_id: info.bounty_entity_id.to_string(),
+                bounty_space_id: info.space_id.to_string(),
+                bounty_name: None,
+            }),
+        },
+    }
+}
+
+/// Extract newly-created bounties from a `HermesEdit`.
+///
+/// Matches `CreateRelation` ops that type an entity as a Bounty
+/// (`relation_type == Types`, `to == Bounty type`); the relation's `from` is the
+/// new bounty entity.
+pub fn extract_bounty_created(
+    edit: &hermes_schema::pb::knowledge::HermesEdit,
+) -> Result<Vec<BountyCreatedInfo>, crate::error::HandlerError> {
+    use crate::error::HandlerError;
+
+    let meta = edit.meta.as_ref().ok_or(HandlerError::MissingMetadata)?;
+    let block_number = meta.block_number;
+    let sequence = u64::from(meta.sequence);
+    let timestamp = meta.created_at;
+    let edit_space_id = Uuid::from_slice(&edit.space_id).map_err(HandlerError::Uuid)?;
+
+    let decoded = grc_20::decode_edit(&edit.payload)
+        .map_err(|e| HandlerError::Grc20Decode(format!("{}", e)))?;
+
+    let types_rel = ids::types_relation_type();
+    let bounty_type = ids::bounty_type();
+
+    let mut results = Vec::new();
+    for op in &decoded.ops {
+        if let grc_20::Op::CreateRelation(rel) = op {
+            if Uuid::from_bytes(rel.relation_type) == types_rel
+                && Uuid::from_bytes(rel.to) == bounty_type
+            {
+                results.push(BountyCreatedInfo {
+                    bounty_entity_id: Uuid::from_bytes(rel.from),
+                    space_id: edit_space_id,
+                    block_number,
+                    sequence,
+                    timestamp,
+                });
+            }
+        }
+    }
+    Ok(results)
+}
+
+// ---------------------------------------------------------------------------
+// Proposal comments (Phase 2a) — a comment posted on a proposal
+// ---------------------------------------------------------------------------
+
+/// A comment (Comment entity that replies to a parent) detected in a
+/// `HermesEdit`. The parent is a *candidate* proposal — the consumer confirms it
+/// is a proposal (and resolves the recipient/space) via the DB.
+#[derive(Debug, Clone)]
+pub struct ProposalCommentInfo {
+    pub comment_entity_id: Uuid,
+    /// The entity the comment replies to (candidate proposal id).
+    pub proposal_id: Uuid,
+    /// The commenter's personal space (the edit's space).
+    pub commenter_space_id: Uuid,
+    /// The proposal's owning space — `nil` until resolved by the consumer
+    /// (`find_proposal_proposer_and_space`).
+    pub proposal_space_id: Uuid,
+    pub block_number: u64,
+    pub sequence: u64,
+    pub timestamp: u64,
+}
+
+/// Build a notification event for a comment on a proposal.
+pub fn handle_proposal_comment(info: &ProposalCommentInfo) -> NotificationEvent {
+    let idempotency_base = format!("{}:{}:proposal_comment", info.block_number, info.sequence);
+
+    NotificationEvent {
+        event_type: NotificationEventType::ProposalComment,
+        idempotency_key: idempotency_base,
+        payload: NotificationPayload {
+            version: PAYLOAD_VERSION,
+            event_type: NotificationEventType::ProposalComment.as_str().to_string(),
+            category: NotificationEventType::ProposalComment
+                .category()
+                .to_string(),
+            space_id: info.proposal_space_id.to_string(),
+            user_space_id: None,
+            idempotency_key: None,
+            block_number: Some(info.block_number),
+            timestamp: Some(info.timestamp),
+            space_name: None,
+            data: NotificationData::Comment(CommentData {
+                comment_entity_id: info.comment_entity_id.to_string(),
+                proposal_id: info.proposal_id.to_string(),
+                commenter_space_id: info.commenter_space_id.to_string(),
+                proposal_name: None,
+            }),
+        },
+    }
+}
+
+/// Extract proposal comments from a `HermesEdit`.
+///
+/// A comment is a `Comment`-typed entity (`Types → Comment`) with a `Reply to`
+/// relation pointing at its parent. This returns one [`ProposalCommentInfo`] per
+/// such reply; the consumer then checks whether the parent is actually a
+/// proposal (general comments on non-proposal entities are a later phase).
+pub fn extract_proposal_comments(
+    edit: &hermes_schema::pb::knowledge::HermesEdit,
+) -> Result<Vec<ProposalCommentInfo>, crate::error::HandlerError> {
+    use crate::error::HandlerError;
+    use std::collections::HashSet;
+
+    let meta = edit.meta.as_ref().ok_or(HandlerError::MissingMetadata)?;
+    let block_number = meta.block_number;
+    let sequence = u64::from(meta.sequence);
+    let timestamp = meta.created_at;
+    let edit_space_id = Uuid::from_slice(&edit.space_id).map_err(HandlerError::Uuid)?;
+
+    let decoded = grc_20::decode_edit(&edit.payload)
+        .map_err(|e| HandlerError::Grc20Decode(format!("{}", e)))?;
+
+    let types_rel = ids::types_relation_type();
+    let comment_type = ids::comment_type();
+    let reply_to = ids::reply_to_property();
+
+    // Pass 1: entities typed as Comment in this edit (from → Types → Comment).
+    let mut comment_entities: HashSet<[u8; 16]> = HashSet::new();
+    for op in &decoded.ops {
+        if let grc_20::Op::CreateRelation(rel) = op {
+            if Uuid::from_bytes(rel.relation_type) == types_rel
+                && Uuid::from_bytes(rel.to) == comment_type
+            {
+                comment_entities.insert(rel.from);
+            }
+        }
+    }
+
+    // Pass 2: Reply-to relations originating from a Comment entity → its parent.
+    let mut results = Vec::new();
+    for op in &decoded.ops {
+        if let grc_20::Op::CreateRelation(rel) = op {
+            if Uuid::from_bytes(rel.relation_type) == reply_to
+                && comment_entities.contains(&rel.from)
+            {
+                results.push(ProposalCommentInfo {
+                    comment_entity_id: Uuid::from_bytes(rel.from),
+                    proposal_id: Uuid::from_bytes(rel.to),
+                    commenter_space_id: edit_space_id,
+                    proposal_space_id: Uuid::nil(), // resolved via DB in the consumer
+                    block_number,
+                    sequence,
+                    timestamp,
+                });
             }
         }
     }
@@ -2452,5 +2686,179 @@ mod tests {
         let a = Uuid::from_bytes([0x01; 16]);
         let merged = merge_recipients(vec![a, a], vec![]);
         assert_eq!(merged, vec![a]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 3a / 2a: bounty-created + proposal-comment extraction
+    // -----------------------------------------------------------------------
+
+    /// Build a HermesEdit whose GRC-20 payload contains the given relations,
+    /// each as `(relation_type, from, to)`.
+    fn make_hermes_edit_with_relations(
+        relations: &[([u8; 16], [u8; 16], [u8; 16])],
+        space_id: [u8; 16],
+    ) -> hermes_schema::pb::knowledge::HermesEdit {
+        use std::borrow::Cow;
+
+        let ops = relations
+            .iter()
+            .enumerate()
+            .map(|(i, (relation_type, from, to))| {
+                grc_20::Op::CreateRelation(grc_20::CreateRelation {
+                    id: [i as u8 + 1; 16],
+                    relation_type: *relation_type,
+                    from: *from,
+                    from_is_value_ref: false,
+                    to: *to,
+                    to_is_value_ref: false,
+                    from_space: None,
+                    from_version: None,
+                    to_space: None,
+                    to_version: None,
+                    entity: None,
+                    position: None,
+                    context: None,
+                })
+            })
+            .collect();
+
+        let edit = grc_20::Edit {
+            id: [0x99; 16],
+            name: Cow::Borrowed("test edit"),
+            authors: vec![[0xAA; 16]],
+            created_at: 1700000000,
+            ops,
+        };
+        let payload = grc_20::encode_edit(&edit).expect("encode should succeed");
+
+        hermes_schema::pb::knowledge::HermesEdit {
+            id: vec![0x88; 16],
+            name: "test".into(),
+            payload,
+            authors: vec![vec![0xAA; 16]],
+            language: None,
+            space_id: space_id.to_vec(),
+            is_canonical: true,
+            meta: Some(make_metadata(12345, 1700000000)),
+        }
+    }
+
+    #[test]
+    fn extract_bounty_created_matches_types_to_bounty() {
+        let types = ids::types_relation_type().into_bytes();
+        let bounty_type = ids::bounty_type().into_bytes();
+        // from = the new bounty entity, to = Bounty type.
+        let edit = make_hermes_edit_with_relations(
+            &[(types, [0xB0; 16], bounty_type)],
+            [0x5E; 16], // edit space
+        );
+        let out = extract_bounty_created(&edit).expect("extract");
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].bounty_entity_id, Uuid::from_bytes([0xB0; 16]));
+        assert_eq!(out[0].space_id, Uuid::from_bytes([0x5E; 16]));
+        assert_eq!(out[0].block_number, 12345);
+    }
+
+    #[test]
+    fn extract_bounty_created_ignores_other_types_and_relations() {
+        let types = ids::types_relation_type().into_bytes();
+        // A Types relation to a *non-bounty* type, plus an unrelated relation.
+        let edit = make_hermes_edit_with_relations(
+            &[
+                (types, [0xB0; 16], [0xAA; 16]),      // Types -> some other type
+                ([0xCC; 16], [0xB0; 16], [0xDD; 16]), // non-Types relation
+            ],
+            [0x5E; 16],
+        );
+        let out = extract_bounty_created(&edit).expect("extract");
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn extract_proposal_comments_matches_comment_reply() {
+        let types = ids::types_relation_type().into_bytes();
+        let comment_type = ids::comment_type().into_bytes();
+        let reply_to = ids::reply_to_property().into_bytes();
+        let comment_entity = [0xC0; 16];
+        let proposal = [0x9A; 16];
+        // Comment entity typed as Comment, replying to the proposal.
+        let edit = make_hermes_edit_with_relations(
+            &[
+                (types, comment_entity, comment_type),
+                (reply_to, comment_entity, proposal),
+            ],
+            [0x5E; 16], // commenter's personal space
+        );
+        let out = extract_proposal_comments(&edit).expect("extract");
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].comment_entity_id, Uuid::from_bytes(comment_entity));
+        assert_eq!(out[0].proposal_id, Uuid::from_bytes(proposal));
+        assert_eq!(out[0].commenter_space_id, Uuid::from_bytes([0x5E; 16]));
+        assert_eq!(out[0].proposal_space_id, Uuid::nil()); // resolved later via DB
+    }
+
+    #[test]
+    fn extract_proposal_comments_ignores_reply_from_non_comment() {
+        let reply_to = ids::reply_to_property().into_bytes();
+        // A Reply-to relation whose `from` is NOT typed as a Comment in this edit.
+        let edit =
+            make_hermes_edit_with_relations(&[(reply_to, [0xC0; 16], [0x9A; 16])], [0x5E; 16]);
+        let out = extract_proposal_comments(&edit).expect("extract");
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn handle_bounty_created_payload_structure() {
+        let info = BountyCreatedInfo {
+            bounty_entity_id: Uuid::from_bytes([0xB0; 16]),
+            space_id: Uuid::from_bytes([0x5E; 16]),
+            block_number: 100,
+            sequence: 0,
+            timestamp: 1700000000,
+        };
+        let event = handle_bounty_created(&info);
+        assert_eq!(event.event_type, NotificationEventType::BountyCreated);
+        let json = serde_json::to_value(&event.payload).expect("serialize");
+        assert_eq!(json["event_type"], "bounty_created");
+        assert_eq!(json["category"], "bounty");
+        assert_eq!(
+            json["bounty_entity_id"],
+            Uuid::from_bytes([0xB0; 16]).to_string()
+        );
+        assert_eq!(json["space_id"], Uuid::from_bytes([0x5E; 16]).to_string());
+        // governance/comment fields absent
+        assert!(json.get("proposal_id").is_none());
+        assert!(json.get("comment_entity_id").is_none());
+    }
+
+    #[test]
+    fn handle_proposal_comment_payload_structure() {
+        let info = ProposalCommentInfo {
+            comment_entity_id: Uuid::from_bytes([0xC0; 16]),
+            proposal_id: Uuid::from_bytes([0x9A; 16]),
+            commenter_space_id: Uuid::from_bytes([0x11; 16]),
+            proposal_space_id: Uuid::from_bytes([0x5E; 16]),
+            block_number: 100,
+            sequence: 2,
+            timestamp: 1700000000,
+        };
+        let event = handle_proposal_comment(&info);
+        assert_eq!(event.event_type, NotificationEventType::ProposalComment);
+        let json = serde_json::to_value(&event.payload).expect("serialize");
+        assert_eq!(json["event_type"], "proposal_comment");
+        assert_eq!(json["category"], "comment");
+        assert_eq!(json["space_id"], Uuid::from_bytes([0x5E; 16]).to_string()); // proposal's space
+        assert_eq!(
+            json["proposal_id"],
+            Uuid::from_bytes([0x9A; 16]).to_string()
+        );
+        assert_eq!(
+            json["comment_entity_id"],
+            Uuid::from_bytes([0xC0; 16]).to_string()
+        );
+        assert_eq!(
+            json["commenter_space_id"],
+            Uuid::from_bytes([0x11; 16]).to_string()
+        );
     }
 }

--- a/notification-service/notification-indexer/src/models.rs
+++ b/notification-service/notification-indexer/src/models.rs
@@ -859,7 +859,13 @@ pub struct BountyRelationInfo {
 
 /// Build a notification event for a bounty interest expression.
 pub fn handle_bounty_interest(info: &BountyRelationInfo) -> NotificationEvent {
-    let idempotency_base = format!("{}:{}:bounty_interest", info.block_number, info.sequence);
+    // Include relation_id: a single edit can carry multiple interest relations,
+    // all sharing (block, sequence). Without the relation id they'd hash to the
+    // same per-user key and all but one would be silently dropped on insert.
+    let idempotency_base = format!(
+        "{}:{}:bounty_interest:{}",
+        info.block_number, info.sequence, info.relation_id
+    );
 
     NotificationEvent {
         event_type: NotificationEventType::BountyInterest,
@@ -890,7 +896,12 @@ pub fn handle_bounty_interest(info: &BountyRelationInfo) -> NotificationEvent {
 
 /// Build a notification event for a bounty allocation.
 pub fn handle_bounty_allocated(info: &BountyRelationInfo) -> NotificationEvent {
-    let idempotency_base = format!("{}:{}:bounty_allocated", info.block_number, info.sequence);
+    // Include relation_id — a single edit can carry multiple allocation
+    // relations sharing (block, sequence); see handle_bounty_interest.
+    let idempotency_base = format!(
+        "{}:{}:bounty_allocated:{}",
+        info.block_number, info.sequence, info.relation_id
+    );
 
     NotificationEvent {
         event_type: NotificationEventType::BountyAllocated,
@@ -923,7 +934,12 @@ pub fn handle_bounty_allocated(info: &BountyRelationInfo) -> NotificationEvent {
 
 /// Build a notification event for a bounty payout.
 pub fn handle_bounty_payout(info: &BountyRelationInfo) -> NotificationEvent {
-    let idempotency_base = format!("{}:{}:bounty_payout", info.block_number, info.sequence);
+    // Include relation_id — a single edit can carry multiple payout relations
+    // sharing (block, sequence); see handle_bounty_interest.
+    let idempotency_base = format!(
+        "{}:{}:bounty_payout:{}",
+        info.block_number, info.sequence, info.relation_id
+    );
 
     NotificationEvent {
         event_type: NotificationEventType::BountyPayout,
@@ -1037,7 +1053,13 @@ pub struct BountyCreatedInfo {
 
 /// Build a notification event for a newly-created bounty.
 pub fn handle_bounty_created(info: &BountyCreatedInfo) -> NotificationEvent {
-    let idempotency_base = format!("{}:{}:bounty_created", info.block_number, info.sequence);
+    // Include bounty_entity_id: extract_bounty_created can return several new
+    // bounties from one edit, all sharing (block, sequence). The entity id makes
+    // each logical event unique so none are dropped as false duplicates.
+    let idempotency_base = format!(
+        "{}:{}:bounty_created:{}",
+        info.block_number, info.sequence, info.bounty_entity_id
+    );
 
     NotificationEvent {
         event_type: NotificationEventType::BountyCreated,
@@ -1126,7 +1148,13 @@ pub struct ProposalCommentInfo {
 
 /// Build a notification event for a comment on a proposal.
 pub fn handle_proposal_comment(info: &ProposalCommentInfo) -> NotificationEvent {
-    let idempotency_base = format!("{}:{}:proposal_comment", info.block_number, info.sequence);
+    // Include comment_entity_id: extract_proposal_comments can return multiple
+    // comments from one edit, all sharing (block, sequence). The comment entity
+    // id makes each logical event unique so none are dropped as false duplicates.
+    let idempotency_base = format!(
+        "{}:{}:proposal_comment:{}",
+        info.block_number, info.sequence, info.comment_entity_id
+    );
 
     NotificationEvent {
         event_type: NotificationEventType::ProposalComment,
@@ -1238,7 +1266,13 @@ pub struct CommentThreadInfo {
 
 /// Build a notification event for a comment/reply in a thread.
 pub fn handle_comment(info: &CommentThreadInfo) -> NotificationEvent {
-    let idempotency_base = format!("{}:{}:comment", info.block_number, info.sequence);
+    // Include comment_entity_id: a single edit can carry multiple thread
+    // comments sharing (block, sequence). The comment entity id (globally unique)
+    // makes each logical event unique so none are dropped as false duplicates.
+    let idempotency_base = format!(
+        "{}:{}:comment:{}",
+        info.block_number, info.sequence, info.comment_entity_id
+    );
 
     NotificationEvent {
         event_type: NotificationEventType::Comment,
@@ -1720,7 +1754,10 @@ mod tests {
         let event = handle_bounty_interest(&info);
 
         assert_eq!(event.event_type, NotificationEventType::BountyInterest);
-        assert_eq!(event.idempotency_key, "50000:7:bounty_interest");
+        assert_eq!(
+            event.idempotency_key,
+            format!("50000:7:bounty_interest:{}", info.relation_id)
+        );
 
         let json = serde_json::to_value(&event.payload).expect("should serialize");
         assert_eq!(json["event_type"], "bounty_interest");
@@ -1748,7 +1785,10 @@ mod tests {
         let event = handle_bounty_allocated(&info);
 
         assert_eq!(event.event_type, NotificationEventType::BountyAllocated);
-        assert_eq!(event.idempotency_key, "50000:7:bounty_allocated");
+        assert_eq!(
+            event.idempotency_key,
+            format!("50000:7:bounty_allocated:{}", info.relation_id)
+        );
 
         let json = serde_json::to_value(&event.payload).expect("should serialize");
         assert_eq!(json["event_type"], "bounty_allocated");
@@ -1768,7 +1808,10 @@ mod tests {
         let event = handle_bounty_payout(&info);
 
         assert_eq!(event.event_type, NotificationEventType::BountyPayout);
-        assert_eq!(event.idempotency_key, "50000:7:bounty_payout");
+        assert_eq!(
+            event.idempotency_key,
+            format!("50000:7:bounty_payout:{}", info.relation_id)
+        );
 
         let json = serde_json::to_value(&event.payload).expect("should serialize");
         assert_eq!(json["event_type"], "bounty_payout");
@@ -1892,7 +1935,10 @@ mod tests {
         let event = handle_bounty_interest(&info);
 
         assert_eq!(event.event_type, NotificationEventType::BountyInterest);
-        assert_eq!(event.idempotency_key, "50000:7:bounty_interest");
+        assert_eq!(
+            event.idempotency_key,
+            format!("50000:7:bounty_interest:{}", info.relation_id)
+        );
 
         let json = serde_json::to_value(&event.payload).expect("should serialize");
         assert_eq!(json["event_type"], "bounty_interest");
@@ -1943,7 +1989,10 @@ mod tests {
         let event = handle_bounty_allocated(&info);
 
         assert_eq!(event.event_type, NotificationEventType::BountyAllocated);
-        assert_eq!(event.idempotency_key, "50000:7:bounty_allocated");
+        assert_eq!(
+            event.idempotency_key,
+            format!("50000:7:bounty_allocated:{}", info.relation_id)
+        );
 
         let json = serde_json::to_value(&event.payload).expect("should serialize");
         assert_eq!(json["event_type"], "bounty_allocated");
@@ -2001,7 +2050,10 @@ mod tests {
         let event = handle_bounty_payout(&info);
 
         assert_eq!(event.event_type, NotificationEventType::BountyPayout);
-        assert_eq!(event.idempotency_key, "50000:7:bounty_payout");
+        assert_eq!(
+            event.idempotency_key,
+            format!("50000:7:bounty_payout:{}", info.relation_id)
+        );
 
         let json = serde_json::to_value(&event.payload).expect("should serialize");
         assert_eq!(json["event_type"], "bounty_payout");
@@ -2082,7 +2134,7 @@ mod tests {
 
     #[test]
     fn test_bounty_idempotency_keys_differ_by_block() {
-        let mut info1 = make_bounty_info();
+        let info1 = make_bounty_info();
         let mut info2 = make_bounty_info();
         info2.block_number = 50001;
 
@@ -2093,13 +2145,114 @@ mod tests {
 
     #[test]
     fn test_bounty_idempotency_keys_differ_by_sequence() {
-        let mut info1 = make_bounty_info();
+        let info1 = make_bounty_info();
         let mut info2 = make_bounty_info();
         info2.sequence = 8;
 
         let event1 = handle_bounty_interest(&info1);
         let event2 = handle_bounty_interest(&info2);
         assert_ne!(event1.idempotency_key, event2.idempotency_key);
+    }
+
+    // -----------------------------------------------------------------------
+    // Same-edit uniqueness: multiple logical events of the same type from one
+    // HermesEdit share (block, sequence) but must NOT collide on the idempotency
+    // key, or all-but-one would be silently dropped by the outbox ON CONFLICT.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_bounty_relations_same_edit_differ_by_relation_id() {
+        // Two interest relations in one edit: same block/sequence, different
+        // relation_id (and even the same bounty/curator) must yield distinct keys.
+        let mut a = make_bounty_info();
+        let mut b = make_bounty_info();
+        a.relation_id = Uuid::from_bytes([0xA1; 16]);
+        b.relation_id = Uuid::from_bytes([0xB2; 16]);
+
+        for build in [
+            handle_bounty_interest,
+            handle_bounty_allocated,
+            handle_bounty_payout,
+        ] {
+            let ka = build(&a).idempotency_key;
+            let kb = build(&b).idempotency_key;
+            assert_ne!(
+                ka, kb,
+                "same-edit relations must not share an idempotency key"
+            );
+            assert!(ka.contains(&a.relation_id.to_string()));
+        }
+    }
+
+    #[test]
+    fn test_bounty_created_same_edit_differ_by_entity() {
+        // Two bounties created in one edit must not collide.
+        let base = BountyCreatedInfo {
+            bounty_entity_id: Uuid::from_bytes([0x01; 16]),
+            space_id: Uuid::from_bytes([0x5E; 16]),
+            block_number: 100,
+            sequence: 0,
+            timestamp: 1700000000,
+        };
+        let other = BountyCreatedInfo {
+            bounty_entity_id: Uuid::from_bytes([0x02; 16]),
+            ..base.clone()
+        };
+        let k1 = handle_bounty_created(&base).idempotency_key;
+        let k2 = handle_bounty_created(&other).idempotency_key;
+        assert_ne!(k1, k2);
+        assert_eq!(
+            k1,
+            format!("100:0:bounty_created:{}", base.bounty_entity_id)
+        );
+    }
+
+    #[test]
+    fn test_proposal_comment_same_edit_differ_by_comment() {
+        // Two proposal comments in one edit must not collide.
+        let base = ProposalCommentInfo {
+            comment_entity_id: Uuid::from_bytes([0xC1; 16]),
+            proposal_id: Uuid::from_bytes([0x9A; 16]),
+            commenter_space_id: Uuid::from_bytes([0x11; 16]),
+            proposal_space_id: Uuid::from_bytes([0x5E; 16]),
+            block_number: 100,
+            sequence: 2,
+            timestamp: 1700000000,
+        };
+        let other = ProposalCommentInfo {
+            comment_entity_id: Uuid::from_bytes([0xC2; 16]),
+            ..base.clone()
+        };
+        let k1 = handle_proposal_comment(&base).idempotency_key;
+        let k2 = handle_proposal_comment(&other).idempotency_key;
+        assert_ne!(k1, k2);
+        assert_eq!(
+            k1,
+            format!("100:2:proposal_comment:{}", base.comment_entity_id)
+        );
+    }
+
+    #[test]
+    fn test_comment_thread_same_edit_differ_by_comment() {
+        // Two thread comments in one edit must not collide.
+        let base = CommentThreadInfo {
+            comment_entity_id: Uuid::from_bytes([0xC1; 16]),
+            parent_id: Uuid::from_bytes([0x91; 16]),
+            root_id: Uuid::from_bytes([0x9A; 16]),
+            commenter_space_id: Uuid::from_bytes([0x11; 16]),
+            root_space_id: Uuid::from_bytes([0x5E; 16]),
+            block_number: 100,
+            sequence: 4,
+            timestamp: 1700000000,
+        };
+        let other = CommentThreadInfo {
+            comment_entity_id: Uuid::from_bytes([0xC2; 16]),
+            ..base.clone()
+        };
+        let k1 = handle_comment(&base).idempotency_key;
+        let k2 = handle_comment(&other).idempotency_key;
+        assert_ne!(k1, k2);
+        assert_eq!(k1, format!("100:4:comment:{}", base.comment_entity_id));
     }
 
     // -----------------------------------------------------------------------
@@ -2965,5 +3118,186 @@ mod tests {
         );
         // not a governance/proposal payload
         assert!(json.get("proposal_id").is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Adversarial: try to BREAK idempotency by packing multiple same-type
+    // events into one HermesEdit payload (they share block+sequence). These go
+    // through the real decode -> extract -> handle path, not hand-built Info
+    // structs, so they guard the fix against regressions at the seam where the
+    // old {block}:{seq}:{event_type} key collided.
+    // -----------------------------------------------------------------------
+
+    /// Wrap a set of GRC-20 ops into a HermesEdit at a fixed block/sequence.
+    fn make_edit_with_ops(
+        ops: Vec<grc_20::Op<'static>>,
+        space_id: [u8; 16],
+        block_number: u64,
+        sequence: u32,
+    ) -> hermes_schema::pb::knowledge::HermesEdit {
+        use std::borrow::Cow;
+        let edit = grc_20::Edit {
+            id: [0x77; 16],
+            name: Cow::Borrowed("adversarial edit"),
+            authors: vec![[0xAA; 16]],
+            created_at: 1700000000,
+            ops,
+        };
+        let payload = grc_20::encode_edit(&edit).expect("encode should succeed");
+        hermes_schema::pb::knowledge::HermesEdit {
+            id: vec![0x77; 16],
+            name: "adversarial".into(),
+            payload,
+            authors: vec![vec![0xAA; 16]],
+            language: None,
+            space_id: space_id.to_vec(),
+            is_canonical: true,
+            meta: Some(BlockchainMetadata {
+                block_number,
+                created_at: 1700000000,
+                created_by: vec![],
+                cursor: String::new(),
+                sequence,
+                is_last: false,
+            }),
+        }
+    }
+
+    fn create_relation(
+        id: [u8; 16],
+        relation_type: [u8; 16],
+        from: [u8; 16],
+        to: [u8; 16],
+    ) -> grc_20::Op<'static> {
+        grc_20::Op::CreateRelation(grc_20::CreateRelation {
+            id,
+            relation_type,
+            from,
+            from_is_value_ref: false,
+            to,
+            to_is_value_ref: false,
+            from_space: None,
+            from_version: None,
+            to_space: None,
+            to_version: None,
+            entity: None,
+            position: None,
+            context: None,
+        })
+    }
+
+    #[test]
+    fn idempotency_break_many_bounty_interest_in_one_edit() {
+        // Three interest relations in ONE edit for the SAME bounty by the SAME
+        // curator — the worst case: everything identical except relation_id.
+        let config = BountyConfig::default();
+        let interest = *Uuid::parse_str(DEFAULT_INTEREST_TYPE_ID)
+            .expect("valid")
+            .as_bytes();
+        let bounty = [0x20; 16];
+        let curator = [0x10; 16];
+        let ops = vec![
+            create_relation([0x01; 16], interest, curator, bounty),
+            create_relation([0x02; 16], interest, curator, bounty),
+            create_relation([0x03; 16], interest, curator, bounty),
+        ];
+        let edit = make_edit_with_ops(ops, [0x40; 16], 100, 0);
+
+        let relations = extract_bounty_relations(&edit, &config).expect("extract");
+        assert_eq!(relations.len(), 3, "all three interest relations extracted");
+
+        let keys: std::collections::HashSet<String> = relations
+            .iter()
+            .map(|(info, _)| handle_bounty_interest(info).idempotency_key)
+            .collect();
+        assert_eq!(
+            keys.len(),
+            3,
+            "three same-edit interest relations must yield three distinct keys"
+        );
+        // All share the old prefix — proving relation_id is what disambiguates.
+        assert!(keys.iter().all(|k| k.starts_with("100:0:bounty_interest:")));
+    }
+
+    #[test]
+    fn idempotency_break_many_bounties_created_in_one_edit() {
+        let types = crate::ids::types_relation_type().into_bytes();
+        let bounty_type = crate::ids::bounty_type().into_bytes();
+        // Four new bounties typed in one edit.
+        let ops: Vec<grc_20::Op> = (0u8..4)
+            .map(|i| create_relation([0xF0 + i; 16], types, [0xB0 + i; 16], bounty_type))
+            .collect();
+        let edit = make_edit_with_ops(ops, [0x40; 16], 200, 1);
+
+        let created = extract_bounty_created(&edit).expect("extract");
+        assert_eq!(created.len(), 4);
+
+        let keys: std::collections::HashSet<String> = created
+            .iter()
+            .map(|info| handle_bounty_created(info).idempotency_key)
+            .collect();
+        assert_eq!(
+            keys.len(),
+            4,
+            "four bounties created in one edit must yield four distinct keys"
+        );
+        assert!(keys.iter().all(|k| k.starts_with("200:1:bounty_created:")));
+    }
+
+    #[test]
+    fn idempotency_break_many_comments_in_one_edit() {
+        let types = crate::ids::types_relation_type().into_bytes();
+        let comment_type = crate::ids::comment_type().into_bytes();
+        let reply_to = crate::ids::reply_to_property().into_bytes();
+        let parent = [0x9A; 16];
+        // Two distinct comment entities, each typed as Comment and replying to
+        // the same parent, in one edit.
+        let c1 = [0xC1; 16];
+        let c2 = [0xC2; 16];
+        let ops = vec![
+            create_relation([0x01; 16], types, c1, comment_type),
+            create_relation([0x02; 16], reply_to, c1, parent),
+            create_relation([0x03; 16], types, c2, comment_type),
+            create_relation([0x04; 16], reply_to, c2, parent),
+        ];
+        let edit = make_edit_with_ops(ops, [0x50; 16], 300, 2);
+
+        let comments = extract_proposal_comments(&edit).expect("extract");
+        assert_eq!(comments.len(), 2, "both comments extracted");
+
+        // proposal_comment path
+        let pc_keys: std::collections::HashSet<String> = comments
+            .iter()
+            .map(|info| handle_proposal_comment(info).idempotency_key)
+            .collect();
+        assert_eq!(
+            pc_keys.len(),
+            2,
+            "two comments -> two proposal_comment keys"
+        );
+        assert!(pc_keys
+            .iter()
+            .all(|k| k.starts_with("300:2:proposal_comment:")));
+
+        // general comment-thread path (Phase 2b / #706) — same edit, must also
+        // produce distinct keys.
+        let thread_keys: std::collections::HashSet<String> = comments
+            .iter()
+            .map(|info| {
+                let cinfo = CommentThreadInfo {
+                    comment_entity_id: info.comment_entity_id,
+                    parent_id: info.proposal_id,
+                    root_id: Uuid::from_bytes(parent),
+                    commenter_space_id: info.commenter_space_id,
+                    root_space_id: Uuid::from_bytes([0x5E; 16]),
+                    block_number: info.block_number,
+                    sequence: info.sequence,
+                    timestamp: info.timestamp,
+                };
+                handle_comment(&cinfo).idempotency_key
+            })
+            .collect();
+        assert_eq!(thread_keys.len(), 2, "two comments -> two comment keys");
+        assert!(thread_keys.iter().all(|k| k.starts_with("300:2:comment:")));
     }
 }

--- a/notification-service/notification-indexer/src/storage.rs
+++ b/notification-service/notification-indexer/src/storage.rs
@@ -9,20 +9,8 @@ use sqlx::{PgPool, Row};
 use uuid::Uuid;
 
 use crate::error::StorageError;
+use crate::ids;
 use crate::models::NotificationEvent;
-
-// Well-known system IDs from the knowledge graph.
-// Sourced from geo-sdk (src/core/ids/system.ts) and curator-app (packages/curator-utils/src/ids.ts).
-// These are being upstreamed to the grc-20 Rust crate — once available, import from there instead.
-
-/// The "Types" relation type ID — used for entity type membership (e.g. entity → Bounty type).
-const TYPE_RELATION_TYPE_ID: &str = "8f151ba4-de20-4e3c-9cb4-99ddf96f48f1";
-/// The "Space" type entity ID — used to identify space entities via Types relations.
-const SPACE_TYPE_ID: &str = "362c1dbd-dc64-44bb-a3c4-652f38a642d7";
-/// The "Bounty" type entity ID — used to identify bounty entities via Types relations.
-const BOUNTY_TYPE_ID: &str = "808af0ba-d588-4e33-91f0-9dd4b25e18be";
-/// The "Name" property ID — used to look up entity display names.
-const NAME_PROPERTY_ID: &str = "a126ca53-0c8e-48d5-b888-82c734c38935";
 
 /// Storage for notification-related database operations.
 pub struct Storage {
@@ -202,9 +190,6 @@ impl Storage {
     /// that has a Types relation pointing from the entity to SPACE_TYPE.
     #[instrument(name = "notification_indexer.storage.lookup_entity_space", skip(self))]
     pub async fn lookup_entity_space(&self, entity_id: Uuid) -> Result<Option<Uuid>, StorageError> {
-        let type_rel_id =
-            Uuid::parse_str(TYPE_RELATION_TYPE_ID).expect("valid TYPE_RELATION_TYPE_ID");
-        let space_type_id = Uuid::parse_str(SPACE_TYPE_ID).expect("valid SPACE_TYPE_ID");
         let result = sqlx::query_scalar::<_, Uuid>(
             r#"
             SELECT r.space_id
@@ -217,8 +202,8 @@ impl Storage {
             "#,
         )
         .bind(entity_id)
-        .bind(type_rel_id)
-        .bind(space_type_id)
+        .bind(ids::types_relation_type())
+        .bind(ids::space_type())
         .fetch_optional(&self.pool)
         .await?;
         Ok(result)
@@ -234,9 +219,6 @@ impl Storage {
         &self,
         bounty_entity_id: Uuid,
     ) -> Result<Option<Uuid>, StorageError> {
-        let type_rel_id =
-            Uuid::parse_str(TYPE_RELATION_TYPE_ID).expect("valid TYPE_RELATION_TYPE_ID");
-        let bounty_type_id = Uuid::parse_str(BOUNTY_TYPE_ID).expect("valid BOUNTY_TYPE_ID");
         let result = sqlx::query_scalar::<_, Uuid>(
             r#"
             SELECT space_id
@@ -248,8 +230,8 @@ impl Storage {
             "#,
         )
         .bind(bounty_entity_id)
-        .bind(type_rel_id)
-        .bind(bounty_type_id)
+        .bind(ids::types_relation_type())
+        .bind(ids::bounty_type())
         .fetch_optional(&self.pool)
         .await?;
         Ok(result)
@@ -317,6 +299,55 @@ impl Storage {
         Ok(rows.iter().map(|r| r.get("voter_id")).collect())
     }
 
+    /// Resolve a proposal's proposer (`proposed_by`) and owning `space_id`.
+    ///
+    /// Returns `None` if no proposal with that id exists — which is how the
+    /// proposal-comment path distinguishes "comment replies to a proposal" from
+    /// "comment replies to some other entity" (the latter is a general comment,
+    /// handled in a later phase). The proposer is the recipient; the space
+    /// scopes the "commenter must be a member/editor" filter.
+    #[instrument(
+        name = "notification_indexer.storage.find_proposal_proposer_and_space",
+        skip(self)
+    )]
+    pub async fn find_proposal_proposer_and_space(
+        &self,
+        proposal_id: Uuid,
+    ) -> Result<Option<(Uuid, Uuid)>, StorageError> {
+        let row = sqlx::query("SELECT proposed_by, space_id FROM proposals WHERE id = $1")
+            .bind(proposal_id)
+            .fetch_optional(&self.pool)
+            .await?;
+        Ok(row.map(|r| (r.get("proposed_by"), r.get("space_id"))))
+    }
+
+    /// Whether `user_space_id` is a member or editor of `space_id`.
+    ///
+    /// Gates proposal-comment notifications on the commenter being a member or
+    /// editor of the proposal's space (per the product requirement that proposal
+    /// comments come from a space member/editor).
+    #[instrument(name = "notification_indexer.storage.is_member_or_editor", skip(self))]
+    pub async fn is_member_or_editor(
+        &self,
+        space_id: Uuid,
+        user_space_id: Uuid,
+    ) -> Result<bool, StorageError> {
+        let exists = sqlx::query_scalar::<_, bool>(
+            r#"
+            SELECT EXISTS (
+                SELECT 1 FROM editors WHERE space_id = $1 AND member_space_id = $2
+                UNION ALL
+                SELECT 1 FROM members WHERE space_id = $1 AND member_space_id = $2
+            )
+            "#,
+        )
+        .bind(space_id)
+        .bind(user_space_id)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(exists)
+    }
+
     /// Find proposals that have expired (end_time < now) without being executed,
     /// and for which we haven't yet sent a rejection notification.
     ///
@@ -369,7 +400,6 @@ impl Storage {
     ///
     /// Returns `None` if the entity has no name or the query fails.
     pub async fn lookup_entity_name(&self, entity_id: Uuid, space_id: Uuid) -> Option<String> {
-        let name_prop_id = Uuid::parse_str(NAME_PROPERTY_ID).expect("valid NAME_PROPERTY_ID");
         sqlx::query_scalar::<_, String>(
             r#"
             SELECT v.text
@@ -383,7 +413,7 @@ impl Storage {
         )
         .bind(entity_id)
         .bind(space_id)
-        .bind(name_prop_id)
+        .bind(ids::name_property())
         .fetch_optional(&self.pool)
         .await
         .ok()

--- a/notification-service/notification-indexer/src/storage.rs
+++ b/notification-service/notification-indexer/src/storage.rs
@@ -198,6 +198,7 @@ impl Storage {
             WHERE r.from_entity_id = $1
               AND r.type_id = $2
               AND r.to_entity_id = $3
+            ORDER BY r.space_id
             LIMIT 1
             "#,
         )
@@ -226,6 +227,7 @@ impl Storage {
             WHERE from_entity_id = $1
               AND type_id = $2
               AND to_entity_id = $3
+            ORDER BY space_id
             LIMIT 1
             "#,
         )
@@ -363,8 +365,11 @@ impl Storage {
         let reply_to = ids::reply_to_property();
         let mut current = parent;
         for _ in 0..64 {
+            // Deterministic parent choice: an entity could carry multiple `Reply to`
+            // relations; ORDER BY keeps the resolved thread root stable across runs.
             let next: Option<Uuid> = sqlx::query_scalar::<_, Uuid>(
-                "SELECT to_entity_id FROM relations WHERE type_id = $1 AND from_entity_id = $2 LIMIT 1",
+                "SELECT to_entity_id FROM relations WHERE type_id = $1 AND from_entity_id = $2 \
+                 ORDER BY to_entity_id LIMIT 1",
             )
             .bind(reply_to)
             .bind(current)
@@ -418,6 +423,11 @@ impl Storage {
     /// this equals the creator. Used as the root-creator recipient for
     /// non-proposal comment threads (proposals resolve their creator exactly via
     /// `find_proposal_proposer_and_space`).
+    ///
+    /// An entity may have several `Types` relations (multi-typed, or re-typed in
+    /// a later edit). `ORDER BY space_id` makes the choice deterministic across
+    /// runs — still best-effort, but stable, so recipients and the payload
+    /// `space_id` don't flap between replays.
     #[instrument(
         name = "notification_indexer.storage.find_entity_home_space",
         skip(self)
@@ -427,7 +437,8 @@ impl Storage {
         entity_id: Uuid,
     ) -> Result<Option<Uuid>, StorageError> {
         let result = sqlx::query_scalar::<_, Uuid>(
-            "SELECT space_id FROM relations WHERE from_entity_id = $1 AND type_id = $2 LIMIT 1",
+            "SELECT space_id FROM relations WHERE from_entity_id = $1 AND type_id = $2 \
+             ORDER BY space_id LIMIT 1",
         )
         .bind(entity_id)
         .bind(ids::types_relation_type())
@@ -460,6 +471,7 @@ impl Storage {
             WHERE p.end_time < EXTRACT(EPOCH FROM now())
               AND p.executed_at IS NULL
               AND o.id IS NULL
+            ORDER BY p.end_time ASC, p.id
             LIMIT $1
             "#,
         )

--- a/notification-service/notification-indexer/src/storage.rs
+++ b/notification-service/notification-indexer/src/storage.rs
@@ -348,6 +348,94 @@ impl Storage {
         Ok(exists)
     }
 
+    // -----------------------------------------------------------------------
+    // Comment-thread resolution (Phase 2b)
+    // -----------------------------------------------------------------------
+
+    /// Walk `Reply to` relations upward from `parent` to the thread root.
+    ///
+    /// A comment replies to its parent; that parent may itself be a comment that
+    /// replies to another, and so on. The root is the first ancestor with no
+    /// outgoing `Reply to` relation (the actual "thing being commented on").
+    /// Bounded to a fixed depth as a cycle/abuse guard.
+    #[instrument(name = "notification_indexer.storage.resolve_thread_root", skip(self))]
+    pub async fn resolve_thread_root(&self, parent: Uuid) -> Result<Uuid, StorageError> {
+        let reply_to = ids::reply_to_property();
+        let mut current = parent;
+        for _ in 0..64 {
+            let next: Option<Uuid> = sqlx::query_scalar::<_, Uuid>(
+                "SELECT to_entity_id FROM relations WHERE type_id = $1 AND from_entity_id = $2 LIMIT 1",
+            )
+            .bind(reply_to)
+            .bind(current)
+            .fetch_optional(&self.pool)
+            .await?;
+            match next {
+                Some(n) if n != current => current = n,
+                _ => break,
+            }
+        }
+        Ok(current)
+    }
+
+    /// All distinct participant spaces in the thread rooted at `root`.
+    ///
+    /// Participants are the authors of every comment in the thread — derived
+    /// from the `space_id` of each `Reply to` relation in the subtree (a
+    /// relation's `space_id` is the space it was published from, i.e. the
+    /// comment author's personal space). `UNION` (not `UNION ALL`) makes the
+    /// recursion cycle-safe.
+    #[instrument(
+        name = "notification_indexer.storage.find_thread_participants",
+        skip(self)
+    )]
+    pub async fn find_thread_participants(&self, root: Uuid) -> Result<Vec<Uuid>, StorageError> {
+        let reply_to = ids::reply_to_property();
+        let rows = sqlx::query(
+            r#"
+            WITH RECURSIVE thread AS (
+                SELECT from_entity_id AS comment_id, space_id
+                FROM relations
+                WHERE type_id = $1 AND to_entity_id = $2
+                UNION
+                SELECT r.from_entity_id, r.space_id
+                FROM relations r
+                JOIN thread t ON r.to_entity_id = t.comment_id
+                WHERE r.type_id = $1
+            )
+            SELECT DISTINCT space_id FROM thread
+            "#,
+        )
+        .bind(reply_to)
+        .bind(root)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.iter().map(|r| r.get("space_id")).collect())
+    }
+
+    /// Best-effort "home" space of an entity — the `space_id` of its `Types`
+    /// relation (where it was created). For entities created in a personal space
+    /// this equals the creator. Used as the root-creator recipient for
+    /// non-proposal comment threads (proposals resolve their creator exactly via
+    /// `find_proposal_proposer_and_space`).
+    #[instrument(
+        name = "notification_indexer.storage.find_entity_home_space",
+        skip(self)
+    )]
+    pub async fn find_entity_home_space(
+        &self,
+        entity_id: Uuid,
+    ) -> Result<Option<Uuid>, StorageError> {
+        let result = sqlx::query_scalar::<_, Uuid>(
+            "SELECT space_id FROM relations WHERE from_entity_id = $1 AND type_id = $2 LIMIT 1",
+        )
+        .bind(entity_id)
+        .bind(ids::types_relation_type())
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(result)
+    }
+
     /// Find proposals that have expired (end_time < now) without being executed,
     /// and for which we haven't yet sent a rejection notification.
     ///

--- a/sdk/src/core/content_ids.rs
+++ b/sdk/src/core/content_ids.rs
@@ -6,3 +6,15 @@
 
 /// Comment type entity. Used for user comments on entities.
 pub const COMMENT_TYPE_ID: &str = "82f6123a-0323-4c6c-a811-701c5bc026e9";
+
+/// Reply-to property — the relation type linking a comment to the entity it
+/// replies to (comment → parent). Used to model comment threads.
+pub const REPLY_TO_PROPERTY_ID: &str = "310d4a24-0e5b-451c-b215-1bfce40d0fe6";
+
+/// Bounty type entity. Used to identify bounty entities via Types relations.
+pub const BOUNTY_TYPE_ID: &str = "808af0ba-d588-4e33-91f0-9dd4b25e18be";
+
+/// Space type entity (content convention; distinct from the UUIDv5-derived
+/// `ids::SPACE_TYPE_ID`). Used to identify a space's "front page entity" via a
+/// Types relation (entity → Space type).
+pub const SPACE_TYPE_ID: &str = "362c1dbd-dc64-44bb-a3c4-652f38a642d7";


### PR DESCRIPTION
## What

Adds the next batch of notification types (detected from the `knowledge.edits` GRC-20 stream), relocates the knowledge-graph IDs into the shared `sdk` crate, and includes three correctness/performance fixes found in review. Builds on #704 (governance targeting).

| Type | Trigger | Recipients |
|---|---|---|
| **`bounty_created`** (3a) | entity → `Types` → Bounty | editors of the space it was created in |
| **`proposal_comment`** (2a) | `Comment` replying directly to a proposal | the proposal's **proposer**, gated on the commenter being a **member/editor** of the proposal's space |
| **`comment`** (2b) | a `Comment`/reply whose parent is **not** a proposal | **all thread participants ∪ the thread root's creator** (app servers handle per-user snooze/mute) |

## How

- **IDs in `sdk`:** system/content IDs now live in `sdk::core::{ids,content_ids}` (added `REPLY_TO_PROPERTY_ID`, `BOUNTY_TYPE_ID`, content `SPACE_TYPE_ID`); the indexer's `ids.rs` is a thin `Uuid` helper over them.
- **Extraction** (pure, unit-tested): `extract_bounty_created`, `extract_proposal_comments`.
- **Thread resolution** (2b): `resolve_thread_root`, `find_thread_participants` (cycle-safe recursive CTE), `find_entity_home_space`.
- **Recipient resolvers:** `find_proposal_proposer_and_space`, `is_member_or_editor`.

## Fixes included

- **Idempotency — no dropped notifications.** One edit can emit several events of the same type; the key was only `{block}:{seq}:{event_type}`, so same-edit duplicates for one user collided under `ON CONFLICT DO NOTHING` and were silently dropped. Keys now carry a per-instance discriminator (`bounty_entity_id` / `comment_entity_id` / `relation_id`) across all six multi-instance handlers. Governance handlers are unaffected (one event per Kafka message). Adversarial tests build real multi-relation payloads and assert no collisions.
- **Determinism — stable recipients/payload.** Several best-effort lookups used `LIMIT 1` with no `ORDER BY`, so the chosen `space_id` could vary between replays. Added `ORDER BY` to `find_entity_home_space`, `resolve_thread_root`, `lookup_entity_space`, `lookup_bounty_space`, and `find_expired_proposals` (FIFO). PK/UNIQUE/already-ordered queries were audited and left as-is.
- **Query cost.** Migration `0058` adds the partial expression index `idx_outbox_rejected_proposal` (it previously existed only in the e2e fixture) so the rejection poller's anti-join stops seq-scanning the unbounded outbox; the heartbeat `count(*)` is replaced with an O(1) `pg_class.reltuples` estimate.

## Recipient-resolution note

Thread **participants** are exact (`relations.space_id`). The **root creator** is exact for proposals (`proposed_by`); for a general entity it's approximated by the root's home space (its `Types`-relation `space_id`) since `entities` has no `created_by` — equal to the creator for personal-space content.

## Tests

- **Unit (79):** id parsing, extraction (incl. negative cases), payload handlers, per-instance key uniqueness + adversarial multi-relation payloads.
- **E2E (187):** asserts bounty_created → space editors (incl. **two bounties in one edit** both delivering), a member's proposal comment → proposer while a **non-member's is filtered out**, and a thread reply → prior participant + root creator while the **author is excluded**.

Verified locally (toolchain 1.92.0): `cargo fmt --check`, `cargo clippy -p notification-indexer -p delivery-worker -- -D warnings`, `cargo test -p notification-indexer`, the full docker-compose e2e, and the `0058` migration applied against Postgres 16.

## Deferred

Outbox/deliveries retention, caching `lookup_latest_block`, a thread-CTE `LIMIT`, and Votes/trending — all tracked for follow-ups.
