### PR TITLE
feat: add 'testnet' environment for shared-broker isolation

### DIFF
--- a/api/main.ts
+++ b/api/main.ts
@@ -90,11 +90,15 @@ if (opensearchUrl) {
 		throw error
 	}
 
-	// Get environment-specific index name
-	// staging -> staging_entities, production -> entities
+	// Get environment-specific index name; must mirror search-indexer-shared's
+	// get_index_prefix(): staging -> staging_entities, testnet -> testnet_entities,
+	// production -> entities
 	const environment = process.env.ENVIRONMENT
 	const baseIndexAlias = process.env.INDEX_ALIAS ?? "entities"
-	const indexName = environment === "staging" ? `staging_${baseIndexAlias}` : baseIndexAlias
+	const indexName =
+		environment === "staging" || environment === "testnet"
+			? `${environment}_${baseIndexAlias}`
+			: baseIndexAlias
 
 	const searchClient = new OpenSearchClient(opensearchUrl, indexName)
 	await searchClient.init()

--- a/hermes-kafka/src/lib.rs
+++ b/hermes-kafka/src/lib.rs
@@ -195,6 +195,7 @@ static TOPIC_PREFIX: OnceLock<&'static str> = OnceLock::new();
 /// of the process. Returns a `&'static str` for zero-allocation usage.
 ///
 /// - `ENVIRONMENT=staging` → returns `"staging."`
+/// - `ENVIRONMENT=testnet` → returns `"testnet."`
 /// - `ENVIRONMENT=production` → returns `""`
 ///
 /// # Panics
@@ -212,12 +213,13 @@ static TOPIC_PREFIX: OnceLock<&'static str> = OnceLock::new();
 pub fn get_topic_prefix() -> &'static str {
     TOPIC_PREFIX.get_or_init(|| {
         let environment = env::var("ENVIRONMENT")
-            .expect("ENVIRONMENT variable must be set to 'staging' or 'production'");
+            .expect("ENVIRONMENT variable must be set to 'staging', 'testnet' or 'production'");
         match environment.as_str() {
             "staging" => "staging.",
+            "testnet" => "testnet.",
             "production" => "",
             other => panic!(
-                "ENVIRONMENT must be 'staging' or 'production', got '{}'",
+                "ENVIRONMENT must be 'staging', 'testnet' or 'production', got '{}'",
                 other
             ),
         }
@@ -240,8 +242,9 @@ pub fn prefixed_topic(prefix: &str, base: &str) -> String {
 
 /// Strip the environment prefix from a topic name.
 ///
-/// In staging, topics are prefixed with "staging." (e.g., "staging.hermes.blocks").
-/// This function strips that prefix so consumers can match on canonical topic names.
+/// In staging/testnet, topics are prefixed with "staging." / "testnet."
+/// (e.g., "staging.hermes.blocks"). This function strips that prefix so
+/// consumers can match on canonical topic names.
 ///
 /// # Example
 ///
@@ -249,10 +252,14 @@ pub fn prefixed_topic(prefix: &str, base: &str) -> String {
 /// use hermes_kafka::strip_topic_prefix;
 ///
 /// assert_eq!(strip_topic_prefix("staging.hermes.blocks"), "hermes.blocks");
+/// assert_eq!(strip_topic_prefix("testnet.hermes.blocks"), "hermes.blocks");
 /// assert_eq!(strip_topic_prefix("hermes.blocks"), "hermes.blocks");
 /// ```
 pub fn strip_topic_prefix(topic: &str) -> &str {
-    topic.strip_prefix("staging.").unwrap_or(topic)
+    topic
+        .strip_prefix("staging.")
+        .or_else(|| topic.strip_prefix("testnet."))
+        .unwrap_or(topic)
 }
 
 #[cfg(test)]
@@ -297,6 +304,17 @@ mod tests {
     fn test_strip_topic_prefix_without_staging() {
         assert_eq!(strip_topic_prefix("hermes.blocks"), "hermes.blocks");
         assert_eq!(strip_topic_prefix("knowledge.edits"), "knowledge.edits");
+    }
+
+    #[test]
+    fn test_strip_topic_prefix_with_testnet() {
+        assert_eq!(strip_topic_prefix("testnet.hermes.blocks"), "hermes.blocks");
+        assert_eq!(
+            strip_topic_prefix("testnet.space.trust.extensions"),
+            "space.trust.extensions"
+        );
+        // Should NOT strip if "testnet" is not a prefix
+        assert_eq!(strip_topic_prefix("my.testnet.topic"), "my.testnet.topic");
     }
 
     #[test]

--- a/search-admin/src/main.rs
+++ b/search-admin/src/main.rs
@@ -15,10 +15,12 @@ use commands::{
 /// Get the prefixed alias name based on environment.
 ///
 /// - `staging` → `staging_{base_alias}`
+/// - `testnet` → `testnet_{base_alias}`
 /// - `production` (or any other value) → `{base_alias}`
 fn get_prefixed_alias(environment: &str, base_alias: &str) -> String {
     match environment {
         "staging" => format!("staging_{}", base_alias),
+        "testnet" => format!("testnet_{}", base_alias),
         _ => base_alias.to_string(),
     }
 }
@@ -78,10 +80,10 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     // Validate environment value
-    if cli.environment != "staging" && cli.environment != "production" {
+    if cli.environment != "staging" && cli.environment != "testnet" && cli.environment != "production" {
         error!(
             environment = %cli.environment,
-            "ENVIRONMENT must be 'staging' or 'production'"
+            "ENVIRONMENT must be 'staging', 'testnet' or 'production'"
         );
         std::process::exit(1);
     }

--- a/search-indexer-shared/src/env.rs
+++ b/search-indexer-shared/src/env.rs
@@ -18,6 +18,7 @@ static CONSUMER_GROUP_PREFIX: OnceLock<&'static str> = OnceLock::new();
 /// of the process. Returns a `&'static str` for zero-allocation usage.
 ///
 /// - `ENVIRONMENT=staging` → returns `"staging_"`
+/// - `ENVIRONMENT=testnet` → returns `"testnet_"`
 /// - `ENVIRONMENT=production` → returns `""`
 ///
 /// # Panics
@@ -35,12 +36,13 @@ static CONSUMER_GROUP_PREFIX: OnceLock<&'static str> = OnceLock::new();
 pub fn get_index_prefix() -> &'static str {
     INDEX_PREFIX.get_or_init(|| {
         let environment = env::var("ENVIRONMENT")
-            .expect("ENVIRONMENT variable must be set to 'staging' or 'production'");
+            .expect("ENVIRONMENT variable must be set to 'staging', 'testnet' or 'production'");
         match environment.as_str() {
             "staging" => "staging_",
+            "testnet" => "testnet_",
             "production" => "",
             other => panic!(
-                "ENVIRONMENT must be 'staging' or 'production', got '{}'",
+                "ENVIRONMENT must be 'staging', 'testnet' or 'production', got '{}'",
                 other
             ),
         }
@@ -53,6 +55,7 @@ pub fn get_index_prefix() -> &'static str {
 /// of the process. Returns a `&'static str` for zero-allocation usage.
 ///
 /// - `ENVIRONMENT=staging` → returns `"staging-"`
+/// - `ENVIRONMENT=testnet` → returns `"testnet-"`
 /// - `ENVIRONMENT=production` → returns `""`
 ///
 /// # Panics
@@ -72,12 +75,13 @@ pub fn get_index_prefix() -> &'static str {
 pub fn get_consumer_group_prefix() -> &'static str {
     CONSUMER_GROUP_PREFIX.get_or_init(|| {
         let environment = env::var("ENVIRONMENT")
-            .expect("ENVIRONMENT variable must be set to 'staging' or 'production'");
+            .expect("ENVIRONMENT variable must be set to 'staging', 'testnet' or 'production'");
         match environment.as_str() {
             "staging" => "staging-",
+            "testnet" => "testnet-",
             "production" => "",
             other => panic!(
-                "ENVIRONMENT must be 'staging' or 'production', got '{}'",
+                "ENVIRONMENT must be 'staging', 'testnet' or 'production', got '{}'",
                 other
             ),
         }

--- a/search-indexer/src/consumer/scores_consumer.rs
+++ b/search-indexer/src/consumer/scores_consumer.rs
@@ -57,9 +57,10 @@ impl ScoresConsumer {
     /// * `group_id` - Consumer group ID (will append "-scores" suffix)
     pub fn new(brokers: &str, group_id: &str) -> Result<Self, IngestError> {
         // Scores are produced by the Python scoring cron which uses "{environment}."
-        // as the topic prefix (e.g. "production.curation.scores", "staging.curation.scores").
+        // as the topic prefix (e.g. "production.curation.scores", "staging.curation.scores",
+        // "testnet.curation.scores").
         let environment = env::var("ENVIRONMENT")
-            .expect("ENVIRONMENT variable must be set to 'staging' or 'production'");
+            .expect("ENVIRONMENT variable must be set to 'staging', 'testnet' or 'production'");
         let base_topic =
             env::var("SCORES_KAFKA_TOPIC").unwrap_or_else(|_| Self::SCORES_TOPIC.to_string());
         let topic = format!("{}.{}", environment, base_topic);


### PR DESCRIPTION
## Why

The gaia-v2 chain-migration stack (GEO-664) can't get a dedicated Kafka cluster (DO database-cluster limit reached), so it must share the existing broker with prod (unprefixed topics) and staging (`staging.*`). It therefore needs a third environment prefix.

## What

`ENVIRONMENT=testnet` is now accepted everywhere `staging`/`production` are, yielding a fully isolated namespace:

| Subsystem | Prefix | Where |
|---|---|---|
| Kafka topics | `testnet.*` | `hermes-kafka::get_topic_prefix` — inherited by hermes-pipeline, atlas, kg-indexer, search-indexer consumers, vote/topology-indexer, notification-indexer |
| Topic canonicalization | strips `testnet.` | `hermes-kafka::strip_topic_prefix` (kg-indexer would otherwise fail to match topics) |
| OpenSearch index | `testnet_<alias>` | `search-indexer-shared::get_index_prefix`, `search-admin`, `api/main.ts` |
| Consumer groups | `testnet-*` | `search-indexer-shared::get_consumer_group_prefix` |

No logic change needed in the scoring path: the Python cron and `scores_consumer` both build `{environment}.curation.scores` from the raw value.

## Testing

- `cargo test -p hermes-kafka -p search-indexer-shared` — green, incl. new `strip_topic_prefix` testnet cases
- `cargo check -p search-admin -p search-indexer -p kg-indexer` — clean
- `api`: `tsc --noEmit` — clean

Part of GEO-664; companion to the [DO deploy runbook](https://app.notion.com/p/37c9a4c092c781e49259c39cdea3c16c).

