### PR TITLE
fix(kg-indexer): version relation Update/Unset ops (read-based)

### DIFF
--- a/kg-indexer/src/handlers/edits.rs
+++ b/kg-indexer/src/handlers/edits.rs
@@ -312,6 +312,9 @@ fn merge_relation_ops(existing: RelationOp, new: RelationOp) -> RelationOp {
             to_version_id: u.to_version_id.or(e.to_version_id),
             position: u.position.or(e.position),
             verified: u.verified.or(e.verified),
+            // Later context wins; fall back to earlier if later is None.
+            context_root_id: u.context_root_id.or(e.context_root_id),
+            context_edge_type_id: u.context_edge_type_id.or(e.context_edge_type_id),
         }),
 
         // update -> delete: Delete wins
@@ -351,6 +354,8 @@ fn merge_relation_ops(existing: RelationOp, new: RelationOp) -> RelationOp {
             } else {
                 e.verified
             },
+            context_root_id: u.context_root_id.or(e.context_root_id),
+            context_edge_type_id: u.context_edge_type_id.or(e.context_edge_type_id),
         }),
 
         // delete -> anything: New op wins (recreation after delete)
@@ -375,6 +380,8 @@ fn merge_relation_ops(existing: RelationOp, new: RelationOp) -> RelationOp {
             to_version_id: u.to_version_id.or(e.to_version_id),
             position: u.position.or(e.position),
             verified: u.verified.or(e.verified),
+            context_root_id: u.context_root_id.or(e.context_root_id),
+            context_edge_type_id: u.context_edge_type_id.or(e.context_edge_type_id),
         }),
     }
 }
@@ -734,6 +741,7 @@ fn extract_relations(edit: &Grc20Edit, space_id: &Uuid) -> Vec<RelationOp> {
                 let from_version = updated.from_version.map(|id| id_to_uuid(&id).to_string());
                 let to_space = updated.to_space.map(|id| id_to_uuid(&id).to_string());
                 let to_version = updated.to_version.map(|id| id_to_uuid(&id).to_string());
+                let (context_root_id, context_edge_type_id) = extract_context(&updated.context);
 
                 // Check if any fields are being unset
                 let has_unset = !updated.unset.is_empty();
@@ -764,6 +772,8 @@ fn extract_relations(edit: &Grc20Edit, space_id: &Uuid) -> Vec<RelationOp> {
                             .contains(&UnsetRelationField::Position)
                             .then_some(true),
                         verified: None,
+                        context_root_id,
+                        context_edge_type_id,
                     }));
                 }
 
@@ -783,10 +793,14 @@ fn extract_relations(edit: &Grc20Edit, space_id: &Uuid) -> Vec<RelationOp> {
                         from_space_id: from_space,
                         from_version_id: from_version,
                         to_version_id: to_version,
+                        context_root_id,
+                        context_edge_type_id,
                     }));
                 }
             }
             Grc20Op::DeleteRelation(del) => {
+                // Delete-with-context tombstone is not yet implemented; see
+                // DeleteRelationItem doc comment.
                 relation_ops.push(RelationOp::Delete(DeleteRelationItem {
                     id: id_to_uuid(&del.id),
                     space_id: *space_id,
@@ -876,6 +890,8 @@ mod tests {
             to_version_id: None,
             position: None,
             verified: None,
+            context_root_id: None,
+            context_edge_type_id: None,
         }
     }
 
@@ -889,6 +905,8 @@ mod tests {
             to_version_id: None,
             position: None,
             verified: None,
+            context_root_id: None,
+            context_edge_type_id: None,
         }
     }
 

--- a/kg-indexer/src/models/relations.rs
+++ b/kg-indexer/src/models/relations.rs
@@ -30,6 +30,11 @@ pub struct UpdateRelationItem {
     pub position: Option<String>,
     pub space_id: Uuid,
     pub verified: Option<bool>,
+    // Context columns for grouping (GRC-20 Section 4.5). Without these,
+    // relation_versions rows written for updates land with NULL context and
+    // become invisible to context-aware diff discovery.
+    pub context_root_id: Option<Uuid>,
+    pub context_edge_type_id: Option<Uuid>,
 }
 
 #[derive(Clone, Debug)]
@@ -42,9 +47,20 @@ pub struct UnsetRelationItem {
     pub position: Option<bool>,
     pub space_id: Uuid,
     pub verified: Option<bool>,
+    // Context columns — same rationale as UpdateRelationItem.
+    pub context_root_id: Option<Uuid>,
+    pub context_edge_type_id: Option<Uuid>,
 }
 
-/// Delete relation item with space context
+/// Delete relation item with space context.
+///
+/// NOTE: Delete ops do not currently write a tombstone version row carrying
+/// context, because the live `relations` row is removed before the version
+/// table is touched. Adding delete-with-context attribution would require
+/// fetching the relation's pre-delete state up the call chain — tracked
+/// separately. Until then, deletions made under a contextual edit appear in
+/// diffs only via the closure of `valid_to_key` on the existing version row,
+/// without context surfacing in `queryContextEntities`.
 #[derive(Clone, Debug)]
 pub struct DeleteRelationItem {
     pub id: Uuid,

--- a/kg-indexer/src/storage.rs
+++ b/kg-indexer/src/storage.rs
@@ -1609,49 +1609,93 @@ impl Storage {
         .execute(&mut **tx)
         .await?;
 
-        // Filter to only Create operations for inserting new versions
-        let creates: Vec<&SetRelationItem> = relations
-            .iter()
-            .filter_map(|r| match r {
-                RelationOp::Create(item) => Some(item),
-                _ => None,
-            })
-            .collect();
+        // Build the rows to insert. Three sources:
+        //
+        //   - Create ops: synthesize from the SetRelationItem in-memory.
+        //   - Update / Unset ops: read post-mutation state from `relations`
+        //     (callers run live-table mutations before us in the same tx) and
+        //     attach the op's context columns. Without this path, an update
+        //     would close the existing version row but write no new row, so
+        //     queries at `version_key` would treat the relation as deleted.
+        //   - Delete ops: skip — closing valid_to_key already represents the
+        //     deletion in the temporal table.
+        let mut rows: Vec<VersionRow> = Vec::new();
 
-        if creates.is_empty() {
+        for r in relations {
+            match r {
+                RelationOp::Create(item) => rows.push(VersionRow {
+                    relation_id: item.id,
+                    entity_id: item.entity_id,
+                    type_id: item.type_id,
+                    from_id: item.from_id,
+                    from_space_id: item.from_space_id.as_ref().and_then(|s| s.parse().ok()),
+                    to_id: item.to_id,
+                    to_space_id: item.to_space_id.as_ref().and_then(|s| s.parse().ok()),
+                    position: item.position.clone(),
+                    space_id: item.space_id,
+                    verified: item.verified,
+                    context_root_id: item.context_root_id,
+                    context_edge_type_id: item.context_edge_type_id,
+                }),
+                RelationOp::Update(item) => {
+                    if let Some(row) =
+                        Self::fetch_relation_state(item.id, item.space_id, tx).await?
+                    {
+                        rows.push(VersionRow {
+                            context_root_id: item.context_root_id,
+                            context_edge_type_id: item.context_edge_type_id,
+                            ..row
+                        });
+                    }
+                }
+                RelationOp::Unset(item) => {
+                    if let Some(row) =
+                        Self::fetch_relation_state(item.id, item.space_id, tx).await?
+                    {
+                        rows.push(VersionRow {
+                            context_root_id: item.context_root_id,
+                            context_edge_type_id: item.context_edge_type_id,
+                            ..row
+                        });
+                    }
+                }
+                RelationOp::Delete(_) => {}
+            }
+        }
+
+        if rows.is_empty() {
             return Ok(());
         }
 
         // Prepare arrays for bulk insert
-        let mut ids = Vec::with_capacity(creates.len());
-        let mut r_relation_ids = Vec::with_capacity(creates.len());
-        let mut r_entity_ids = Vec::with_capacity(creates.len());
-        let mut r_type_ids = Vec::with_capacity(creates.len());
-        let mut r_from_entity_ids = Vec::with_capacity(creates.len());
-        let mut r_from_space_ids: Vec<Option<Uuid>> = Vec::with_capacity(creates.len());
-        let mut r_to_entity_ids = Vec::with_capacity(creates.len());
-        let mut r_to_space_ids: Vec<Option<Uuid>> = Vec::with_capacity(creates.len());
-        let mut r_positions = Vec::with_capacity(creates.len());
-        let mut r_space_ids = Vec::with_capacity(creates.len());
-        let mut r_verified = Vec::with_capacity(creates.len());
-        let mut valid_from_keys = Vec::with_capacity(creates.len());
-        let mut context_root_ids = Vec::with_capacity(creates.len());
-        let mut context_edge_type_ids = Vec::with_capacity(creates.len());
+        let mut ids = Vec::with_capacity(rows.len());
+        let mut r_relation_ids = Vec::with_capacity(rows.len());
+        let mut r_entity_ids = Vec::with_capacity(rows.len());
+        let mut r_type_ids = Vec::with_capacity(rows.len());
+        let mut r_from_entity_ids = Vec::with_capacity(rows.len());
+        let mut r_from_space_ids: Vec<Option<Uuid>> = Vec::with_capacity(rows.len());
+        let mut r_to_entity_ids = Vec::with_capacity(rows.len());
+        let mut r_to_space_ids: Vec<Option<Uuid>> = Vec::with_capacity(rows.len());
+        let mut r_positions = Vec::with_capacity(rows.len());
+        let mut r_space_ids = Vec::with_capacity(rows.len());
+        let mut r_verified = Vec::with_capacity(rows.len());
+        let mut valid_from_keys = Vec::with_capacity(rows.len());
+        let mut context_root_ids = Vec::with_capacity(rows.len());
+        let mut context_edge_type_ids = Vec::with_capacity(rows.len());
 
-        for r in &creates {
-            // Derive deterministic ID for idempotency
+        for r in &rows {
             ids.push(Self::derive_relation_version_id(
-                &r.id,
+                &r.relation_id,
                 &r.space_id,
                 version_key,
             ));
-            r_relation_ids.push(r.id);
+            r_relation_ids.push(r.relation_id);
             r_entity_ids.push(r.entity_id);
             r_type_ids.push(r.type_id);
             r_from_entity_ids.push(r.from_id);
-            r_from_space_ids.push(r.from_space_id.as_ref().and_then(|s| s.parse().ok()));
+            r_from_space_ids.push(r.from_space_id);
             r_to_entity_ids.push(r.to_id);
-            r_to_space_ids.push(r.to_space_id.as_ref().and_then(|s| s.parse().ok()));
+            r_to_space_ids.push(r.to_space_id);
             r_positions.push(r.position.as_deref());
             r_space_ids.push(r.space_id);
             r_verified.push(r.verified);
@@ -1694,4 +1738,72 @@ impl Storage {
 
         Ok(())
     }
+
+    /// Read the current state of a relation from the live `relations` table.
+    /// Used by `insert_relation_versions` to materialize a new version row
+    /// after Update/Unset live-table mutations have already been applied.
+    async fn fetch_relation_state(
+        relation_id: Uuid,
+        space_id: Uuid,
+        tx: &mut sqlx::Transaction<'_, Postgres>,
+    ) -> Result<Option<VersionRow>, IndexerError> {
+        let row = sqlx::query_as::<_, RelationStateRow>(
+            r#"
+            SELECT id, entity_id, type_id, from_entity_id, from_space_id,
+                   to_entity_id, to_space_id, position, space_id, verified
+            FROM relations
+            WHERE id = $1 AND space_id = $2
+            "#,
+        )
+        .bind(relation_id)
+        .bind(space_id)
+        .fetch_optional(&mut **tx)
+        .await?;
+
+        Ok(row.map(|r| VersionRow {
+            relation_id: r.id,
+            entity_id: r.entity_id,
+            type_id: r.type_id,
+            from_id: r.from_entity_id,
+            from_space_id: r.from_space_id,
+            to_id: r.to_entity_id,
+            to_space_id: r.to_space_id,
+            position: r.position,
+            space_id: r.space_id,
+            verified: r.verified,
+            // Caller fills in op's context columns.
+            context_root_id: None,
+            context_edge_type_id: None,
+        }))
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct RelationStateRow {
+    id: Uuid,
+    entity_id: Uuid,
+    type_id: Uuid,
+    from_entity_id: Uuid,
+    from_space_id: Option<Uuid>,
+    to_entity_id: Uuid,
+    to_space_id: Option<Uuid>,
+    position: Option<String>,
+    space_id: Uuid,
+    verified: Option<bool>,
+}
+
+/// Internal helper struct used by `insert_relation_versions`.
+struct VersionRow {
+    relation_id: Uuid,
+    entity_id: Uuid,
+    type_id: Uuid,
+    from_id: Uuid,
+    from_space_id: Option<Uuid>,
+    to_id: Uuid,
+    to_space_id: Option<Uuid>,
+    position: Option<String>,
+    space_id: Uuid,
+    verified: Option<bool>,
+    context_root_id: Option<Uuid>,
+    context_edge_type_id: Option<Uuid>,
 }

--- a/kg-indexer/tests/relation_versions_context.rs
+++ b/kg-indexer/tests/relation_versions_context.rs
@@ -1,0 +1,352 @@
+//! Integration tests for context propagation through `insert_relation_versions`
+//! on Update / Unset / Create relation ops (RFC 0003 — context-aware diffs).
+//!
+//! These tests verify the storage-layer rewrite that materializes a new
+//! `relation_versions` row for Update and Unset ops by reading the
+//! post-mutation state from the live `relations` table and attaching the
+//! op's `context_root_id` / `context_edge_type_id`. Without this path, an
+//! update would close the existing version row and write nothing new, so
+//! contextual updates were invisible to `queryContextEntities`.
+//!
+//! Prerequisites:
+//! - PostgreSQL running with migrations applied
+//! - DATABASE_URL environment variable set
+//!
+//! Run with:
+//!   cargo test --package kg-indexer \
+//!     --test relation_versions_context -- --ignored
+
+use kg_indexer::models::relations::{
+    RelationOp, SetRelationItem, UnsetRelationItem, UpdateRelationItem,
+};
+use kg_indexer::storage::Storage;
+use sqlx::postgres::PgPoolOptions;
+use std::env;
+use uuid::Uuid;
+
+async fn get_pool() -> sqlx::Pool<sqlx::Postgres> {
+    let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    PgPoolOptions::new()
+        .max_connections(5)
+        .connect(&database_url)
+        .await
+        .expect("Failed to connect to database")
+}
+
+async fn setup_storage() -> Storage {
+    let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    Storage::new(&database_url)
+        .await
+        .expect("Failed to create storage")
+}
+
+async fn ensure_entity(pool: &sqlx::Pool<sqlx::Postgres>, id: Uuid) {
+    sqlx::query(
+        "INSERT INTO entities (id, created_at, created_at_block, updated_at, updated_at_block)
+         VALUES ($1, '2024-01-01', '1', '2024-01-01', '1')
+         ON CONFLICT (id) DO NOTHING",
+    )
+    .bind(id)
+    .execute(pool)
+    .await
+    .expect("Failed to insert entity");
+}
+
+async fn cleanup(pool: &sqlx::Pool<sqlx::Postgres>, rel_id: Uuid) {
+    sqlx::query("DELETE FROM relation_versions WHERE relation_id = $1")
+        .bind(rel_id)
+        .execute(pool)
+        .await
+        .ok();
+    sqlx::query("DELETE FROM relations WHERE id = $1")
+        .bind(rel_id)
+        .execute(pool)
+        .await
+        .ok();
+}
+
+#[derive(sqlx::FromRow)]
+struct VersionRow {
+    valid_from_key: i64,
+    valid_to_key: Option<i64>,
+    context_root_id: Option<Uuid>,
+    context_edge_type_id: Option<Uuid>,
+    position: Option<String>,
+}
+
+async fn fetch_versions(pool: &sqlx::Pool<sqlx::Postgres>, relation_id: Uuid) -> Vec<VersionRow> {
+    sqlx::query_as::<_, VersionRow>(
+        "SELECT valid_from_key, valid_to_key, context_root_id, context_edge_type_id,
+                position
+         FROM relation_versions
+         WHERE relation_id = $1
+         ORDER BY valid_from_key",
+    )
+    .bind(relation_id)
+    .fetch_all(pool)
+    .await
+    .expect("Failed to query relation_versions")
+}
+
+// --------------------------------------------------------------------------
+// Test: a contextual Update materializes a new relation_versions row that
+// carries the op's context columns and the post-mutation state.
+// --------------------------------------------------------------------------
+#[tokio::test]
+#[ignore]
+async fn update_with_context_inserts_new_version_row() {
+    let pool = get_pool().await;
+    let storage = setup_storage().await;
+
+    let rel_id = Uuid::new_v4();
+    let space_id = Uuid::new_v4();
+    let entity_id = Uuid::new_v4();
+    let from_id = Uuid::new_v4();
+    let to_id = Uuid::new_v4();
+    let type_id = Uuid::new_v4();
+    let root_id = Uuid::new_v4();
+    let edge_type_id = Uuid::new_v4();
+
+    for id in [entity_id, from_id, to_id, type_id, root_id, edge_type_id] {
+        ensure_entity(&pool, id).await;
+    }
+
+    cleanup(&pool, rel_id).await;
+
+    let v1_key: i64 = (1_000_i64) << 32;
+    let v2_key: i64 = (1_001_i64) << 32;
+
+    // Seed: create relation at v1 with no context.
+    let create = SetRelationItem {
+        id: rel_id,
+        entity_id,
+        type_id,
+        from_id,
+        from_space_id: None,
+        from_version_id: None,
+        to_id,
+        to_space_id: None,
+        to_version_id: None,
+        position: Some("a".to_string()),
+        space_id,
+        verified: None,
+        is_system: false,
+        context_root_id: None,
+        context_edge_type_id: None,
+    };
+    let mut tx = pool.begin().await.unwrap();
+    storage
+        .insert_relations(std::slice::from_ref(&create), &mut tx)
+        .await
+        .unwrap();
+    storage
+        .insert_relation_versions(&[RelationOp::Create(create)], v1_key, &mut tx)
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    // Apply: contextual Update at v2 — moves position to "b".
+    let update = UpdateRelationItem {
+        id: rel_id,
+        space_id,
+        from_space_id: None,
+        from_version_id: None,
+        to_space_id: None,
+        to_version_id: None,
+        position: Some("b".to_string()),
+        verified: None,
+        context_root_id: Some(root_id),
+        context_edge_type_id: Some(edge_type_id),
+    };
+    let mut tx = pool.begin().await.unwrap();
+    storage
+        .update_relations(std::slice::from_ref(&update), &mut tx)
+        .await
+        .unwrap();
+    storage
+        .insert_relation_versions(&[RelationOp::Update(update)], v2_key, &mut tx)
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    let rows = fetch_versions(&pool, rel_id).await;
+    assert_eq!(rows.len(), 2, "expected one v1 and one v2 row");
+
+    let v1 = &rows[0];
+    let v2 = &rows[1];
+
+    // v1 closed by v2.
+    assert_eq!(v1.valid_from_key, v1_key);
+    assert_eq!(v1.valid_to_key, Some(v2_key));
+    assert_eq!(v1.context_root_id, None);
+    assert_eq!(v1.context_edge_type_id, None);
+
+    // v2 carries the op's context AND the post-mutation state.
+    assert_eq!(v2.valid_from_key, v2_key);
+    assert_eq!(v2.valid_to_key, None);
+    assert_eq!(v2.context_root_id, Some(root_id));
+    assert_eq!(v2.context_edge_type_id, Some(edge_type_id));
+    assert_eq!(v2.position.as_deref(), Some("b"));
+
+    cleanup(&pool, rel_id).await;
+}
+
+// --------------------------------------------------------------------------
+// Test: a contextual Unset materializes a new relation_versions row with
+// the unset applied (position null) and the op's context columns.
+// --------------------------------------------------------------------------
+#[tokio::test]
+#[ignore]
+async fn unset_with_context_inserts_new_version_row() {
+    let pool = get_pool().await;
+    let storage = setup_storage().await;
+
+    let rel_id = Uuid::new_v4();
+    let space_id = Uuid::new_v4();
+    let entity_id = Uuid::new_v4();
+    let from_id = Uuid::new_v4();
+    let to_id = Uuid::new_v4();
+    let type_id = Uuid::new_v4();
+    let root_id = Uuid::new_v4();
+    let edge_type_id = Uuid::new_v4();
+
+    for id in [entity_id, from_id, to_id, type_id, root_id, edge_type_id] {
+        ensure_entity(&pool, id).await;
+    }
+
+    cleanup(&pool, rel_id).await;
+
+    let v1_key: i64 = (2_000_i64) << 32;
+    let v2_key: i64 = (2_001_i64) << 32;
+
+    // Seed: create at v1 with a position to unset later.
+    let create = SetRelationItem {
+        id: rel_id,
+        entity_id,
+        type_id,
+        from_id,
+        from_space_id: None,
+        from_version_id: None,
+        to_id,
+        to_space_id: None,
+        to_version_id: None,
+        position: Some("a".to_string()),
+        space_id,
+        verified: None,
+        is_system: false,
+        context_root_id: None,
+        context_edge_type_id: None,
+    };
+    let mut tx = pool.begin().await.unwrap();
+    storage
+        .insert_relations(std::slice::from_ref(&create), &mut tx)
+        .await
+        .unwrap();
+    storage
+        .insert_relation_versions(&[RelationOp::Create(create)], v1_key, &mut tx)
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    // Apply: contextual Unset of position at v2.
+    let unset = UnsetRelationItem {
+        id: rel_id,
+        space_id,
+        from_space_id: None,
+        from_version_id: None,
+        to_space_id: None,
+        to_version_id: None,
+        position: Some(true), // unset position
+        verified: None,
+        context_root_id: Some(root_id),
+        context_edge_type_id: Some(edge_type_id),
+    };
+    let mut tx = pool.begin().await.unwrap();
+    storage
+        .unset_relation_fields(std::slice::from_ref(&unset), &mut tx)
+        .await
+        .unwrap();
+    storage
+        .insert_relation_versions(&[RelationOp::Unset(unset)], v2_key, &mut tx)
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    let rows = fetch_versions(&pool, rel_id).await;
+    assert_eq!(rows.len(), 2);
+
+    let v2 = &rows[1];
+    assert_eq!(v2.valid_from_key, v2_key);
+    assert_eq!(v2.valid_to_key, None);
+    assert_eq!(v2.context_root_id, Some(root_id));
+    assert_eq!(v2.context_edge_type_id, Some(edge_type_id));
+    // Unset cleared the position; the new version row reflects the post-unset state.
+    assert_eq!(v2.position, None);
+
+    cleanup(&pool, rel_id).await;
+}
+
+// --------------------------------------------------------------------------
+// Regression test: a contextual Create still writes the version row with
+// context. This is the simplest case but covers the original RFC path.
+// --------------------------------------------------------------------------
+#[tokio::test]
+#[ignore]
+async fn create_with_context_writes_version_row() {
+    let pool = get_pool().await;
+    let storage = setup_storage().await;
+
+    let rel_id = Uuid::new_v4();
+    let space_id = Uuid::new_v4();
+    let entity_id = Uuid::new_v4();
+    let from_id = Uuid::new_v4();
+    let to_id = Uuid::new_v4();
+    let type_id = Uuid::new_v4();
+    let root_id = Uuid::new_v4();
+    let edge_type_id = Uuid::new_v4();
+
+    for id in [entity_id, from_id, to_id, type_id, root_id, edge_type_id] {
+        ensure_entity(&pool, id).await;
+    }
+
+    cleanup(&pool, rel_id).await;
+
+    let v1_key: i64 = (3_000_i64) << 32;
+
+    let create = SetRelationItem {
+        id: rel_id,
+        entity_id,
+        type_id,
+        from_id,
+        from_space_id: None,
+        from_version_id: None,
+        to_id,
+        to_space_id: None,
+        to_version_id: None,
+        position: Some("a".to_string()),
+        space_id,
+        verified: None,
+        is_system: false,
+        context_root_id: Some(root_id),
+        context_edge_type_id: Some(edge_type_id),
+    };
+    let mut tx = pool.begin().await.unwrap();
+    storage
+        .insert_relations(std::slice::from_ref(&create), &mut tx)
+        .await
+        .unwrap();
+    storage
+        .insert_relation_versions(&[RelationOp::Create(create)], v1_key, &mut tx)
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    let rows = fetch_versions(&pool, rel_id).await;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].context_root_id, Some(root_id));
+    assert_eq!(rows[0].context_edge_type_id, Some(edge_type_id));
+    assert_eq!(rows[0].valid_from_key, v1_key);
+    assert_eq!(rows[0].valid_to_key, None);
+
+    cleanup(&pool, rel_id).await;
+}

--- a/kg-indexer/tests/system_relations_integration.rs
+++ b/kg-indexer/tests/system_relations_integration.rs
@@ -207,6 +207,8 @@ async fn test_update_relations_does_not_modify_system_relation() {
         position: Some("updated_position".to_string()),
         space_id,
         verified: Some(false),
+        context_root_id: None,
+        context_edge_type_id: None,
     };
 
     let mut tx = pool.begin().await.unwrap();
@@ -264,6 +266,8 @@ async fn test_unset_relation_fields_does_not_nullify_system_relation() {
         position: Some(true), // request to unset
         space_id,
         verified: Some(true), // request to unset
+        context_root_id: None,
+        context_edge_type_id: None,
     };
 
     let mut tx = pool.begin().await.unwrap();


### PR DESCRIPTION
## What

Version relation **Update/Unset** ops in `insert_relation_versions`. Previously only `Create` ops were versioned.

## The bug

`insert_relation_versions` runs two steps per edit: (1) **close** any open `relation_versions` row (`valid_to_key = version_key`) for every relation in the batch, then (2) **insert** new version rows — but only for `Create` ops. So an `Update`/`Unset`:

- step 1 closed the open row,
- step 2 wrote nothing,

leaving the relation with **no open version row**. A temporal query at any `version_key >= the update` (`valid_from_key <= K AND (valid_to_key IS NULL OR valid_to_key > K)`) then matches no row → the relation reads as **deleted**, even though the live `relations` table is correct.

## Why this hasn't surfaced in prod

- The **live tables are always correct** (`update_relations` writes them directly) — the main GraphQL API is unaffected. The gap is only in the `relation_versions` *temporal* table.
- The **only consumer** of temporal accuracy for updates is the versioned-diff API — a new/unshipped feature.
- Creates and deletes were always versioned correctly; only the in-place **update** transition was lossy, and relation field-updates (reorder via `position`, `to_version` pin, `verified` toggle) are the minority op.

## This PR (read-based)

Versions `Update`/`Unset` by reading post-mutation state from the live `relations` table via `fetch_relation_state`, attaching the op's `context_root_id` / `context_edge_type_id`. Also threads those context columns onto `UpdateRelationItem`/`UnsetRelationItem` and through the squash/merge logic, so contextual updates are discoverable by `queryContextEntities`.

## ⚠️ Tradeoff — read on the write path

This adds a **per-op `SELECT` on the indexer write path** (N+1 over update/unset ops). Our team has deliberately kept that path read-free. **Sibling PR `fix/relation-update-versioning-zero-read` implements the same fix with zero reads** (via `RETURNING` off the live `update_relations`/`unset_relation_fields`). **This pair is intentional — pick one.** This one is the smaller/lower-risk diff; the sibling honors the no-reads invariant.

## Scope / notes

- **Decoupled from `context_last_to_entity_id`** — that column (and its create-side population) ships with the v2 diff API PR (#215), so this targets `dev` cleanly with no migration.
- **Prod backfill:** relations already mis-versioned by past updates aren't repaired by this going-forward fix; a backfill of `relation_versions` would be needed if historical diffs across those updates must be correct.
- Delete-with-context tombstones remain a documented gap (live row is gone before versioning).

## Testing

`kg-indexer/tests/relation_versions_context.rs` (gated on `DATABASE_URL`, run with `--ignored`). Verified locally against Postgres:

```
test create_with_context_writes_version_row ... ok
test update_with_context_inserts_new_version_row ... ok
test unset_with_context_inserts_new_version_row ... ok
```

Opened as **draft** pending the team's read-vs-zero-read decision.
