### PR TITLE
feat(proposal-executor): stage-1 membership-request detection query

### DIFF
--- a/proposal-executor/src/detect.ts
+++ b/proposal-executor/src/detect.ts
@@ -182,6 +182,9 @@ export function findExecutableProposals(client: PgClient, nowSeconds: number): E
  * - Not yet executed (executed_at IS NULL)
  * - Created in the past (guards against corrupt future timestamps; no age cutoff
  *   — backlog is admitted, unlike the executor's MAX_PROPOSAL_AGE)
+ * - Voting period has not ended (now <= end_time) — the protocol rejects votes
+ *   cast after the period closes, and an untouched Fast proposal whose period
+ *   has ended is already classified REJECTED (threshold not reached)
  * - Exactly one action, an AddMember targeting the proposer itself
  *   (target_id = proposed_by) — the self-service request-to-join signature, not
  *   an editor-initiated add
@@ -202,6 +205,7 @@ WHERE p.space_id = ANY($1)
   AND p.voting_mode = 'Fast'
   AND p.executed_at IS NULL
   AND p.created_at::bigint <= $2::bigint
+  AND $2::bigint <= p.end_time
   AND a.action_type = 'AddMember'
   AND a.target_id = p.proposed_by
   AND NOT EXISTS (SELECT 1 FROM proposal_votes pv WHERE pv.proposal_id = p.id)

--- a/proposal-executor/src/detect.ts
+++ b/proposal-executor/src/detect.ts
@@ -26,6 +26,19 @@ export interface Proposal {
 	spaceId: string
 }
 
+/**
+ * A request-to-join proposal: a Fast-mode proposal whose single action admits
+ * its own proposer (self-service join). Candidate for an auto-accept YES vote.
+ */
+export interface MembershipRequest {
+	/** Proposal UUID (with dashes) */
+	id: string
+	/** DAO space UUID being joined (with dashes); always in the allowlist */
+	spaceId: string
+	/** Member space UUID being added (== proposedBy for a self-service request) */
+	requesterId: string
+}
+
 // ---------------------------------------------------------------------------
 // Clock skew buffer
 // ---------------------------------------------------------------------------
@@ -153,6 +166,82 @@ export function findExecutableProposals(client: PgClient, nowSeconds: number): E
 					? error.message.replace(/postgresql?:\/\/[^\s]+/gi, "<redacted>")
 					: "unknown error"
 			return new InfraError({message: `Detection query failed: ${safe}`, durationMs: 0})
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Membership-request detection (stage 1)
+// ---------------------------------------------------------------------------
+
+/**
+ * Finds open, untouched, allowlisted request-to-join proposals (stage 1 of the
+ * two-stage untouched check — the indexer side). A row qualifies iff:
+ * - space_id is in the allowlist ($1)
+ * - Fast voting mode (a single YES vote can execute via the fast-path threshold)
+ * - Not yet executed (executed_at IS NULL)
+ * - Created in the past (guards against corrupt future timestamps; no age cutoff
+ *   — backlog is admitted, unlike the executor's MAX_PROPOSAL_AGE)
+ * - Exactly one action, an AddMember targeting the proposer itself
+ *   (target_id = proposed_by) — the self-service request-to-join signature, not
+ *   an editor-initiated add
+ * - No indexed votes (NOT EXISTS in proposal_votes) — checks raw indexed votes,
+ *   not the async-denormalized yes_count/no_count/abstain_count columns
+ *
+ * This filters voting_mode = 'Fast' while the executor's query filters 'Slow',
+ * so the two paths never return the same proposal.
+ *
+ * ORDER BY created_at::bigint ASC for FIFO ordering (created_at is text Unix
+ * seconds, so the ::bigint cast ensures numeric ordering).
+ */
+export const MEMBERSHIP_DETECTION_SQL = `
+SELECT p.id, p.space_id AS "spaceId", a.target_id AS "requesterId"
+FROM proposals p
+JOIN proposal_actions a ON a.proposal_id = p.id
+WHERE p.space_id = ANY($1)
+  AND p.voting_mode = 'Fast'
+  AND p.executed_at IS NULL
+  AND p.created_at::bigint <= $2::bigint
+  AND a.action_type = 'AddMember'
+  AND a.target_id = p.proposed_by
+  AND NOT EXISTS (SELECT 1 FROM proposal_votes pv WHERE pv.proposal_id = p.id)
+  AND (SELECT COUNT(*) FROM proposal_actions a2 WHERE a2.proposal_id = p.id) = 1
+ORDER BY p.created_at::bigint ASC
+`
+
+/**
+ * Find all untouched request-to-join proposals in allowlisted spaces that are
+ * candidates for an auto-accept YES vote.
+ *
+ * Short-circuits to [] without querying when the allowlist is empty — the
+ * kill switch (an emptied MEMBERSHIP_AUTOACCEPT_SPACE_IDS stops all activity).
+ *
+ * @param client - Connected pg.Client
+ * @param allowlistSpaceIds - Dashed UUIDs of allowlisted DAO spaces (from bytes16 config)
+ */
+export function findMembershipRequests(
+	client: PgClient,
+	allowlistSpaceIds: string[],
+): Effect.Effect<MembershipRequest[], InfraError> {
+	if (allowlistSpaceIds.length === 0) {
+		return Effect.succeed([])
+	}
+	const nowSeconds = Math.floor(Date.now() / 1000)
+	return Effect.tryPromise({
+		try: async () => {
+			const result = await client.query<MembershipRequest>(MEMBERSHIP_DETECTION_SQL, [
+				allowlistSpaceIds,
+				nowSeconds,
+			])
+			return result.rows
+		},
+		catch: (error) => {
+			// Sanitize: pg errors on broken connections may contain the connection string (with password).
+			const safe =
+				error instanceof Error
+					? error.message.replace(/postgresql?:\/\/[^\s]+/gi, "<redacted>")
+					: "unknown error"
+			return new InfraError({message: `Membership detection query failed: ${safe}`, durationMs: 0})
 		},
 	})
 }

--- a/proposal-executor/tests/detect.test.ts
+++ b/proposal-executor/tests/detect.test.ts
@@ -132,9 +132,14 @@ describe("membership detection SQL", () => {
 
 	test("guards against corrupt future timestamps but applies no age cutoff", () => {
 		expect(membershipSql).toContain("p.created_at::bigint <= $2::bigint")
-		// Backlog is admitted: no maximum-age bound and no voting-period gate.
+		// Backlog is admitted: no maximum-age bound (unlike the executor query).
 		expect(membershipSql).not.toContain("MAX_PROPOSAL_AGE")
-		expect(membershipSql).not.toContain("end_time")
+	})
+
+	test("excludes proposals whose voting period has ended", () => {
+		// Votes cast after end_time are rejected by the protocol, and an untouched
+		// Fast proposal past its period is already classified REJECTED.
+		expect(membershipSql).toContain("$2::bigint <= p.end_time")
 	})
 })
 

--- a/proposal-executor/tests/detect.test.ts
+++ b/proposal-executor/tests/detect.test.ts
@@ -7,7 +7,9 @@
  */
 
 import {describe, expect, test} from "bun:test"
+import {Effect} from "effect"
 import {RATIO_BASE} from "../src/contracts.js"
+import {findMembershipRequests, MEMBERSHIP_DETECTION_SQL} from "../src/detect.js"
 
 // ---------------------------------------------------------------------------
 // RATIO_BASE cross-validation
@@ -72,5 +74,103 @@ describe("Proposal type", () => {
 		}
 		expect(proposal.id).toContain("-") // UUID with dashes
 		expect(proposal.spaceId).toContain("-") // UUID with dashes
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Membership-request detection SQL (stage 1)
+// ---------------------------------------------------------------------------
+
+// Whitespace-normalized SQL for robust substring assertions.
+const membershipSql = MEMBERSHIP_DETECTION_SQL.replace(/\s+/g, " ").trim()
+
+describe("membership detection SQL", () => {
+	test("scopes to the allowlist via space_id = ANY($1)", () => {
+		expect(membershipSql).toContain("p.space_id = ANY($1)")
+	})
+
+	test("selects only Fast-mode proposals (a single YES vote can execute)", () => {
+		expect(membershipSql).toContain("p.voting_mode = 'Fast'")
+	})
+
+	test("requires the action to be a self-service AddMember (target == proposer)", () => {
+		expect(membershipSql).toContain("a.action_type = 'AddMember'")
+		expect(membershipSql).toContain("a.target_id = p.proposed_by")
+	})
+
+	test("projects the MembershipRequest row shape {id, spaceId, requesterId}", () => {
+		expect(membershipSql).toContain("p.id")
+		expect(membershipSql).toContain('p.space_id AS "spaceId"')
+		expect(membershipSql).toContain('a.target_id AS "requesterId"')
+	})
+
+	test("orders FIFO by numeric created_at", () => {
+		expect(membershipSql).toContain("ORDER BY p.created_at::bigint ASC")
+	})
+
+	test("excludes proposals with any indexed vote", () => {
+		expect(membershipSql).toContain("NOT EXISTS (SELECT 1 FROM proposal_votes pv WHERE pv.proposal_id = p.id)")
+	})
+
+	test("excludes executed proposals", () => {
+		expect(membershipSql).toContain("p.executed_at IS NULL")
+	})
+
+	test("excludes editor-initiated adds by requiring target_id = proposed_by", () => {
+		// An editor-initiated add has proposed_by != target_id, so this predicate filters it out.
+		expect(membershipSql).toContain("a.target_id = p.proposed_by")
+	})
+
+	test("excludes multi-action proposals (exactly one action required)", () => {
+		expect(membershipSql).toContain("(SELECT COUNT(*) FROM proposal_actions a2 WHERE a2.proposal_id = p.id) = 1")
+	})
+
+	test("excludes Slow-mode proposals (Fast-only filter never overlaps the executor query)", () => {
+		expect(membershipSql).toContain("p.voting_mode = 'Fast'")
+		expect(membershipSql).not.toContain("'Slow'")
+	})
+
+	test("guards against corrupt future timestamps but applies no age cutoff", () => {
+		expect(membershipSql).toContain("p.created_at::bigint <= $2::bigint")
+		// Backlog is admitted: no maximum-age bound and no voting-period gate.
+		expect(membershipSql).not.toContain("MAX_PROPOSAL_AGE")
+		expect(membershipSql).not.toContain("end_time")
+	})
+})
+
+// ---------------------------------------------------------------------------
+// findMembershipRequests — kill switch / gating
+// ---------------------------------------------------------------------------
+
+describe("findMembershipRequests", () => {
+	// An empty allowlist is the kill switch: stop all activity, do not query.
+	test("short-circuits to [] without issuing a query when the allowlist is empty", async () => {
+		let queried = false
+		const fakeClient = {
+			query: async () => {
+				queried = true
+				return {rows: []}
+			},
+		} as never
+
+		const result = await Effect.runPromise(findMembershipRequests(fakeClient, []))
+		expect(result).toEqual([])
+		expect(queried).toBe(false)
+	})
+
+	// Gating: only allowlisted spaces reach the query, bound as ANY($1).
+	test("passes the allowlist as the first bind parameter", async () => {
+		const allowlist = ["660e8400-e29b-41d4-a716-446655440000"]
+		let boundParams: unknown[] = []
+		const fakeClient = {
+			query: async (_sql: string, params: unknown[]) => {
+				boundParams = params
+				return {rows: []}
+			},
+		} as never
+
+		await Effect.runPromise(findMembershipRequests(fakeClient, allowlist))
+		expect(boundParams[0]).toEqual(allowlist)
+		expect(typeof boundParams[1]).toBe("number") // nowSeconds guard
 	})
 })


### PR DESCRIPTION
Add MembershipRequest type and findMembershipRequests() to detect.ts: the stage-1 (indexer-side) check for untouched request-to-join proposals in allowlisted spaces. Filters Fast-mode, not-executed, single AddMember self-requests (target_id = proposed_by) with no indexed votes; empty allowlist short-circuits to [] (kill switch). Filters 'Fast' where the executor query filters 'Slow', so the two paths never overlap.

Cover selection, exclusion (indexed votes, executed, editor-initiated adds, multi-action, Slow-mode), and gating/kill-switch cases.