### PR TITLE
fix(kg-indexer): version relation Update/Unset ops (zero-read via RETURNING)

### DIFF
--- a/kg-indexer/src/handlers/edits.rs
+++ b/kg-indexer/src/handlers/edits.rs
@@ -312,6 +312,9 @@ fn merge_relation_ops(existing: RelationOp, new: RelationOp) -> RelationOp {
             to_version_id: u.to_version_id.or(e.to_version_id),
             position: u.position.or(e.position),
             verified: u.verified.or(e.verified),
+            // Later context wins; fall back to earlier if later is None.
+            context_root_id: u.context_root_id.or(e.context_root_id),
+            context_edge_type_id: u.context_edge_type_id.or(e.context_edge_type_id),
         }),
 
         // update -> delete: Delete wins
@@ -351,6 +354,8 @@ fn merge_relation_ops(existing: RelationOp, new: RelationOp) -> RelationOp {
             } else {
                 e.verified
             },
+            context_root_id: u.context_root_id.or(e.context_root_id),
+            context_edge_type_id: u.context_edge_type_id.or(e.context_edge_type_id),
         }),
 
         // delete -> anything: New op wins (recreation after delete)
@@ -375,6 +380,8 @@ fn merge_relation_ops(existing: RelationOp, new: RelationOp) -> RelationOp {
             to_version_id: u.to_version_id.or(e.to_version_id),
             position: u.position.or(e.position),
             verified: u.verified.or(e.verified),
+            context_root_id: u.context_root_id.or(e.context_root_id),
+            context_edge_type_id: u.context_edge_type_id.or(e.context_edge_type_id),
         }),
     }
 }
@@ -734,6 +741,7 @@ fn extract_relations(edit: &Grc20Edit, space_id: &Uuid) -> Vec<RelationOp> {
                 let from_version = updated.from_version.map(|id| id_to_uuid(&id).to_string());
                 let to_space = updated.to_space.map(|id| id_to_uuid(&id).to_string());
                 let to_version = updated.to_version.map(|id| id_to_uuid(&id).to_string());
+                let (context_root_id, context_edge_type_id) = extract_context(&updated.context);
 
                 // Check if any fields are being unset
                 let has_unset = !updated.unset.is_empty();
@@ -764,6 +772,8 @@ fn extract_relations(edit: &Grc20Edit, space_id: &Uuid) -> Vec<RelationOp> {
                             .contains(&UnsetRelationField::Position)
                             .then_some(true),
                         verified: None,
+                        context_root_id,
+                        context_edge_type_id,
                     }));
                 }
 
@@ -783,10 +793,14 @@ fn extract_relations(edit: &Grc20Edit, space_id: &Uuid) -> Vec<RelationOp> {
                         from_space_id: from_space,
                         from_version_id: from_version,
                         to_version_id: to_version,
+                        context_root_id,
+                        context_edge_type_id,
                     }));
                 }
             }
             Grc20Op::DeleteRelation(del) => {
+                // Delete-with-context tombstone is not yet implemented; see
+                // DeleteRelationItem doc comment.
                 relation_ops.push(RelationOp::Delete(DeleteRelationItem {
                     id: id_to_uuid(&del.id),
                     space_id: *space_id,
@@ -876,6 +890,8 @@ mod tests {
             to_version_id: None,
             position: None,
             verified: None,
+            context_root_id: None,
+            context_edge_type_id: None,
         }
     }
 
@@ -889,6 +905,8 @@ mod tests {
             to_version_id: None,
             position: None,
             verified: None,
+            context_root_id: None,
+            context_edge_type_id: None,
         }
     }
 

--- a/kg-indexer/src/main.rs
+++ b/kg-indexer/src/main.rs
@@ -1032,11 +1032,20 @@ async fn process_message(
             storage.insert_values(&set_values, &mut tx).await?;
             storage.delete_values(&delete_value_ids, &mut tx).await?;
             storage.insert_relations(&set_relations, &mut tx).await?;
-            storage.update_relations(&update_relations, &mut tx).await?;
-            storage
+            // Capture post-mutation relation state from the live UPDATEs' RETURNING so
+            // insert_relation_versions can version update/unset ops without re-reading.
+            let updated_rows = storage.update_relations(&update_relations, &mut tx).await?;
+            let unset_rows = storage
                 .unset_relation_fields(&unset_relations, &mut tx)
                 .await?;
             storage.delete_relations(&delete_relations, &mut tx).await?;
+
+            let relation_post_mutation: std::collections::HashMap<(uuid::Uuid, uuid::Uuid), _> =
+                updated_rows
+                    .into_iter()
+                    .chain(unset_rows)
+                    .map(|r| ((r.id, r.space_id), r))
+                    .collect();
 
             // Versioned writes (temporal tables)
             // Only write versions if this edit hasn't been processed before (idempotency)
@@ -1059,7 +1068,12 @@ async fn process_message(
                         .insert_value_versions(&values_for_versioning, version_key, &mut tx)
                         .await?;
                     storage
-                        .insert_relation_versions(&relations_for_versioning, version_key, &mut tx)
+                        .insert_relation_versions(
+                            &relations_for_versioning,
+                            version_key,
+                            &relation_post_mutation,
+                            &mut tx,
+                        )
                         .await?;
                 }
             }
@@ -1440,11 +1454,20 @@ async fn process_block(
                     storage.insert_values(&set_values, &mut tx).await?;
                     storage.delete_values(&delete_value_ids, &mut tx).await?;
                     storage.insert_relations(&set_relations, &mut tx).await?;
-                    storage.update_relations(&update_relations, &mut tx).await?;
-                    storage
+                    let updated_rows = storage.update_relations(&update_relations, &mut tx).await?;
+                    let unset_rows = storage
                         .unset_relation_fields(&unset_relations, &mut tx)
                         .await?;
                     storage.delete_relations(&delete_relations, &mut tx).await?;
+
+                    let relation_post_mutation: std::collections::HashMap<
+                        (uuid::Uuid, uuid::Uuid),
+                        _,
+                    > = updated_rows
+                        .into_iter()
+                        .chain(unset_rows)
+                        .map(|r| ((r.id, r.space_id), r))
+                        .collect();
 
                     // Versioned writes (temporal tables)
                     // Only write versions if this edit hasn't been processed before (idempotency)
@@ -1470,6 +1493,7 @@ async fn process_block(
                                 .insert_relation_versions(
                                     &relations_for_versioning,
                                     version_key,
+                                    &relation_post_mutation,
                                     &mut tx,
                                 )
                                 .await?;

--- a/kg-indexer/src/models/relations.rs
+++ b/kg-indexer/src/models/relations.rs
@@ -30,6 +30,11 @@ pub struct UpdateRelationItem {
     pub position: Option<String>,
     pub space_id: Uuid,
     pub verified: Option<bool>,
+    // Context columns for grouping (GRC-20 Section 4.5). Without these,
+    // relation_versions rows written for updates land with NULL context and
+    // become invisible to context-aware diff discovery.
+    pub context_root_id: Option<Uuid>,
+    pub context_edge_type_id: Option<Uuid>,
 }
 
 #[derive(Clone, Debug)]
@@ -42,9 +47,20 @@ pub struct UnsetRelationItem {
     pub position: Option<bool>,
     pub space_id: Uuid,
     pub verified: Option<bool>,
+    // Context columns — same rationale as UpdateRelationItem.
+    pub context_root_id: Option<Uuid>,
+    pub context_edge_type_id: Option<Uuid>,
 }
 
-/// Delete relation item with space context
+/// Delete relation item with space context.
+///
+/// NOTE: Delete ops do not currently write a tombstone version row carrying
+/// context, because the live `relations` row is removed before the version
+/// table is touched. Adding delete-with-context attribution would require
+/// fetching the relation's pre-delete state up the call chain — tracked
+/// separately. Until then, deletions made under a contextual edit appear in
+/// diffs only via the closure of `valid_to_key` on the existing version row,
+/// without context surfacing in `queryContextEntities`.
 #[derive(Clone, Debug)]
 pub struct DeleteRelationItem {
     pub id: Uuid,

--- a/kg-indexer/src/storage.rs
+++ b/kg-indexer/src/storage.rs
@@ -1,6 +1,7 @@
 use hermes_instrumentation::info;
 use sqlx::{postgres::PgPoolOptions, Postgres, QueryBuilder};
 use std::collections::hash_map::DefaultHasher;
+use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use uuid::Uuid;
 
@@ -303,13 +304,17 @@ impl Storage {
         Ok(())
     }
 
+    /// Apply relation field updates to the live `relations` table and RETURN the
+    /// full post-mutation rows. The returned rows are the authoritative merged
+    /// state — `insert_relation_versions` uses them to write update version rows
+    /// WITHOUT a separate read on the write path.
     pub async fn update_relations(
         &self,
         relations: &[UpdateRelationItem],
         tx: &mut sqlx::Transaction<'_, Postgres>,
-    ) -> Result<(), IndexerError> {
+    ) -> Result<Vec<RelationStateRow>, IndexerError> {
         if relations.is_empty() {
-            return Ok(());
+            return Ok(Vec::new());
         }
 
         let mut query_builder: QueryBuilder<Postgres> = QueryBuilder::new(
@@ -339,21 +344,30 @@ impl Storage {
 
         query_builder.push(
             ") AS v(id, from_space_id, from_version_id, to_space_id, to_version_id, position, verified)
-             WHERE relations.id = v.id AND relations.is_system = false",
+             WHERE relations.id = v.id AND relations.is_system = false
+             RETURNING relations.id, relations.entity_id, relations.type_id,
+                       relations.from_entity_id, relations.from_space_id,
+                       relations.to_entity_id, relations.to_space_id,
+                       relations.position, relations.space_id, relations.verified",
         );
 
-        query_builder.build().execute(&mut **tx).await?;
+        let rows = query_builder
+            .build_query_as::<RelationStateRow>()
+            .fetch_all(&mut **tx)
+            .await?;
 
-        Ok(())
+        Ok(rows)
     }
 
+    /// Apply relation field unsets to the live `relations` table and RETURN the
+    /// full post-mutation rows (see `update_relations` — same no-read rationale).
     pub async fn unset_relation_fields(
         &self,
         relations: &[UnsetRelationItem],
         tx: &mut sqlx::Transaction<'_, Postgres>,
-    ) -> Result<(), IndexerError> {
+    ) -> Result<Vec<RelationStateRow>, IndexerError> {
         if relations.is_empty() {
-            return Ok(());
+            return Ok(Vec::new());
         }
 
         let mut query_builder: QueryBuilder<Postgres> = QueryBuilder::new(
@@ -380,12 +394,19 @@ impl Storage {
         query_builder.push(
             ") AS v(id, unset_from_space_id, unset_from_version_id, unset_to_space_id,
                    unset_to_version_id, unset_position, unset_verified)
-             WHERE relations.id = v.id AND relations.is_system = false",
+             WHERE relations.id = v.id AND relations.is_system = false
+             RETURNING relations.id, relations.entity_id, relations.type_id,
+                       relations.from_entity_id, relations.from_space_id,
+                       relations.to_entity_id, relations.to_space_id,
+                       relations.position, relations.space_id, relations.verified",
         );
 
-        query_builder.build().execute(&mut **tx).await?;
+        let rows = query_builder
+            .build_query_as::<RelationStateRow>()
+            .fetch_all(&mut **tx)
+            .await?;
 
-        Ok(())
+        Ok(rows)
     }
 
     pub async fn delete_relations(
@@ -1580,6 +1601,7 @@ impl Storage {
         &self,
         relations: &[RelationOp],
         version_key: i64,
+        post_mutation: &HashMap<(Uuid, Uuid), RelationStateRow>,
         tx: &mut sqlx::Transaction<'_, Postgres>,
     ) -> Result<(), IndexerError> {
         if relations.is_empty() {
@@ -1609,49 +1631,105 @@ impl Storage {
         .execute(&mut **tx)
         .await?;
 
-        // Filter to only Create operations for inserting new versions
-        let creates: Vec<&SetRelationItem> = relations
-            .iter()
-            .filter_map(|r| match r {
-                RelationOp::Create(item) => Some(item),
-                _ => None,
-            })
-            .collect();
+        // Build the rows to insert. Three sources:
+        //
+        //   - Create ops: synthesize from the SetRelationItem in-memory.
+        //   - Update / Unset ops: use the post-mutation state captured from the
+        //     live `relations` UPDATE's RETURNING (passed in by the caller) and
+        //     attach the op's context columns. NO read happens here — the row was
+        //     already materialized by update_relations / unset_relation_fields in
+        //     the same tx. Without a version row, an update would close the open
+        //     row but write no successor, so queries at `version_key` would treat
+        //     the relation as deleted.
+        //   - Delete ops: skip — closing valid_to_key already represents the
+        //     deletion in the temporal table.
+        let row_from_state =
+            |state: &RelationStateRow, item_ctx: (Option<Uuid>, Option<Uuid>)| VersionRow {
+                relation_id: state.id,
+                entity_id: state.entity_id,
+                type_id: state.type_id,
+                from_id: state.from_entity_id,
+                from_space_id: state.from_space_id,
+                to_id: state.to_entity_id,
+                to_space_id: state.to_space_id,
+                position: state.position.clone(),
+                space_id: state.space_id,
+                verified: state.verified,
+                context_root_id: item_ctx.0,
+                context_edge_type_id: item_ctx.1,
+            };
 
-        if creates.is_empty() {
+        let mut rows: Vec<VersionRow> = Vec::new();
+
+        for r in relations {
+            match r {
+                RelationOp::Create(item) => rows.push(VersionRow {
+                    relation_id: item.id,
+                    entity_id: item.entity_id,
+                    type_id: item.type_id,
+                    from_id: item.from_id,
+                    from_space_id: item.from_space_id.as_ref().and_then(|s| s.parse().ok()),
+                    to_id: item.to_id,
+                    to_space_id: item.to_space_id.as_ref().and_then(|s| s.parse().ok()),
+                    position: item.position.clone(),
+                    space_id: item.space_id,
+                    verified: item.verified,
+                    context_root_id: item.context_root_id,
+                    context_edge_type_id: item.context_edge_type_id,
+                }),
+                RelationOp::Update(item) => {
+                    if let Some(state) = post_mutation.get(&(item.id, item.space_id)) {
+                        rows.push(row_from_state(
+                            state,
+                            (item.context_root_id, item.context_edge_type_id),
+                        ));
+                    }
+                }
+                RelationOp::Unset(item) => {
+                    if let Some(state) = post_mutation.get(&(item.id, item.space_id)) {
+                        rows.push(row_from_state(
+                            state,
+                            (item.context_root_id, item.context_edge_type_id),
+                        ));
+                    }
+                }
+                RelationOp::Delete(_) => {}
+            }
+        }
+
+        if rows.is_empty() {
             return Ok(());
         }
 
         // Prepare arrays for bulk insert
-        let mut ids = Vec::with_capacity(creates.len());
-        let mut r_relation_ids = Vec::with_capacity(creates.len());
-        let mut r_entity_ids = Vec::with_capacity(creates.len());
-        let mut r_type_ids = Vec::with_capacity(creates.len());
-        let mut r_from_entity_ids = Vec::with_capacity(creates.len());
-        let mut r_from_space_ids: Vec<Option<Uuid>> = Vec::with_capacity(creates.len());
-        let mut r_to_entity_ids = Vec::with_capacity(creates.len());
-        let mut r_to_space_ids: Vec<Option<Uuid>> = Vec::with_capacity(creates.len());
-        let mut r_positions = Vec::with_capacity(creates.len());
-        let mut r_space_ids = Vec::with_capacity(creates.len());
-        let mut r_verified = Vec::with_capacity(creates.len());
-        let mut valid_from_keys = Vec::with_capacity(creates.len());
-        let mut context_root_ids = Vec::with_capacity(creates.len());
-        let mut context_edge_type_ids = Vec::with_capacity(creates.len());
+        let mut ids = Vec::with_capacity(rows.len());
+        let mut r_relation_ids = Vec::with_capacity(rows.len());
+        let mut r_entity_ids = Vec::with_capacity(rows.len());
+        let mut r_type_ids = Vec::with_capacity(rows.len());
+        let mut r_from_entity_ids = Vec::with_capacity(rows.len());
+        let mut r_from_space_ids: Vec<Option<Uuid>> = Vec::with_capacity(rows.len());
+        let mut r_to_entity_ids = Vec::with_capacity(rows.len());
+        let mut r_to_space_ids: Vec<Option<Uuid>> = Vec::with_capacity(rows.len());
+        let mut r_positions = Vec::with_capacity(rows.len());
+        let mut r_space_ids = Vec::with_capacity(rows.len());
+        let mut r_verified = Vec::with_capacity(rows.len());
+        let mut valid_from_keys = Vec::with_capacity(rows.len());
+        let mut context_root_ids = Vec::with_capacity(rows.len());
+        let mut context_edge_type_ids = Vec::with_capacity(rows.len());
 
-        for r in &creates {
-            // Derive deterministic ID for idempotency
+        for r in &rows {
             ids.push(Self::derive_relation_version_id(
-                &r.id,
+                &r.relation_id,
                 &r.space_id,
                 version_key,
             ));
-            r_relation_ids.push(r.id);
+            r_relation_ids.push(r.relation_id);
             r_entity_ids.push(r.entity_id);
             r_type_ids.push(r.type_id);
             r_from_entity_ids.push(r.from_id);
-            r_from_space_ids.push(r.from_space_id.as_ref().and_then(|s| s.parse().ok()));
+            r_from_space_ids.push(r.from_space_id);
             r_to_entity_ids.push(r.to_id);
-            r_to_space_ids.push(r.to_space_id.as_ref().and_then(|s| s.parse().ok()));
+            r_to_space_ids.push(r.to_space_id);
             r_positions.push(r.position.as_deref());
             r_space_ids.push(r.space_id);
             r_verified.push(r.verified);
@@ -1694,4 +1772,37 @@ impl Storage {
 
         Ok(())
     }
+}
+
+/// Post-mutation relation state, returned by `update_relations` /
+/// `unset_relation_fields` via RETURNING and consumed by
+/// `insert_relation_versions` to write update version rows without a read.
+#[derive(sqlx::FromRow)]
+pub struct RelationStateRow {
+    pub id: Uuid,
+    pub entity_id: Uuid,
+    pub type_id: Uuid,
+    pub from_entity_id: Uuid,
+    pub from_space_id: Option<Uuid>,
+    pub to_entity_id: Uuid,
+    pub to_space_id: Option<Uuid>,
+    pub position: Option<String>,
+    pub space_id: Uuid,
+    pub verified: Option<bool>,
+}
+
+/// Internal helper struct used by `insert_relation_versions`.
+struct VersionRow {
+    relation_id: Uuid,
+    entity_id: Uuid,
+    type_id: Uuid,
+    from_id: Uuid,
+    from_space_id: Option<Uuid>,
+    to_id: Uuid,
+    to_space_id: Option<Uuid>,
+    position: Option<String>,
+    space_id: Uuid,
+    verified: Option<bool>,
+    context_root_id: Option<Uuid>,
+    context_edge_type_id: Option<Uuid>,
 }

--- a/kg-indexer/tests/relation_versions_context.rs
+++ b/kg-indexer/tests/relation_versions_context.rs
@@ -1,0 +1,377 @@
+//! Integration tests for context propagation through `insert_relation_versions`
+//! on Update / Unset / Create relation ops (RFC 0003 — context-aware diffs).
+//!
+//! These tests verify the storage-layer rewrite that materializes a new
+//! `relation_versions` row for Update and Unset ops by reading the
+//! post-mutation state from the live `relations` table and attaching the
+//! op's `context_root_id` / `context_edge_type_id`. Without this path, an
+//! update would close the existing version row and write nothing new, so
+//! contextual updates were invisible to `queryContextEntities`.
+//!
+//! Prerequisites:
+//! - PostgreSQL running with migrations applied
+//! - DATABASE_URL environment variable set
+//!
+//! Run with:
+//!   cargo test --package kg-indexer \
+//!     --test relation_versions_context -- --ignored
+
+use kg_indexer::models::relations::{
+    RelationOp, SetRelationItem, UnsetRelationItem, UpdateRelationItem,
+};
+use kg_indexer::storage::Storage;
+use sqlx::postgres::PgPoolOptions;
+use std::env;
+use uuid::Uuid;
+
+async fn get_pool() -> sqlx::Pool<sqlx::Postgres> {
+    let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    PgPoolOptions::new()
+        .max_connections(5)
+        .connect(&database_url)
+        .await
+        .expect("Failed to connect to database")
+}
+
+async fn setup_storage() -> Storage {
+    let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    Storage::new(&database_url)
+        .await
+        .expect("Failed to create storage")
+}
+
+async fn ensure_entity(pool: &sqlx::Pool<sqlx::Postgres>, id: Uuid) {
+    sqlx::query(
+        "INSERT INTO entities (id, created_at, created_at_block, updated_at, updated_at_block)
+         VALUES ($1, '2024-01-01', '1', '2024-01-01', '1')
+         ON CONFLICT (id) DO NOTHING",
+    )
+    .bind(id)
+    .execute(pool)
+    .await
+    .expect("Failed to insert entity");
+}
+
+async fn cleanup(pool: &sqlx::Pool<sqlx::Postgres>, rel_id: Uuid) {
+    sqlx::query("DELETE FROM relation_versions WHERE relation_id = $1")
+        .bind(rel_id)
+        .execute(pool)
+        .await
+        .ok();
+    sqlx::query("DELETE FROM relations WHERE id = $1")
+        .bind(rel_id)
+        .execute(pool)
+        .await
+        .ok();
+}
+
+#[derive(sqlx::FromRow)]
+struct VersionRow {
+    valid_from_key: i64,
+    valid_to_key: Option<i64>,
+    context_root_id: Option<Uuid>,
+    context_edge_type_id: Option<Uuid>,
+    position: Option<String>,
+}
+
+async fn fetch_versions(pool: &sqlx::Pool<sqlx::Postgres>, relation_id: Uuid) -> Vec<VersionRow> {
+    sqlx::query_as::<_, VersionRow>(
+        "SELECT valid_from_key, valid_to_key, context_root_id, context_edge_type_id,
+                position
+         FROM relation_versions
+         WHERE relation_id = $1
+         ORDER BY valid_from_key",
+    )
+    .bind(relation_id)
+    .fetch_all(pool)
+    .await
+    .expect("Failed to query relation_versions")
+}
+
+// --------------------------------------------------------------------------
+// Test: a contextual Update materializes a new relation_versions row that
+// carries the op's context columns and the post-mutation state.
+// --------------------------------------------------------------------------
+#[tokio::test]
+#[ignore]
+async fn update_with_context_inserts_new_version_row() {
+    let pool = get_pool().await;
+    let storage = setup_storage().await;
+
+    let rel_id = Uuid::new_v4();
+    let space_id = Uuid::new_v4();
+    let entity_id = Uuid::new_v4();
+    let from_id = Uuid::new_v4();
+    let to_id = Uuid::new_v4();
+    let type_id = Uuid::new_v4();
+    let root_id = Uuid::new_v4();
+    let edge_type_id = Uuid::new_v4();
+
+    for id in [entity_id, from_id, to_id, type_id, root_id, edge_type_id] {
+        ensure_entity(&pool, id).await;
+    }
+
+    cleanup(&pool, rel_id).await;
+
+    let v1_key: i64 = (1_000_i64) << 32;
+    let v2_key: i64 = (1_001_i64) << 32;
+
+    // Seed: create relation at v1 with no context.
+    let create = SetRelationItem {
+        id: rel_id,
+        entity_id,
+        type_id,
+        from_id,
+        from_space_id: None,
+        from_version_id: None,
+        to_id,
+        to_space_id: None,
+        to_version_id: None,
+        position: Some("a".to_string()),
+        space_id,
+        verified: None,
+        is_system: false,
+        context_root_id: None,
+        context_edge_type_id: None,
+    };
+    let mut tx = pool.begin().await.unwrap();
+    storage
+        .insert_relations(std::slice::from_ref(&create), &mut tx)
+        .await
+        .unwrap();
+    storage
+        .insert_relation_versions(
+            &[RelationOp::Create(create)],
+            v1_key,
+            &std::collections::HashMap::new(),
+            &mut tx,
+        )
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    // Apply: contextual Update at v2 — moves position to "b".
+    let update = UpdateRelationItem {
+        id: rel_id,
+        space_id,
+        from_space_id: None,
+        from_version_id: None,
+        to_space_id: None,
+        to_version_id: None,
+        position: Some("b".to_string()),
+        verified: None,
+        context_root_id: Some(root_id),
+        context_edge_type_id: Some(edge_type_id),
+    };
+    let mut tx = pool.begin().await.unwrap();
+    // Zero-read: the version row is sourced from the live UPDATE's RETURNING.
+    let updated = storage
+        .update_relations(std::slice::from_ref(&update), &mut tx)
+        .await
+        .unwrap();
+    let post: std::collections::HashMap<(Uuid, Uuid), _> = updated
+        .into_iter()
+        .map(|r| ((r.id, r.space_id), r))
+        .collect();
+    storage
+        .insert_relation_versions(&[RelationOp::Update(update)], v2_key, &post, &mut tx)
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    let rows = fetch_versions(&pool, rel_id).await;
+    assert_eq!(rows.len(), 2, "expected one v1 and one v2 row");
+
+    let v1 = &rows[0];
+    let v2 = &rows[1];
+
+    // v1 closed by v2.
+    assert_eq!(v1.valid_from_key, v1_key);
+    assert_eq!(v1.valid_to_key, Some(v2_key));
+    assert_eq!(v1.context_root_id, None);
+    assert_eq!(v1.context_edge_type_id, None);
+
+    // v2 carries the op's context AND the post-mutation state.
+    assert_eq!(v2.valid_from_key, v2_key);
+    assert_eq!(v2.valid_to_key, None);
+    assert_eq!(v2.context_root_id, Some(root_id));
+    assert_eq!(v2.context_edge_type_id, Some(edge_type_id));
+    assert_eq!(v2.position.as_deref(), Some("b"));
+
+    cleanup(&pool, rel_id).await;
+}
+
+// --------------------------------------------------------------------------
+// Test: a contextual Unset materializes a new relation_versions row with
+// the unset applied (position null) and the op's context columns.
+// --------------------------------------------------------------------------
+#[tokio::test]
+#[ignore]
+async fn unset_with_context_inserts_new_version_row() {
+    let pool = get_pool().await;
+    let storage = setup_storage().await;
+
+    let rel_id = Uuid::new_v4();
+    let space_id = Uuid::new_v4();
+    let entity_id = Uuid::new_v4();
+    let from_id = Uuid::new_v4();
+    let to_id = Uuid::new_v4();
+    let type_id = Uuid::new_v4();
+    let root_id = Uuid::new_v4();
+    let edge_type_id = Uuid::new_v4();
+
+    for id in [entity_id, from_id, to_id, type_id, root_id, edge_type_id] {
+        ensure_entity(&pool, id).await;
+    }
+
+    cleanup(&pool, rel_id).await;
+
+    let v1_key: i64 = (2_000_i64) << 32;
+    let v2_key: i64 = (2_001_i64) << 32;
+
+    // Seed: create at v1 with a position to unset later.
+    let create = SetRelationItem {
+        id: rel_id,
+        entity_id,
+        type_id,
+        from_id,
+        from_space_id: None,
+        from_version_id: None,
+        to_id,
+        to_space_id: None,
+        to_version_id: None,
+        position: Some("a".to_string()),
+        space_id,
+        verified: None,
+        is_system: false,
+        context_root_id: None,
+        context_edge_type_id: None,
+    };
+    let mut tx = pool.begin().await.unwrap();
+    storage
+        .insert_relations(std::slice::from_ref(&create), &mut tx)
+        .await
+        .unwrap();
+    storage
+        .insert_relation_versions(
+            &[RelationOp::Create(create)],
+            v1_key,
+            &std::collections::HashMap::new(),
+            &mut tx,
+        )
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    // Apply: contextual Unset of position at v2.
+    let unset = UnsetRelationItem {
+        id: rel_id,
+        space_id,
+        from_space_id: None,
+        from_version_id: None,
+        to_space_id: None,
+        to_version_id: None,
+        position: Some(true), // unset position
+        verified: None,
+        context_root_id: Some(root_id),
+        context_edge_type_id: Some(edge_type_id),
+    };
+    let mut tx = pool.begin().await.unwrap();
+    // Zero-read: the version row is sourced from the live UPDATE's RETURNING.
+    let unset_rows = storage
+        .unset_relation_fields(std::slice::from_ref(&unset), &mut tx)
+        .await
+        .unwrap();
+    let post: std::collections::HashMap<(Uuid, Uuid), _> = unset_rows
+        .into_iter()
+        .map(|r| ((r.id, r.space_id), r))
+        .collect();
+    storage
+        .insert_relation_versions(&[RelationOp::Unset(unset)], v2_key, &post, &mut tx)
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    let rows = fetch_versions(&pool, rel_id).await;
+    assert_eq!(rows.len(), 2);
+
+    let v2 = &rows[1];
+    assert_eq!(v2.valid_from_key, v2_key);
+    assert_eq!(v2.valid_to_key, None);
+    assert_eq!(v2.context_root_id, Some(root_id));
+    assert_eq!(v2.context_edge_type_id, Some(edge_type_id));
+    // Unset cleared the position; the new version row reflects the post-unset state.
+    assert_eq!(v2.position, None);
+
+    cleanup(&pool, rel_id).await;
+}
+
+// --------------------------------------------------------------------------
+// Regression test: a contextual Create still writes the version row with
+// context. This is the simplest case but covers the original RFC path.
+// --------------------------------------------------------------------------
+#[tokio::test]
+#[ignore]
+async fn create_with_context_writes_version_row() {
+    let pool = get_pool().await;
+    let storage = setup_storage().await;
+
+    let rel_id = Uuid::new_v4();
+    let space_id = Uuid::new_v4();
+    let entity_id = Uuid::new_v4();
+    let from_id = Uuid::new_v4();
+    let to_id = Uuid::new_v4();
+    let type_id = Uuid::new_v4();
+    let root_id = Uuid::new_v4();
+    let edge_type_id = Uuid::new_v4();
+
+    for id in [entity_id, from_id, to_id, type_id, root_id, edge_type_id] {
+        ensure_entity(&pool, id).await;
+    }
+
+    cleanup(&pool, rel_id).await;
+
+    let v1_key: i64 = (3_000_i64) << 32;
+
+    let create = SetRelationItem {
+        id: rel_id,
+        entity_id,
+        type_id,
+        from_id,
+        from_space_id: None,
+        from_version_id: None,
+        to_id,
+        to_space_id: None,
+        to_version_id: None,
+        position: Some("a".to_string()),
+        space_id,
+        verified: None,
+        is_system: false,
+        context_root_id: Some(root_id),
+        context_edge_type_id: Some(edge_type_id),
+    };
+    let mut tx = pool.begin().await.unwrap();
+    storage
+        .insert_relations(std::slice::from_ref(&create), &mut tx)
+        .await
+        .unwrap();
+    storage
+        .insert_relation_versions(
+            &[RelationOp::Create(create)],
+            v1_key,
+            &std::collections::HashMap::new(),
+            &mut tx,
+        )
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+
+    let rows = fetch_versions(&pool, rel_id).await;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].context_root_id, Some(root_id));
+    assert_eq!(rows[0].context_edge_type_id, Some(edge_type_id));
+    assert_eq!(rows[0].valid_from_key, v1_key);
+    assert_eq!(rows[0].valid_to_key, None);
+
+    cleanup(&pool, rel_id).await;
+}

--- a/kg-indexer/tests/system_relations_integration.rs
+++ b/kg-indexer/tests/system_relations_integration.rs
@@ -207,6 +207,8 @@ async fn test_update_relations_does_not_modify_system_relation() {
         position: Some("updated_position".to_string()),
         space_id,
         verified: Some(false),
+        context_root_id: None,
+        context_edge_type_id: None,
     };
 
     let mut tx = pool.begin().await.unwrap();
@@ -264,6 +266,8 @@ async fn test_unset_relation_fields_does_not_nullify_system_relation() {
         position: Some(true), // request to unset
         space_id,
         verified: Some(true), // request to unset
+        context_root_id: None,
+        context_edge_type_id: None,
     };
 
     let mut tx = pool.begin().await.unwrap();


### PR DESCRIPTION
## What

Same correctness fix as **#216**, implemented with **zero reads on the indexer write path**. These two PRs are a deliberate pair — **pick one.**

## The bug (identical to #216)

`insert_relation_versions` only wrote version rows for `Create` ops. An `Update`/`Unset` closed the open `relation_versions` row (`valid_to_key = version_key`) but wrote no successor, so a temporal query at any `version_key >= the update` matches no row → the relation reads as **deleted** even though the live `relations` table is correct. Invisible in prod because the versioned-diff API is the only consumer of that temporal accuracy and relation field-updates are the minority op. (Full explanation in #216.)

## This PR — zero-read (`RETURNING`)

Instead of re-reading the live `relations` table per op, source the post-mutation state from the **`RETURNING`** of the live `UPDATE` that already runs in the same transaction:

- `update_relations` / `unset_relation_fields` now `RETURNING` the full post-mutation rows (`Vec<RelationStateRow>`). The `UPDATE` was already executing — `RETURNING` adds no round trip.
- The caller (`main.rs`, both edit paths) collects those into a `HashMap<(relation_id, space_id), RelationStateRow>` and threads it into `insert_relation_versions`.
- `insert_relation_versions` builds `Update`/`Unset` version rows from that map (no read), attaching the op's `context_root_id` / `context_edge_type_id`. `Create` is synthesized in-memory as before.

**No per-op `SELECT`; the COALESCE/unset merge logic stays in one place** (`update_relations`).

## Tradeoff vs #216

| | #216 (read-based) | This PR (zero-read) |
|---|---|---|
| Write-path reads | per-op `SELECT` (N+1) | **none** |
| Files touched | `storage.rs` (+ models/extract/test) | also `main.rs` (2 call sites) + `update_relations`/`unset_relation_fields` signatures |
| Diff size / risk | smaller, localized | larger, more moving parts |

This honors the team's no-reads-on-the-write-path invariant; #216 is the smaller diff. **Decision needed: merge one, close the other.**

## Scope / notes (same as #216)

- Decoupled from `context_last_to_entity_id` (ships with the v2 diff API PR #215) — targets `dev` with no migration.
- Prod backfill of `relation_versions` may be needed for relations already mis-versioned by past updates.
- Delete-with-context tombstones remain a documented gap.

## Testing

`kg-indexer/tests/relation_versions_context.rs` (gated on `DATABASE_URL`, `--ignored`). Verified locally against Postgres:

```
test create_with_context_writes_version_row ... ok
test update_with_context_inserts_new_version_row ... ok
test unset_with_context_inserts_new_version_row ... ok
```

Opened as **draft** pending the team's read-vs-zero-read decision.
