### PR TITLE
feat(proposal-executor): membership stage-2 read + YES vote cast

### DIFF
--- a/proposal-executor/src/execute.ts
+++ b/proposal-executor/src/execute.ts
@@ -225,7 +225,7 @@ const REVERT_ERROR_NAMES = new Set([
 /** Fallback string patterns when structured error types aren't available */
 const REVERT_MESSAGE_PATTERNS = ["revert", "execution reverted", "CALL_EXCEPTION", "UserOperation reverted"]
 
-function classifyAsRevert(error: unknown, errorName: string, message: string): boolean {
+export function classifyAsRevert(error: unknown, errorName: string, message: string): boolean {
 	// 1. Check structured error name (most reliable)
 	if (REVERT_ERROR_NAMES.has(errorName)) return true
 

--- a/proposal-executor/src/membership.ts
+++ b/proposal-executor/src/membership.ts
@@ -1,0 +1,240 @@
+/**
+ * Membership-accept path: stage-2 on-chain eligibility read + PROPOSAL_VOTED (Yes)
+ * vote cast, both performed by the dedicated bot wallet.
+ *
+ * Stage 1 (the indexer side) lives in detect.ts (findMembershipRequests). This module
+ * is the authoritative stage-2 half of the "untouched" check: it reads the live on-chain
+ * tally from the per-space DAOSpace contract and casts a single YES vote on a still-
+ * untouched request. Because allowlisted spaces run with fastPathFlatThreshold = 1, that
+ * one YES vote meets the threshold and the contract executes the AddMember action in the
+ * same transaction — admitting the joiner with no human in the loop.
+ *
+ * Reuses the executor's smart-wallet, enter() calldata pattern, encoding helpers, and
+ * error classification (classifyAsRevert) wholesale — see execute.ts.
+ */
+
+import {Effect} from "effect"
+import {type Address, encodeAbiParameters, encodeFunctionData, type Hex} from "viem"
+import {
+	DAOSpaceAbi,
+	EMPTY_SIGNATURE,
+	InfraError,
+	PROPOSAL_VOTED_ACTION,
+	RevertError,
+	SpaceRegistryAbi,
+	VOTE_YES,
+} from "./contracts.js"
+import type {MembershipRequest} from "./detect.js"
+import {classifyAsRevert, padBytes16ToBytes32, type SmartWallet, uuidToBytes16} from "./execute.js"
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** The on-chain Tally plus the executed flag from getLatestProposalInformation. */
+export interface ProposalTally {
+	executed: boolean
+	yes: bigint
+	no: bigint
+	abstain: bigint
+}
+
+/** SpaceRegistry.spaceIdToAddress returns this for an unregistered space. */
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+
+// ---------------------------------------------------------------------------
+// Sanitization — never leak a bundler URL's API key into an error message.
+// Defense in depth: mirrors the pattern in execute.ts / detect.ts.
+// ---------------------------------------------------------------------------
+
+function sanitizeError(error: unknown): string {
+	return String(error).replace(/apikey=[^\s&"]+/gi, "apikey=<redacted>")
+}
+
+// ---------------------------------------------------------------------------
+// Vote-data encoding
+// ---------------------------------------------------------------------------
+
+/**
+ * ABI-encode the PROPOSAL_VOTED data payload: abi.encode(bytes16 proposalId, uint8 voteOption).
+ * A YES vote passes VOTE_YES (1) — see the IDAOSpace.VoteOption enum (None=0, Yes=1, No=2, Abstain=3).
+ */
+export function encodeVoteData(proposalIdHex: Hex, voteOption: number): Hex {
+	return encodeAbiParameters(
+		[
+			{name: "proposalId", type: "bytes16"},
+			{name: "voteOption", type: "uint8"},
+		],
+		[proposalIdHex, voteOption],
+	)
+}
+
+// ---------------------------------------------------------------------------
+// DAO space address resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a DAO space's on-chain contract address via SpaceRegistry.spaceIdToAddress.
+ * The vote-tally getters live on the per-space DAOSpace contract, not the registry, so
+ * this must be resolved before reading the tally. Resolve once per space (cache per run).
+ *
+ * A zero address means the space is unregistered (misconfiguration) — surfaced as an
+ * InfraError so the space is skipped and retried next cycle.
+ */
+export function resolveDaoSpaceAddress(
+	wallet: SmartWallet,
+	spaceRegistryAddress: Address,
+	daoSpaceId: Hex,
+): Effect.Effect<Address, InfraError> {
+	return Effect.tryPromise({
+		try: async () => {
+			const address = await wallet.publicClient.readContract({
+				address: spaceRegistryAddress,
+				abi: SpaceRegistryAbi,
+				functionName: "spaceIdToAddress",
+				args: [daoSpaceId],
+			})
+			if (address.toLowerCase() === ZERO_ADDRESS) {
+				throw new Error(
+					`DAO space ${daoSpaceId} is not registered (spaceIdToAddress returned the zero address)`,
+				)
+			}
+			return address
+		},
+		catch: (error) =>
+			new InfraError({message: `DAO space address resolution failed: ${sanitizeError(error)}`, durationMs: 0}),
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Stage-2 authoritative untouched read
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the live on-chain tally for a proposal from its DAOSpace contract.
+ *
+ * This is the authoritative stage-2 untouched check. It closes the indexing-lag window
+ * (a vote may already be on-chain before the indexer surfaces it) and, because the bot's
+ * own prior vote shows up here immediately, it makes the job idempotent across cycles.
+ */
+export function readProposalTally(
+	wallet: SmartWallet,
+	daoSpaceAddress: Address,
+	proposalId: string,
+): Effect.Effect<ProposalTally, InfraError> {
+	return Effect.tryPromise({
+		try: async () => {
+			const proposalIdHex = uuidToBytes16(proposalId)
+			const [executed, , , tally] = await wallet.publicClient.readContract({
+				address: daoSpaceAddress,
+				abi: DAOSpaceAbi,
+				functionName: "getLatestProposalInformation",
+				args: [proposalIdHex],
+			})
+			return {executed, yes: tally.yes, no: tally.no, abstain: tally.abstain}
+		},
+		catch: (error) =>
+			new InfraError({
+				proposalId,
+				message: `Proposal tally read failed: ${sanitizeError(error)}`,
+				durationMs: 0,
+			}),
+	})
+}
+
+/**
+ * A request is eligible for an auto-accept YES vote iff it has not executed and no vote of
+ * any kind is recorded on-chain. A non-zero tally covers both a human's vote (indexing lag)
+ * and the bot's own in-flight vote → SKIP (reason: onchain_tally_nonzero), idempotency.
+ */
+export function isEligibleToVote(tally: ProposalTally): boolean {
+	return !tally.executed && tally.yes === 0n && tally.no === 0n && tally.abstain === 0n
+}
+
+// ---------------------------------------------------------------------------
+// Vote cast
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify a vote-cast failure, reusing the executor's revert detection.
+ *
+ * Expected reverts (the request is already resolved by someone else): "already executed",
+ * CanNotExecute, InvalidAction → RevertError(expected=true), logged INFO. A CanNotVote
+ * revert means the bot lacks the EDITOR role — a real misconfiguration → expected=false,
+ * skipped and retried next cycle. Everything else is infrastructure → InfraError.
+ */
+function classifyVoteError(error: unknown, proposalId: string, durationMs: number): RevertError | InfraError {
+	const message = sanitizeError(error)
+	const errorName = error instanceof Error ? error.name : typeof error
+
+	if (classifyAsRevert(error, errorName, message)) {
+		const isExpected =
+			message.includes("already executed") ||
+			message.includes("ProposalAlreadyExecuted") ||
+			message.includes("CanNotExecute") ||
+			message.includes("InvalidAction")
+		return new RevertError({proposalId, message: `[${errorName}] ${message}`, expected: isExpected, durationMs})
+	}
+
+	return new InfraError({proposalId, message: `[${errorName}] ${message}`, durationMs})
+}
+
+/**
+ * Cast a single YES vote on a membership request via the bot wallet.
+ *
+ * Builds the same gas-sponsored enter() UserOperation the executor uses, with the
+ * PROPOSAL_VOTED action and the (proposalId, Yes) vote data:
+ *
+ *   enter(botSpaceId, daoSpaceId, PROPOSAL_VOTED, bytes32(proposalId),
+ *         abi.encode(bytes16 proposalId, uint8 1), "0x")
+ *
+ * Returns the transaction hash on success. Errors are classified as RevertError /
+ * InfraError; retry and timeout are composed externally in index.ts.
+ */
+export function castMembershipVote(
+	wallet: SmartWallet,
+	request: MembershipRequest,
+	botSpaceId: Hex,
+	spaceRegistryAddress: Address,
+): Effect.Effect<string, RevertError | InfraError> {
+	// Effect.suspend captures `start` fresh on each retry attempt so durationMs reflects
+	// only the current attempt's wall time (matches executeProposal).
+	return Effect.suspend(() => {
+		const start = Date.now()
+
+		return Effect.tryPromise({
+			try: async () => {
+				const daoSpaceId = uuidToBytes16(request.spaceId)
+				const proposalIdHex = uuidToBytes16(request.id)
+
+				const calldata = encodeFunctionData({
+					abi: SpaceRegistryAbi,
+					functionName: "enter",
+					args: [
+						botSpaceId, // bytes16: membership bot's personal space ID
+						daoSpaceId, // bytes16: DAO space being joined
+						PROPOSAL_VOTED_ACTION, // bytes32: action hash
+						padBytes16ToBytes32(proposalIdHex), // bytes32: topic = bytes32(proposalId), left-aligned
+						encodeVoteData(proposalIdHex, VOTE_YES), // bytes: abi.encode(bytes16 proposalId, uint8 1)
+						EMPTY_SIGNATURE, // bytes: "0x" (ignored when msg.sender == _fromSpace)
+					],
+				})
+
+				const account = wallet.smartAccountClient.account
+				if (!account) {
+					throw new Error("Smart account client has no account — bot wallet was not initialized correctly")
+				}
+
+				const hash = await wallet.smartAccountClient.sendTransaction({
+					account,
+					chain: wallet.chain,
+					to: spaceRegistryAddress,
+					data: calldata,
+				})
+
+				return hash
+			},
+			catch: (error) => classifyVoteError(error, request.id, Date.now() - start),
+		})
+	})
+}

--- a/proposal-executor/src/membership.ts
+++ b/proposal-executor/src/membership.ts
@@ -111,23 +111,31 @@ export function resolveDaoSpaceAddress(
 	spaceRegistryAddress: Address,
 	daoSpaceId: Hex,
 ): Effect.Effect<Address, InfraError> {
-	return Effect.tryPromise({
-		try: async () => {
-			const address = await wallet.publicClient.readContract({
-				address: spaceRegistryAddress,
-				abi: SpaceRegistryAbi,
-				functionName: "spaceIdToAddress",
-				args: [daoSpaceId],
-			})
-			if (address.toLowerCase() === ZERO_ADDRESS) {
-				throw new Error(
-					`DAO space ${daoSpaceId} is not registered (spaceIdToAddress returned the zero address)`,
-				)
-			}
-			return address
-		},
-		catch: (error) =>
-			new InfraError({message: `DAO space address resolution failed: ${sanitizeError(error)}`, durationMs: 0}),
+	// Effect.suspend captures `start` fresh on each retry attempt, so durationMs
+	// reflects only the current attempt's wall time — mirrors executeProposal().
+	return Effect.suspend(() => {
+		const start = Date.now()
+		return Effect.tryPromise({
+			try: async () => {
+				const address = await wallet.publicClient.readContract({
+					address: spaceRegistryAddress,
+					abi: SpaceRegistryAbi,
+					functionName: "spaceIdToAddress",
+					args: [daoSpaceId],
+				})
+				if (address.toLowerCase() === ZERO_ADDRESS) {
+					throw new Error(
+						`DAO space ${daoSpaceId} is not registered (spaceIdToAddress returned the zero address)`,
+					)
+				}
+				return address
+			},
+			catch: (error) =>
+				new InfraError({
+					message: `DAO space address resolution failed: ${sanitizeError(error)}`,
+					durationMs: Date.now() - start,
+				}),
+		})
 	})
 }
 
@@ -147,30 +155,35 @@ export function readProposalTally(
 	daoSpaceAddress: Address,
 	proposalId: string,
 ): Effect.Effect<ProposalTally, InfraError> {
-	return Effect.tryPromise({
-		try: async () => {
-			const proposalIdHex = uuidToBytes16(proposalId)
-			const [executed, , parameters, tally] = await wallet.publicClient.readContract({
-				address: daoSpaceAddress,
-				abi: DAOSpaceAbi,
-				functionName: "getLatestProposalInformation",
-				args: [proposalIdHex],
-			})
-			return {
-				executed,
-				yes: tally.yes,
-				no: tally.no,
-				abstain: tally.abstain,
-				startDate: parameters.startDate,
-				lastDate: parameters.lastDate,
-			}
-		},
-		catch: (error) =>
-			new InfraError({
-				proposalId,
-				message: `Proposal tally read failed: ${sanitizeError(error)}`,
-				durationMs: 0,
-			}),
+	// Effect.suspend captures `start` fresh on each retry attempt, so durationMs
+	// reflects only the current attempt's wall time — mirrors executeProposal().
+	return Effect.suspend(() => {
+		const start = Date.now()
+		return Effect.tryPromise({
+			try: async () => {
+				const proposalIdHex = uuidToBytes16(proposalId)
+				const [executed, , parameters, tally] = await wallet.publicClient.readContract({
+					address: daoSpaceAddress,
+					abi: DAOSpaceAbi,
+					functionName: "getLatestProposalInformation",
+					args: [proposalIdHex],
+				})
+				return {
+					executed,
+					yes: tally.yes,
+					no: tally.no,
+					abstain: tally.abstain,
+					startDate: parameters.startDate,
+					lastDate: parameters.lastDate,
+				}
+			},
+			catch: (error) =>
+				new InfraError({
+					proposalId,
+					message: `Proposal tally read failed: ${sanitizeError(error)}`,
+					durationMs: Date.now() - start,
+				}),
+		})
 	})
 }
 

--- a/proposal-executor/src/membership.ts
+++ b/proposal-executor/src/membership.ts
@@ -99,6 +99,12 @@ export function encodeVoteData(proposalIdHex: Hex, voteOption: number): Hex {
  *
  * A zero address means the space is unregistered (misconfiguration) — surfaced as an
  * InfraError so the space is skipped and retried next cycle.
+ *
+ * TODO(caching): this helper always performs a readContract() despite the "cache per run"
+ * note above — caching is the caller's responsibility today, which is easy to get wrong once
+ * a future orchestrator reuses this module. Either (a) add a memoizing wrapper here, e.g.
+ * makeDaoSpaceResolver(wallet, registryAddr) returning a fn backed by an internal
+ * Map<Hex, Address>, or (b) reword the docstring to state explicitly that callers must cache.
  */
 export function resolveDaoSpaceAddress(
 	wallet: SmartWallet,

--- a/proposal-executor/src/membership.ts
+++ b/proposal-executor/src/membership.ts
@@ -31,16 +31,35 @@ import {classifyAsRevert, padBytes16ToBytes32, type SmartWallet, uuidToBytes16} 
 // Types
 // ---------------------------------------------------------------------------
 
-/** The on-chain Tally plus the executed flag from getLatestProposalInformation. */
+/**
+ * The on-chain Tally plus the executed flag and voting-window bounds from
+ * getLatestProposalInformation. startDate/lastDate come from ProposalParameters
+ * and are authoritative: the protocol rejects a vote whose block.timestamp falls
+ * outside [startDate, lastDate], so stage-2 eligibility must honour them.
+ */
 export interface ProposalTally {
 	executed: boolean
 	yes: bigint
 	no: bigint
 	abstain: bigint
+	/** Unix seconds the voting window opens (ProposalParameters.startDate). */
+	startDate: bigint
+	/** Unix seconds the voting window closes (ProposalParameters.lastDate); later votes revert. */
+	lastDate: bigint
 }
 
 /** SpaceRegistry.spaceIdToAddress returns this for an unregistered space. */
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+
+/**
+ * Seconds of slack added past the on-chain voting window's close when deciding
+ * whether to vote. The buffer is applied leniently (it extends the window rather
+ * than shrinking it): missing a genuinely-open request during its final seconds
+ * is worse than casting a vote that the contract rejects. So near the boundary we
+ * prefer to vote and risk an at-most-CLOCK_SKEW_BUFFER_SECONDS-late revert over a
+ * conservative skip. Mirrors the detection query's clock-skew constant.
+ */
+export const CLOCK_SKEW_BUFFER_SECONDS = 60n
 
 // ---------------------------------------------------------------------------
 // Sanitization — never leak a bundler URL's API key into an error message.
@@ -125,13 +144,20 @@ export function readProposalTally(
 	return Effect.tryPromise({
 		try: async () => {
 			const proposalIdHex = uuidToBytes16(proposalId)
-			const [executed, , , tally] = await wallet.publicClient.readContract({
+			const [executed, , parameters, tally] = await wallet.publicClient.readContract({
 				address: daoSpaceAddress,
 				abi: DAOSpaceAbi,
 				functionName: "getLatestProposalInformation",
 				args: [proposalIdHex],
 			})
-			return {executed, yes: tally.yes, no: tally.no, abstain: tally.abstain}
+			return {
+				executed,
+				yes: tally.yes,
+				no: tally.no,
+				abstain: tally.abstain,
+				startDate: parameters.startDate,
+				lastDate: parameters.lastDate,
+			}
 		},
 		catch: (error) =>
 			new InfraError({
@@ -143,12 +169,61 @@ export function readProposalTally(
 }
 
 /**
- * A request is eligible for an auto-accept YES vote iff it has not executed and no vote of
- * any kind is recorded on-chain. A non-zero tally covers both a human's vote (indexing lag)
- * and the bot's own in-flight vote → SKIP (reason: onchain_tally_nonzero), idempotency.
+ * Read the current chain time (latest block's timestamp) as Unix seconds.
+ *
+ * The voting-window check should compare against block.timestamp — the same clock
+ * the protocol enforces — not the pod's wall clock, which can drift. If the block
+ * read fails (transient RPC hiccup), fall back to the pod wall clock rather than
+ * failing the batch; CLOCK_SKEW_BUFFER_SECONDS absorbs the drift. Read once per
+ * run and reuse across requests in the batch.
  */
-export function isEligibleToVote(tally: ProposalTally): boolean {
-	return !tally.executed && tally.yes === 0n && tally.no === 0n && tally.abstain === 0n
+export function readChainTimeSeconds(wallet: SmartWallet): Effect.Effect<bigint> {
+	return Effect.tryPromise({
+		try: async () => (await wallet.publicClient.getBlock()).timestamp,
+		catch: (error) => error,
+	}).pipe(Effect.orElseSucceed(() => BigInt(Math.floor(Date.now() / 1000))))
+}
+
+/**
+ * A proposal's voting window is open iff now is at/after startDate and before
+ * lastDate extended by the clock-skew buffer. The close is widened, not narrowed:
+ * during the final CLOCK_SKEW_BUFFER_SECONDS — and up to that long past lastDate —
+ * the bot still votes, accepting a possible late revert over wrongly skipping a
+ * still-open request. now should be a chain-sourced timestamp (readChainTimeSeconds).
+ */
+export function isVotingOpen(
+	nowSeconds: bigint,
+	startDate: bigint,
+	lastDate: bigint,
+	skewSeconds: bigint = CLOCK_SKEW_BUFFER_SECONDS,
+): boolean {
+	return startDate <= nowSeconds && nowSeconds < lastDate + skewSeconds
+}
+
+/**
+ * A request is eligible for an auto-accept YES vote iff:
+ * - it has not executed,
+ * - no vote of any kind is recorded on-chain — a non-zero tally covers both a human's
+ *   vote (indexing lag) and the bot's own in-flight vote → SKIP (onchain_tally_nonzero),
+ *   which is what makes the job idempotent across cycles, and
+ * - its on-chain voting window is still open (now within [startDate, lastDate], with the
+ *   clock-skew buffer applied to the close). The protocol rejects votes outside the
+ *   window, so this is the authoritative stage-2 guard against voting on a closed request.
+ *
+ * now should be a chain-sourced timestamp (readChainTimeSeconds).
+ */
+export function isEligibleToVote(
+	tally: ProposalTally,
+	nowSeconds: bigint,
+	skewSeconds: bigint = CLOCK_SKEW_BUFFER_SECONDS,
+): boolean {
+	return (
+		!tally.executed &&
+		tally.yes === 0n &&
+		tally.no === 0n &&
+		tally.abstain === 0n &&
+		isVotingOpen(nowSeconds, tally.startDate, tally.lastDate, skewSeconds)
+	)
 }
 
 // ---------------------------------------------------------------------------

--- a/proposal-executor/tests/membership.test.ts
+++ b/proposal-executor/tests/membership.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Tests for membership.ts — vote-data encoding, the enter() vote calldata, the
+ * stage-2 on-chain tally read, two-stage eligibility, and error classification.
+ *
+ * Encoding is pinned against the authoritative IDAOSpace.VoteOption enum (Yes = 1).
+ * On-chain calls are exercised against a fake SmartWallet that captures calldata /
+ * returns canned reads, so no live RPC or paymaster is needed.
+ */
+
+import {describe, expect, test} from "bun:test"
+import {Effect} from "effect"
+import {type Address, decodeAbiParameters, decodeFunctionData, type Hex} from "viem"
+import {PROPOSAL_VOTED_ACTION, SpaceRegistryAbi, VOTE_YES} from "../src/contracts.js"
+import type {MembershipRequest} from "../src/detect.js"
+import type {SmartWallet} from "../src/execute.js"
+import {
+	castMembershipVote,
+	encodeVoteData,
+	isEligibleToVote,
+	type ProposalTally,
+	readProposalTally,
+	resolveDaoSpaceAddress,
+} from "../src/membership.js"
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const PROPOSAL_UUID = "550e8400-e29b-41d4-a716-446655440000"
+const PROPOSAL_BYTES16 = "0x550e8400e29b41d4a716446655440000"
+const SPACE_UUID = "660e8400-e29b-41d4-a716-446655440000"
+const SPACE_BYTES16 = "0x660e8400e29b41d4a716446655440000"
+const BOT_SPACE_ID = "0x770e8400e29b41d4a716446655440000" as Hex
+const REGISTRY = "0x1111111111111111111111111111111111111111" as Address
+const DAO_SPACE_ADDR = "0x2222222222222222222222222222222222222222" as Address
+
+const REQUEST: MembershipRequest = {
+	id: PROPOSAL_UUID,
+	spaceId: SPACE_UUID,
+	requesterId: "880e8400-e29b-41d4-a716-446655440000",
+}
+
+/**
+ * Minimal SmartWallet stub. sendTransaction / readContract are injected per-test;
+ * the account is present by default so the "no account" guard does not trip.
+ */
+function fakeWallet(overrides: {
+	sendTransaction?: (args: {data: Hex; to: Address}) => Promise<string>
+	readContract?: (args: {functionName: string; args: readonly unknown[]}) => Promise<unknown>
+}): SmartWallet {
+	return {
+		smartAccountClient: {
+			account: {address: "0xbot"},
+			sendTransaction: overrides.sendTransaction ?? (async () => "0xhash"),
+		},
+		publicClient: {
+			readContract: overrides.readContract ?? (async () => undefined),
+		},
+		chain: {id: 19411},
+		safeAddress: "0xsafe",
+	} as unknown as SmartWallet
+}
+
+// ---------------------------------------------------------------------------
+// encodeVoteData
+// ---------------------------------------------------------------------------
+
+describe("encodeVoteData", () => {
+	test("encodes abi.encode(bytes16 proposalId, uint8 voteOption)", () => {
+		const data = encodeVoteData(PROPOSAL_BYTES16 as Hex, VOTE_YES)
+		const [proposalId, voteOption] = decodeAbiParameters(
+			[
+				{name: "proposalId", type: "bytes16"},
+				{name: "voteOption", type: "uint8"},
+			],
+			data,
+		)
+		// bytes16 is left-aligned in its 32-byte word; viem returns it padded to bytes32.
+		expect((proposalId as string).slice(0, 34)).toBe(PROPOSAL_BYTES16)
+		expect(voteOption).toBe(VOTE_YES)
+	})
+
+	test("uses VOTE_YES === 1 for a YES vote", () => {
+		// Guards the documented enum discrepancy: a YES vote must encode uint8 1, not 2.
+		expect(VOTE_YES).toBe(1)
+		const data = encodeVoteData(PROPOSAL_BYTES16 as Hex, VOTE_YES)
+		const [, voteOption] = decodeAbiParameters([{type: "bytes16"}, {type: "uint8"}], data)
+		expect(voteOption).toBe(1)
+	})
+
+	test("two words: bytes16 proposalId then uint8 voteOption (0x + 128 hex chars)", () => {
+		const data = encodeVoteData(PROPOSAL_BYTES16 as Hex, VOTE_YES)
+		expect(data.length).toBe(2 + 128)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// castMembershipVote — enter() calldata
+// ---------------------------------------------------------------------------
+
+describe("castMembershipVote calldata", () => {
+	test("builds enter() with the PROPOSAL_VOTED action, bytes32(proposalId) topic, and YES vote data", async () => {
+		let captured: {data: Hex; to: Address} | undefined
+		const wallet = fakeWallet({
+			sendTransaction: async (args) => {
+				captured = args
+				return "0xtxhash"
+			},
+		})
+
+		const hash = await Effect.runPromise(castMembershipVote(wallet, REQUEST, BOT_SPACE_ID, REGISTRY))
+		expect(hash).toBe("0xtxhash")
+		if (!captured) throw new Error("sendTransaction was never called")
+		expect(captured.to).toBe(REGISTRY)
+
+		const decoded = decodeFunctionData({abi: SpaceRegistryAbi, data: captured.data})
+		expect(decoded.functionName).toBe("enter")
+
+		const [fromSpace, toSpace, action, topic, voteData, signature] = decoded.args as readonly [
+			Hex,
+			Hex,
+			Hex,
+			Hex,
+			Hex,
+			Hex,
+		]
+		expect(fromSpace.toLowerCase()).toBe(BOT_SPACE_ID.toLowerCase())
+		expect(toSpace.toLowerCase()).toBe(SPACE_BYTES16)
+		expect(action.toLowerCase()).toBe(PROPOSAL_VOTED_ACTION)
+		// Topic = bytes32(proposalId), left-aligned (proposalId in the high 16 bytes).
+		expect(topic.toLowerCase()).toBe(`${PROPOSAL_BYTES16}${"0".repeat(32)}`)
+		expect(signature).toBe("0x")
+
+		// Vote data decodes to (proposalId, Yes=1).
+		const [encodedId, encodedVote] = decodeAbiParameters([{type: "bytes16"}, {type: "uint8"}], voteData)
+		expect((encodedId as string).slice(0, 34)).toBe(PROPOSAL_BYTES16)
+		expect(encodedVote).toBe(1)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// castMembershipVote — error classification
+// ---------------------------------------------------------------------------
+
+describe("castMembershipVote error classification", () => {
+	test("classifies an on-chain revert as RevertError (CanNotVote ⇒ not expected)", async () => {
+		const revert = new Error("execution reverted: CanNotVote")
+		revert.name = "ContractFunctionRevertedError"
+		const wallet = fakeWallet({
+			sendTransaction: async () => {
+				throw revert
+			},
+		})
+
+		const failure = await Effect.runPromise(
+			Effect.flip(castMembershipVote(wallet, REQUEST, BOT_SPACE_ID, REGISTRY)),
+		)
+		expect(failure._tag).toBe("RevertError")
+		expect((failure as {proposalId: string}).proposalId).toBe(REQUEST.id)
+		// CanNotVote (bot lacks EDITOR) is a real misconfiguration, not an expected race.
+		expect((failure as {expected: boolean}).expected).toBe(false)
+	})
+
+	test("marks an already-executed revert as expected (request resolved elsewhere)", async () => {
+		const revert = new Error("execution reverted: proposal already executed")
+		revert.name = "ContractFunctionRevertedError"
+		const wallet = fakeWallet({
+			sendTransaction: async () => {
+				throw revert
+			},
+		})
+
+		const failure = await Effect.runPromise(
+			Effect.flip(castMembershipVote(wallet, REQUEST, BOT_SPACE_ID, REGISTRY)),
+		)
+		expect(failure._tag).toBe("RevertError")
+		expect((failure as {expected: boolean}).expected).toBe(true)
+	})
+
+	test("classifies a bundler/RPC failure as InfraError", async () => {
+		const wallet = fakeWallet({
+			sendTransaction: async () => {
+				throw new Error("connect ECONNREFUSED api.pimlico.io")
+			},
+		})
+
+		const failure = await Effect.runPromise(
+			Effect.flip(castMembershipVote(wallet, REQUEST, BOT_SPACE_ID, REGISTRY)),
+		)
+		expect(failure._tag).toBe("InfraError")
+		expect((failure as {proposalId?: string}).proposalId).toBe(REQUEST.id)
+	})
+
+	test("redacts a Pimlico API key leaked into an error message", async () => {
+		const wallet = fakeWallet({
+			sendTransaction: async () => {
+				throw new Error("request to https://api.pimlico.io/rpc?apikey=secret123 failed")
+			},
+		})
+
+		const failure = await Effect.runPromise(
+			Effect.flip(castMembershipVote(wallet, REQUEST, BOT_SPACE_ID, REGISTRY)),
+		)
+		expect((failure as {message: string}).message).toContain("apikey=<redacted>")
+		expect((failure as {message: string}).message).not.toContain("secret123")
+	})
+})
+
+// ---------------------------------------------------------------------------
+// readProposalTally
+// ---------------------------------------------------------------------------
+
+describe("readProposalTally", () => {
+	test("decodes the (executed, creator, parameters, Tally, actions) tuple into the tally", async () => {
+		const wallet = fakeWallet({
+			readContract: async (args) => {
+				expect(args.functionName).toBe("getLatestProposalInformation")
+				// proposalId passed as bytes16
+				expect(args.args[0]).toBe(PROPOSAL_BYTES16)
+				return [
+					false, // executed
+					"0xcreator", // creator
+					{}, // parameters (unused by the read)
+					{yes: 3n, no: 1n, abstain: 2n}, // tally
+					[], // actions
+				]
+			},
+		})
+
+		const tally = await Effect.runPromise(readProposalTally(wallet, DAO_SPACE_ADDR, PROPOSAL_UUID))
+		expect(tally).toEqual({executed: false, yes: 3n, no: 1n, abstain: 2n})
+	})
+
+	test("surfaces a read failure as an InfraError carrying the proposalId", async () => {
+		const wallet = fakeWallet({
+			readContract: async () => {
+				throw new Error("RPC timeout")
+			},
+		})
+
+		const failure = await Effect.runPromise(Effect.flip(readProposalTally(wallet, DAO_SPACE_ADDR, PROPOSAL_UUID)))
+		expect(failure._tag).toBe("InfraError")
+		expect((failure as {proposalId?: string}).proposalId).toBe(PROPOSAL_UUID)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// isEligibleToVote — two-stage eligibility (stage 2)
+// ---------------------------------------------------------------------------
+
+describe("isEligibleToVote", () => {
+	test("eligible iff !executed && yes + no + abstain == 0", () => {
+		const fresh: ProposalTally = {executed: false, yes: 0n, no: 0n, abstain: 0n}
+		expect(isEligibleToVote(fresh)).toBe(true)
+	})
+
+	test("ineligible when already executed", () => {
+		expect(isEligibleToVote({executed: true, yes: 0n, no: 0n, abstain: 0n})).toBe(false)
+	})
+
+	test("ineligible when any vote is recorded (yes / no / abstain)", () => {
+		expect(isEligibleToVote({executed: false, yes: 1n, no: 0n, abstain: 0n})).toBe(false)
+		expect(isEligibleToVote({executed: false, yes: 0n, no: 1n, abstain: 0n})).toBe(false)
+		expect(isEligibleToVote({executed: false, yes: 0n, no: 0n, abstain: 1n})).toBe(false)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Idempotency (US2) — a non-zero on-chain tally ⇒ ineligible ⇒ no vote cast
+// ---------------------------------------------------------------------------
+
+describe("idempotency: the bot never double-votes", () => {
+	test("the bot's own prior YES vote makes the request ineligible (stage-2 tally non-zero)", async () => {
+		// After the bot votes once, yes >= 1 is visible on-chain immediately — even before
+		// the indexer surfaces it — so the next cycle reads it and must skip.
+		const wallet = fakeWallet({
+			readContract: async () => [false, "0xcreator", {}, {yes: 1n, no: 0n, abstain: 0n}, []],
+		})
+
+		const tally = await Effect.runPromise(readProposalTally(wallet, DAO_SPACE_ADDR, PROPOSAL_UUID))
+		expect(isEligibleToVote(tally)).toBe(false)
+	})
+
+	test("a human's pre-existing vote (indexing-lag window) also blocks the cast", async () => {
+		const wallet = fakeWallet({
+			readContract: async () => [false, "0xcreator", {}, {yes: 0n, no: 2n, abstain: 0n}, []],
+		})
+
+		const tally = await Effect.runPromise(readProposalTally(wallet, DAO_SPACE_ADDR, PROPOSAL_UUID))
+		expect(isEligibleToVote(tally)).toBe(false)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// resolveDaoSpaceAddress
+// ---------------------------------------------------------------------------
+
+describe("resolveDaoSpaceAddress", () => {
+	test("returns the DAOSpace address from spaceIdToAddress", async () => {
+		const wallet = fakeWallet({
+			readContract: async (args) => {
+				expect(args.functionName).toBe("spaceIdToAddress")
+				return DAO_SPACE_ADDR
+			},
+		})
+
+		const addr = await Effect.runPromise(resolveDaoSpaceAddress(wallet, REGISTRY, SPACE_BYTES16 as Hex))
+		expect(addr).toBe(DAO_SPACE_ADDR)
+	})
+
+	test("rejects an unregistered space (zero address) as an InfraError", async () => {
+		const wallet = fakeWallet({
+			readContract: async () => "0x0000000000000000000000000000000000000000",
+		})
+
+		const failure = await Effect.runPromise(
+			Effect.flip(resolveDaoSpaceAddress(wallet, REGISTRY, SPACE_BYTES16 as Hex)),
+		)
+		expect(failure._tag).toBe("InfraError")
+		expect((failure as {message: string}).message).toContain("not registered")
+	})
+})

--- a/proposal-executor/tests/membership.test.ts
+++ b/proposal-executor/tests/membership.test.ts
@@ -17,7 +17,9 @@ import {
 	castMembershipVote,
 	encodeVoteData,
 	isEligibleToVote,
+	isVotingOpen,
 	type ProposalTally,
+	readChainTimeSeconds,
 	readProposalTally,
 	resolveDaoSpaceAddress,
 } from "../src/membership.js"
@@ -40,13 +42,21 @@ const REQUEST: MembershipRequest = {
 	requesterId: "880e8400-e29b-41d4-a716-446655440000",
 }
 
+// Voting-window fixtures: NOW sits comfortably inside an open window.
+const NOW = 1_700_000_000n
+const START_DATE = NOW - 3_600n // opened an hour ago
+const LAST_DATE = NOW + 3_600n // closes in an hour
+/** A ProposalParameters tuple whose only fields the read uses are startDate/lastDate. */
+const OPEN_PARAMS = {startDate: START_DATE, lastDate: LAST_DATE}
+
 /**
- * Minimal SmartWallet stub. sendTransaction / readContract are injected per-test;
- * the account is present by default so the "no account" guard does not trip.
+ * Minimal SmartWallet stub. sendTransaction / readContract / getBlock are injected
+ * per-test; the account is present by default so the "no account" guard does not trip.
  */
 function fakeWallet(overrides: {
 	sendTransaction?: (args: {data: Hex; to: Address}) => Promise<string>
 	readContract?: (args: {functionName: string; args: readonly unknown[]}) => Promise<unknown>
+	getBlock?: () => Promise<{timestamp: bigint}>
 }): SmartWallet {
 	return {
 		smartAccountClient: {
@@ -55,6 +65,7 @@ function fakeWallet(overrides: {
 		},
 		publicClient: {
 			readContract: overrides.readContract ?? (async () => undefined),
+			getBlock: overrides.getBlock ?? (async () => ({timestamp: NOW})),
 		},
 		chain: {id: 19411},
 		safeAddress: "0xsafe",
@@ -220,7 +231,7 @@ describe("readProposalTally", () => {
 				return [
 					false, // executed
 					"0xcreator", // creator
-					{}, // parameters (unused by the read)
+					OPEN_PARAMS, // parameters → startDate/lastDate
 					{yes: 3n, no: 1n, abstain: 2n}, // tally
 					[], // actions
 				]
@@ -228,7 +239,14 @@ describe("readProposalTally", () => {
 		})
 
 		const tally = await Effect.runPromise(readProposalTally(wallet, DAO_SPACE_ADDR, PROPOSAL_UUID))
-		expect(tally).toEqual({executed: false, yes: 3n, no: 1n, abstain: 2n})
+		expect(tally).toEqual({
+			executed: false,
+			yes: 3n,
+			no: 1n,
+			abstain: 2n,
+			startDate: START_DATE,
+			lastDate: LAST_DATE,
+		})
 	})
 
 	test("surfaces a read failure as an InfraError carrying the proposalId", async () => {
@@ -249,19 +267,87 @@ describe("readProposalTally", () => {
 // ---------------------------------------------------------------------------
 
 describe("isEligibleToVote", () => {
-	test("eligible iff !executed && yes + no + abstain == 0", () => {
-		const fresh: ProposalTally = {executed: false, yes: 0n, no: 0n, abstain: 0n}
-		expect(isEligibleToVote(fresh)).toBe(true)
+	const fresh: ProposalTally = {
+		executed: false,
+		yes: 0n,
+		no: 0n,
+		abstain: 0n,
+		startDate: START_DATE,
+		lastDate: LAST_DATE,
+	}
+
+	test("eligible iff !executed && zero tally && voting window open", () => {
+		expect(isEligibleToVote(fresh, NOW)).toBe(true)
 	})
 
 	test("ineligible when already executed", () => {
-		expect(isEligibleToVote({executed: true, yes: 0n, no: 0n, abstain: 0n})).toBe(false)
+		expect(isEligibleToVote({...fresh, executed: true}, NOW)).toBe(false)
 	})
 
 	test("ineligible when any vote is recorded (yes / no / abstain)", () => {
-		expect(isEligibleToVote({executed: false, yes: 1n, no: 0n, abstain: 0n})).toBe(false)
-		expect(isEligibleToVote({executed: false, yes: 0n, no: 1n, abstain: 0n})).toBe(false)
-		expect(isEligibleToVote({executed: false, yes: 0n, no: 0n, abstain: 1n})).toBe(false)
+		expect(isEligibleToVote({...fresh, yes: 1n}, NOW)).toBe(false)
+		expect(isEligibleToVote({...fresh, no: 1n}, NOW)).toBe(false)
+		expect(isEligibleToVote({...fresh, abstain: 1n}, NOW)).toBe(false)
+	})
+
+	test("ineligible once the voting window has closed (beyond the skew buffer)", () => {
+		// 61s past lastDate: outside the 60s lenient buffer ⇒ no vote.
+		expect(isEligibleToVote(fresh, LAST_DATE + 61n)).toBe(false)
+	})
+
+	test("still eligible within the lenient skew buffer past lastDate", () => {
+		// 30s past close but inside the 60s buffer: prefer voting (may revert) over skipping.
+		expect(isEligibleToVote(fresh, LAST_DATE + 30n)).toBe(true)
+	})
+
+	test("ineligible before the voting window opens", () => {
+		expect(isEligibleToVote(fresh, START_DATE - 1n)).toBe(false)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// isVotingOpen — voting-window predicate
+// ---------------------------------------------------------------------------
+
+describe("isVotingOpen", () => {
+	test("open in the middle of the window", () => {
+		expect(isVotingOpen(NOW, START_DATE, LAST_DATE)).toBe(true)
+	})
+
+	test("open at exactly startDate, closed just before it", () => {
+		expect(isVotingOpen(START_DATE, START_DATE, LAST_DATE)).toBe(true)
+		expect(isVotingOpen(START_DATE - 1n, START_DATE, LAST_DATE)).toBe(false)
+	})
+
+	test("the buffer extends the close, never shrinks it", () => {
+		// Last second of the real window is always open.
+		expect(isVotingOpen(LAST_DATE - 1n, START_DATE, LAST_DATE)).toBe(true)
+		// And the window stays open for skewSeconds past lastDate.
+		expect(isVotingOpen(LAST_DATE + 59n, START_DATE, LAST_DATE, 60n)).toBe(true)
+		expect(isVotingOpen(LAST_DATE + 60n, START_DATE, LAST_DATE, 60n)).toBe(false)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// readChainTimeSeconds — chain clock with wall-clock fallback
+// ---------------------------------------------------------------------------
+
+describe("readChainTimeSeconds", () => {
+	test("returns the latest block timestamp", async () => {
+		const wallet = fakeWallet({getBlock: async () => ({timestamp: 1_234_567n})})
+		const now = await Effect.runPromise(readChainTimeSeconds(wallet))
+		expect(now).toBe(1_234_567n)
+	})
+
+	test("falls back to the pod wall clock when the block read fails", async () => {
+		const wallet = fakeWallet({
+			getBlock: async () => {
+				throw new Error("RPC down")
+			},
+		})
+		const before = BigInt(Math.floor(Date.now() / 1000))
+		const now = await Effect.runPromise(readChainTimeSeconds(wallet))
+		expect(now).toBeGreaterThanOrEqual(before)
 	})
 })
 
@@ -274,20 +360,20 @@ describe("idempotency: the bot never double-votes", () => {
 		// After the bot votes once, yes >= 1 is visible on-chain immediately — even before
 		// the indexer surfaces it — so the next cycle reads it and must skip.
 		const wallet = fakeWallet({
-			readContract: async () => [false, "0xcreator", {}, {yes: 1n, no: 0n, abstain: 0n}, []],
+			readContract: async () => [false, "0xcreator", OPEN_PARAMS, {yes: 1n, no: 0n, abstain: 0n}, []],
 		})
 
 		const tally = await Effect.runPromise(readProposalTally(wallet, DAO_SPACE_ADDR, PROPOSAL_UUID))
-		expect(isEligibleToVote(tally)).toBe(false)
+		expect(isEligibleToVote(tally, NOW)).toBe(false)
 	})
 
 	test("a human's pre-existing vote (indexing-lag window) also blocks the cast", async () => {
 		const wallet = fakeWallet({
-			readContract: async () => [false, "0xcreator", {}, {yes: 0n, no: 2n, abstain: 0n}, []],
+			readContract: async () => [false, "0xcreator", OPEN_PARAMS, {yes: 0n, no: 2n, abstain: 0n}, []],
 		})
 
 		const tally = await Effect.runPromise(readProposalTally(wallet, DAO_SPACE_ADDR, PROPOSAL_UUID))
-		expect(isEligibleToVote(tally)).toBe(false)
+		expect(isEligibleToVote(tally, NOW)).toBe(false)
 	})
 })
 


### PR DESCRIPTION
Add src/membership.ts for the membership-accept path: encodeVoteData (abi (bytes16, uint8)), resolveDaoSpaceAddress (via spaceIdToAddress), readProposalTally + isEligibleToVote (stage-2 untouched check), and castMembershipVote (enter(PROPOSAL_VOTED, Yes) via the bot wallet).

Reuses the executor's classifyAsRevert (now exported) for RevertError/ InfraError classification. CanNotVote (bot lacks EDITOR) is treated as unexpected; already-executed/CanNotExecute/InvalidAction as expected.

Tests pin VOTE_YES === 1 encoding, the full enter() calldata, Tally decoding, eligibility, error classification + API-key redaction, and idempotency (non-zero on-chain tally => ineligible => no cast).