### PR TITLE
feat(k8s): add gaia-v2 manifests for chain-migration deploy (GEO-664)

### DIFF
--- a/api/k8s/v2/api.yaml
+++ b/api/k8s/v2/api.yaml
@@ -1,0 +1,250 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: gaia-v2
+  labels:
+    app: api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        fsGroup: 1001
+      imagePullSecrets:
+        - name: regcred
+      volumes:
+        - name: ssl-certs
+          emptyDir: {}
+      nodeSelector:
+        doks.digitalocean.com/node-pool: gaia-v2-pool
+      tolerations:
+        - key: dedicated
+          value: gaia-v2
+          effect: NoSchedule
+      initContainers:
+        - name: setup-certs
+          image: registry.digitalocean.com/geo/api:latest
+          imagePullPolicy: Always
+          command:
+            - sh
+            - -c
+            - |
+              echo "$DATABASE_SSL_CA" > /ssl/ca.crt
+          env:
+            - name: DATABASE_SSL_CA
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: DATABASE_SSL_CA
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: /ssl
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+        - name: migrate
+          image: registry.digitalocean.com/geo/api:latest
+          imagePullPolicy: Always
+          command: ["bun", "run", "db:migrate"]
+          env:
+            - name: DATABASE_URL_DIRECT
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: DATABASE_URL_DIRECT
+            - name: NODE_EXTRA_CA_CERTS
+              value: /ssl/ca.crt
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: /ssl
+              readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      containers:
+        - name: api
+          image: registry.digitalocean.com/geo/api:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 3000
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: /ssl
+              readOnly: true
+          env:
+            - name: NODE_EXTRA_CA_CERTS
+              value: /ssl/ca.crt
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: DATABASE_URL
+            - name: PG_CONNECTION_TIMEOUT_MS
+              value: "3000"
+            - name: PG_POOL_PRESSURE_WAITING_THRESHOLD
+              value: "1"
+            - name: PG_POOL_PRESSURE_UTILIZATION_THRESHOLD
+              value: "90"
+            - name: PG_POOL_PRESSURE_TIMEOUT_THRESHOLD
+              value: "2"
+            - name: PG_POOL_ACQUIRE_TIMEOUT_WINDOW_MS
+              value: "30000"
+            - name: PG_POOL_SATURATION_ACTIVATION_MS
+              value: "15000"
+            - name: PG_POOL_SATURATION_RELEASE_MS
+              value: "30000"
+            - name: IPFS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: IPFS_KEY
+            - name: IPFS_GATEWAY_WRITE
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: IPFS_GATEWAY_WRITE
+            # Required so the API resolves the correct alias/index in the shared OpenSearch cluster.
+            - name: ENVIRONMENT
+              value: "testnet"
+            - name: OPENSEARCH_URL
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: OPENSEARCH_URL
+            - name: TOPOLOGY_SERVICE_URL
+              value: "http://search-indexer:8080"
+            # Response cache disabled — uncomment to re-enable.
+            # - name: VALKEY_URL
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: api-cache-secrets
+            #       key: VALKEY_URL
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: api-sentry
+                  key: SENTRY_DSN
+                  optional: true
+            - name: SENTRY_TRACES_SAMPLE_RATE
+              valueFrom:
+                secretKeyRef:
+                  name: api-sentry
+                  key: SENTRY_TRACES_SAMPLE_RATE
+                  optional: true
+            - name: SENTRY_ENVIRONMENT
+              valueFrom:
+                secretKeyRef:
+                  name: api-sentry
+                  key: SENTRY_ENVIRONMENT
+                  optional: true
+            - name: SENTRY_RELEASE
+              valueFrom:
+                secretKeyRef:
+                  name: api-sentry
+                  key: SENTRY_RELEASE
+                  optional: true
+            - name: SENTRY_DEBUG
+              valueFrom:
+                secretKeyRef:
+                  name: api-sentry
+                  key: SENTRY_DEBUG
+                  optional: true
+          resources:
+            requests:
+              memory: "768Mi"
+              cpu: "500m"
+            limits:
+              memory: "2Gi"
+          livenessProbe:
+            httpGet:
+              path: /health/liveness
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health/readiness
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: api
+  namespace: gaia-v2
+  labels:
+    app: api
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 3000
+      targetPort: 3000
+      protocol: TCP
+  selector:
+    app: api
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: api
+  namespace: gaia-v2
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/proxy-body-size: "100m"
+    nginx.ingress.kubernetes.io/server-snippet: |
+      gzip on;
+      gzip_comp_level 5;
+      gzip_min_length 512;
+      gzip_proxied any;
+      gzip_vary on;
+      gzip_types
+        application/json
+        application/graphql-response+json
+        application/javascript
+        application/xml
+        text/plain
+        text/css
+        text/javascript
+        text/xml;
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - testnet-api-v2.geobrowser.io
+      secretName: testnet-api-v2-tls
+  rules:
+    - host: testnet-api-v2.geobrowser.io
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: api
+                port:
+                  number: 3000

--- a/api/k8s/v2/hpa.yaml
+++ b/api/k8s/v2/hpa.yaml
@@ -1,0 +1,87 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: api
+  namespace: gaia-v2
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: api
+  minReplicas: 1
+  maxReplicas: 2
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      selectPolicy: Max
+      policies:
+        - type: Percent
+          value: 100
+          periodSeconds: 60
+        - type: Pods
+          value: 4
+          periodSeconds: 60
+    scaleDown:
+      stabilizationWindowSeconds: 600
+      selectPolicy: Min
+      policies:
+        - type: Percent
+          value: 25
+          periodSeconds: 60
+        - type: Pods
+          value: 1
+          periodSeconds: 60
+  metrics:
+    - type: External
+      external:
+        metric:
+          name: api_ingress_p95_latency_seconds_2m
+        target:
+          type: Value
+          value: "1"
+    - type: External
+      external:
+        metric:
+          name: api_ingress_p99_latency_seconds_2m
+        target:
+          type: Value
+          value: "2"
+    # Fast capacity-loss signal from kube-state-metrics via prometheus-adapter.
+    # Returns 0.0 when all replicas are available (allows scale-down).
+    # Rises toward 1.0 as replicas become unavailable (triggers scale-up).
+    # Formula: (spec - available) / spec
+    - type: External
+      external:
+        metric:
+          name: api_ready_replica_pressure
+        target:
+          type: Value
+          value: 500m   # 0.5 — scale up when >50% of replicas are unavailable
+    # Fallback signal when requests are already failing at ingress.
+    # Target 1.5% (15m = 0.015) sustained error ratio.
+    - type: External
+      external:
+        metric:
+          name: api_ingress_503_ratio_rate5m
+        target:
+          type: Value
+          value: 15m
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+    - type: Pods
+      pods:
+        metric:
+          name: gaia_api_graphql_pool_saturated
+        target:
+          type: AverageValue
+          averageValue: 100m

--- a/api/k8s/v2/hpa.yaml
+++ b/api/k8s/v2/hpa.yaml
@@ -32,40 +32,9 @@ spec:
           value: 1
           periodSeconds: 60
   metrics:
-    - type: External
-      external:
-        metric:
-          name: api_ingress_p95_latency_seconds_2m
-        target:
-          type: Value
-          value: "1"
-    - type: External
-      external:
-        metric:
-          name: api_ingress_p99_latency_seconds_2m
-        target:
-          type: Value
-          value: "2"
-    # Fast capacity-loss signal from kube-state-metrics via prometheus-adapter.
-    # Returns 0.0 when all replicas are available (allows scale-down).
-    # Rises toward 1.0 as replicas become unavailable (triggers scale-up).
-    # Formula: (spec - available) / spec
-    - type: External
-      external:
-        metric:
-          name: api_ready_replica_pressure
-        target:
-          type: Value
-          value: 500m   # 0.5 — scale up when >50% of replicas are unavailable
-    # Fallback signal when requests are already failing at ingress.
-    # Target 1.5% (15m = 0.015) sustained error ratio.
-    - type: External
-      external:
-        metric:
-          name: api_ingress_503_ratio_rate5m
-        target:
-          type: Value
-          value: 15m
+    # v2 scales on resource metrics only — the prod External/Pods metrics
+    # (prometheus-adapter + recording rules) are scoped to the prod host and
+    # namespace and don't exist for gaia-v2 until monitoring is wired (Step 15).
     - type: Resource
       resource:
         name: cpu
@@ -78,10 +47,3 @@ spec:
         target:
           type: Utilization
           averageUtilization: 80
-    - type: Pods
-      pods:
-        metric:
-          name: gaia_api_graphql_pool_saturated
-        target:
-          type: AverageValue
-          averageValue: 100m

--- a/api/k8s/v2/valkey.yaml
+++ b/api/k8s/v2/valkey.yaml
@@ -1,0 +1,122 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-cache
+  namespace: gaia-v2
+  labels:
+    app: api-cache
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api-cache
+  template:
+    metadata:
+      labels:
+        app: api-cache
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        fsGroup: 999
+      nodeSelector:
+        doks.digitalocean.com/node-pool: gaia-v2-pool
+      tolerations:
+        - key: dedicated
+          value: gaia-v2
+          effect: NoSchedule
+      containers:
+        - name: valkey
+          image: valkey/valkey:8.1-alpine
+          args:
+            # Ephemeral cache — no persistence, no disk writes
+            - "--save"
+            - ""
+            - "--appendonly"
+            - "no"
+            # Memory limit: conservative for ~15 cached responses at up to 25MB each
+            - "--maxmemory"
+            - "512mb"
+            # LRU eviction: evict least-recently-used keys when memory is full
+            - "--maxmemory-policy"
+            - "allkeys-lru"
+            # Require authentication
+            - "--requirepass"
+            - "$(VALKEY_PASSWORD)"
+          env:
+            - name: VALKEY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: api-cache-secrets
+                  key: VALKEY_PASSWORD
+          ports:
+            - containerPort: 6379
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "50m"
+            limits:
+              memory: "1Gi"
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - valkey-cli -a "$VALKEY_PASSWORD" --no-auth-warning ping
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - valkey-cli -a "$VALKEY_PASSWORD" --no-auth-warning ping
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 3
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-cache
+  namespace: gaia-v2
+  labels:
+    app: api-cache
+spec:
+  type: ClusterIP
+  ports:
+    - name: valkey
+      port: 6379
+      targetPort: 6379
+      protocol: TCP
+  selector:
+    app: api-cache
+---
+# Restrict Valkey access to API pods only
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: api-cache-ingress
+  namespace: gaia-v2
+spec:
+  podSelector:
+    matchLabels:
+      app: api-cache
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: api
+      ports:
+        - port: 6379
+          protocol: TCP

--- a/hermes-ipfs-cache/k8s/v2/hermes-ipfs-cache.yaml
+++ b/hermes-ipfs-cache/k8s/v2/hermes-ipfs-cache.yaml
@@ -1,0 +1,172 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hermes-ipfs-cache
+  namespace: gaia-v2
+  labels:
+    app: hermes-ipfs-cache
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hermes-ipfs-cache
+  template:
+    metadata:
+      labels:
+        app: hermes-ipfs-cache
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        fsGroup: 1001
+      imagePullSecrets:
+        - name: regcred
+      volumes:
+        - name: ssl-certs
+          emptyDir: {}
+      nodeSelector:
+        doks.digitalocean.com/node-pool: gaia-v2-pool
+      tolerations:
+        - key: dedicated
+          value: gaia-v2
+          effect: NoSchedule
+      initContainers:
+        - name: setup-certs
+          image: registry.digitalocean.com/geo/hermes-ipfs-cache:latest
+          imagePullPolicy: Always
+          command:
+            - sh
+            - -c
+            - |
+              echo "$DATABASE_SSL_CA" > /ssl/ca.crt
+          env:
+            - name: DATABASE_SSL_CA
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: DATABASE_SSL_CA
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: /ssl
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      containers:
+        - name: hermes-ipfs-cache
+          image: registry.digitalocean.com/geo/hermes-ipfs-cache:latest
+          imagePullPolicy: Always
+          ports:
+            - name: metrics
+              containerPort: 9464
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: /ssl
+              readOnly: true
+          env:
+            - name: PGSSLROOTCERT
+              value: /ssl/ca.crt
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: DATABASE_URL
+            - name: SUBSTREAMS_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-ipfs-cache-secrets
+                  key: SUBSTREAMS_ENDPOINT
+            - name: SUBSTREAMS_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-ipfs-cache-secrets
+                  key: SUBSTREAMS_API_TOKEN
+            - name: SUBSTREAMS_START_BLOCK
+              value: "82656"
+            - name: IPFS_GATEWAY_URL
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-ipfs-cache-secrets
+                  key: IPFS_GATEWAY_URL
+            - name: RUST_LOG
+              value: "hermes_ipfs_cache=info"
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-ipfs-cache-secrets
+                  key: SENTRY_DSN
+                  optional: true
+            - name: SENTRY_TRACES_SAMPLE_RATE
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-ipfs-cache-secrets
+                  key: SENTRY_TRACES_SAMPLE_RATE
+                  optional: true
+            - name: SENTRY_SEND_DEFAULT_PII
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-ipfs-cache-secrets
+                  key: SENTRY_SEND_DEFAULT_PII
+                  optional: true
+            - name: SENTRY_ENVIRONMENT
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-ipfs-cache-secrets
+                  key: SENTRY_ENVIRONMENT
+                  optional: true
+            - name: SENTRY_RELEASE
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-ipfs-cache-secrets
+                  key: SENTRY_RELEASE
+                  optional: true
+            - name: SENTRY_DEBUG
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-ipfs-cache-secrets
+                  key: SENTRY_DEBUG
+                  optional: true
+            - name: AXIOM_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-ipfs-cache-secrets
+                  key: AXIOM_TOKEN
+                  optional: true
+            - name: AXIOM_DATASET
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-ipfs-cache-secrets
+                  key: AXIOM_DATASET
+                  optional: true
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "250m"
+            limits:
+              memory: "1Gi"
+              cpu: "500m"
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hermes-ipfs-cache
+  namespace: gaia-v2
+  labels:
+    app: hermes-ipfs-cache
+spec:
+  type: ClusterIP
+  selector:
+    app: hermes-ipfs-cache
+  ports:
+    - name: metrics
+      port: 9464
+      targetPort: metrics
+      protocol: TCP

--- a/hermes-ipfs-cache/k8s/v2/hermes-ipfs-cache.yaml
+++ b/hermes-ipfs-cache/k8s/v2/hermes-ipfs-cache.yaml
@@ -88,8 +88,11 @@ spec:
                 secretKeyRef:
                   name: hermes-ipfs-cache-secrets
                   key: SUBSTREAMS_API_TOKEN
+            # 0 = stream from genesis — safe on the fresh chain (non-numeric values are
+            # silently ignored and fall back to the OLD testnet block 82655).
+            # Tighten to the V2 SpaceRegistry deploy block at deploy time (runbook Step 9).
             - name: SUBSTREAMS_START_BLOCK
-              value: "82656"
+              value: "0"
             - name: IPFS_GATEWAY_URL
               valueFrom:
                 secretKeyRef:

--- a/hermes/k8s/v2/atlas.yaml
+++ b/hermes/k8s/v2/atlas.yaml
@@ -1,0 +1,138 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: atlas
+  namespace: gaia-v2
+  labels:
+    app: atlas
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: atlas
+  template:
+    metadata:
+      labels:
+        app: atlas
+    spec:
+      restartPolicy: Always
+      imagePullSecrets:
+        - name: regcred
+      nodeSelector:
+        doks.digitalocean.com/node-pool: gaia-v2-pool
+      tolerations:
+        - key: dedicated
+          value: gaia-v2
+          effect: NoSchedule
+      containers:
+        - name: atlas
+          image: registry.digitalocean.com/geo/atlas:latest
+          imagePullPolicy: Always
+          env:
+            - name: KAFKA_BROKER
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-credentials
+                  key: KAFKA_BROKER
+            - name: KAFKA_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-credentials
+                  key: KAFKA_USERNAME
+            - name: KAFKA_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-credentials
+                  key: KAFKA_PASSWORD
+            - name: KAFKA_SSL_CA_PEM
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-credentials
+                  key: KAFKA_SSL_CA_PEM
+            - name: ENVIRONMENT
+              value: "testnet"
+            - name: KAFKA_TOPIC
+              value: "topology.canonical"
+            - name: USE_MOCK
+              value: "false"
+            - name: SUBSTREAMS_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-ipfs-cache-secrets
+                  key: SUBSTREAMS_ENDPOINT
+            - name: SUBSTREAMS_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-ipfs-cache-secrets
+                  key: SUBSTREAMS_API_TOKEN
+                  optional: true
+            # Set to the V2 SpaceRegistry deploy block on the new chain
+            - name: SUBSTREAMS_START_BLOCK
+              value: "REPLACE_WITH_SPACEREGISTRY_DEPLOY_BLOCK"
+            - name: ROOT_SPACE_ID
+              valueFrom:
+                secretKeyRef:
+                  name: atlas-secrets
+                  key: ROOT_SPACE_ID
+            - name: ATLAS_CHECKPOINT_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: DATABASE_URL
+            - name: ATLAS_INDEXER_ID
+              value: "atlas-production"
+            - name: ATLAS_RUNTIME_COMPATIBILITY_MARKER
+              value: "atlas-v1"
+            - name: ATLAS_FAIL_OPEN_BOUND
+              value: "10"
+            - name: ATLAS_CHECKPOINT_RETRY_ATTEMPTS
+              value: "3"
+            - name: ATLAS_CHECKPOINT_RETRY_BACKOFF_MS
+              value: "200"
+            - name: ATLAS_PAUSE_RECOVERY_MAX_ATTEMPTS
+              value: "120"
+            - name: ATLAS_CHECKPOINT_ALLOW_FRESH_START
+              value: "false"
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: atlas-otel
+                  key: SENTRY_DSN
+                  optional: true
+            - name: SENTRY_TRACES_SAMPLE_RATE
+              valueFrom:
+                secretKeyRef:
+                  name: atlas-otel
+                  key: SENTRY_TRACES_SAMPLE_RATE
+                  optional: true
+            - name: SENTRY_SEND_DEFAULT_PII
+              valueFrom:
+                secretKeyRef:
+                  name: atlas-otel
+                  key: SENTRY_SEND_DEFAULT_PII
+                  optional: true
+            - name: SENTRY_ENVIRONMENT
+              valueFrom:
+                secretKeyRef:
+                  name: atlas-otel
+                  key: SENTRY_ENVIRONMENT
+                  optional: true
+            - name: SENTRY_RELEASE
+              valueFrom:
+                secretKeyRef:
+                  name: atlas-otel
+                  key: SENTRY_RELEASE
+                  optional: true
+            - name: SENTRY_DEBUG
+              valueFrom:
+                secretKeyRef:
+                  name: atlas-otel
+                  key: SENTRY_DEBUG
+                  optional: true
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "250m"
+            limits:
+              memory: "1Gi"
+              cpu: "1000m"

--- a/hermes/k8s/v2/atlas.yaml
+++ b/hermes/k8s/v2/atlas.yaml
@@ -66,9 +66,11 @@ spec:
                   name: hermes-ipfs-cache-secrets
                   key: SUBSTREAMS_API_TOKEN
                   optional: true
-            # Set to the V2 SpaceRegistry deploy block on the new chain
+            # 0 = stream from genesis — safe on the fresh chain (non-numeric values are
+            # silently ignored and fall back to the OLD testnet block 82655).
+            # Tighten to the V2 SpaceRegistry deploy block at deploy time (runbook Step 9).
             - name: SUBSTREAMS_START_BLOCK
-              value: "REPLACE_WITH_SPACEREGISTRY_DEPLOY_BLOCK"
+              value: "0"
             - name: ROOT_SPACE_ID
               valueFrom:
                 secretKeyRef:

--- a/hermes/k8s/v2/atlas.yaml
+++ b/hermes/k8s/v2/atlas.yaml
@@ -82,7 +82,7 @@ spec:
                   name: api-secrets
                   key: DATABASE_URL
             - name: ATLAS_INDEXER_ID
-              value: "atlas-production"
+              value: "atlas-testnet"
             - name: ATLAS_RUNTIME_COMPATIBILITY_MARKER
               value: "atlas-v1"
             - name: ATLAS_FAIL_OPEN_BOUND

--- a/hermes/k8s/v2/hermes-pipeline.yaml
+++ b/hermes/k8s/v2/hermes-pipeline.yaml
@@ -111,11 +111,11 @@ spec:
                 secretKeyRef:
                   name: hermes-ipfs-cache-secrets
                   key: SUBSTREAMS_API_TOKEN
-            # Sole ingestion floor (GEO-537). Must be the V2 SpaceRegistry
-            # deploy block on the new chain — the binary default is the OLD
-            # testnet block, so this must stay explicit here.
+            # 0 = stream from genesis — safe on the fresh chain (non-numeric values are
+            # silently ignored and fall back to the OLD testnet block 82655).
+            # Tighten to the V2 SpaceRegistry deploy block at deploy time (runbook Step 9).
             - name: SUBSTREAMS_START_BLOCK
-              value: "REPLACE_WITH_SPACEREGISTRY_DEPLOY_BLOCK"
+              value: "0"
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:

--- a/hermes/k8s/v2/hermes-pipeline.yaml
+++ b/hermes/k8s/v2/hermes-pipeline.yaml
@@ -1,0 +1,190 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hermes-pipeline
+  namespace: gaia-v2
+  labels:
+    app: hermes-pipeline
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hermes-pipeline
+  template:
+    metadata:
+      labels:
+        app: hermes-pipeline
+    spec:
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        fsGroup: 1001
+      imagePullSecrets:
+        - name: regcred
+      volumes:
+        - name: ssl-certs
+          emptyDir: {}
+      nodeSelector:
+        doks.digitalocean.com/node-pool: gaia-v2-pool
+      tolerations:
+        - key: dedicated
+          value: gaia-v2
+          effect: NoSchedule
+      initContainers:
+        - name: setup-certs
+          image: registry.digitalocean.com/geo/hermes-pipeline:latest
+          imagePullPolicy: Always
+          command:
+            - sh
+            - -c
+            - |
+              echo "$DATABASE_SSL_CA" > /ssl/ca.crt
+          env:
+            - name: DATABASE_SSL_CA
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: DATABASE_SSL_CA
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: /ssl
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      containers:
+        - name: hermes-pipeline
+          image: registry.digitalocean.com/geo/hermes-pipeline:latest
+          imagePullPolicy: Always
+          ports:
+            - name: metrics
+              containerPort: 9464
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: /ssl
+              readOnly: true
+          env:
+            - name: PGSSLROOTCERT
+              value: /ssl/ca.crt
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: DATABASE_URL
+            - name: ENVIRONMENT
+              value: "testnet"
+            - name: KAFKA_BROKER
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-pipeline-secrets
+                  key: KAFKA_BROKER
+            - name: KAFKA_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-pipeline-secrets
+                  key: KAFKA_USERNAME
+            - name: KAFKA_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-pipeline-secrets
+                  key: KAFKA_PASSWORD
+            - name: KAFKA_SSL_CA_PEM
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-pipeline-secrets
+                  key: KAFKA_SSL_CA_PEM
+            - name: SUBSTREAMS_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-ipfs-cache-secrets
+                  key: SUBSTREAMS_ENDPOINT
+            - name: SUBSTREAMS_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-ipfs-cache-secrets
+                  key: SUBSTREAMS_API_TOKEN
+            # Sole ingestion floor (GEO-537). Must be the V2 SpaceRegistry
+            # deploy block on the new chain — the binary default is the OLD
+            # testnet block, so this must stay explicit here.
+            - name: SUBSTREAMS_START_BLOCK
+              value: "REPLACE_WITH_SPACEREGISTRY_DEPLOY_BLOCK"
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-pipeline-secrets
+                  key: SENTRY_DSN
+                  optional: true
+            - name: SENTRY_TRACES_SAMPLE_RATE
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-pipeline-secrets
+                  key: SENTRY_TRACES_SAMPLE_RATE
+                  optional: true
+            - name: SENTRY_SEND_DEFAULT_PII
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-pipeline-secrets
+                  key: SENTRY_SEND_DEFAULT_PII
+                  optional: true
+            - name: SENTRY_ENVIRONMENT
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-pipeline-secrets
+                  key: SENTRY_ENVIRONMENT
+                  optional: true
+            - name: SENTRY_RELEASE
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-pipeline-secrets
+                  key: SENTRY_RELEASE
+                  optional: true
+            - name: SENTRY_DEBUG
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-pipeline-secrets
+                  key: SENTRY_DEBUG
+                  optional: true
+            - name: AXIOM_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-pipeline-secrets
+                  key: AXIOM_TOKEN
+                  optional: true
+            - name: AXIOM_DATASET
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-pipeline-secrets
+                  key: AXIOM_DATASET
+                  optional: true
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "250m"
+            limits:
+              memory: "1Gi"
+              cpu: "500m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hermes-pipeline
+  namespace: gaia-v2
+  labels:
+    app: hermes-pipeline
+spec:
+  type: ClusterIP
+  selector:
+    app: hermes-pipeline
+  ports:
+    - name: metrics
+      port: 9464
+      targetPort: metrics
+      protocol: TCP

--- a/kg-indexer/k8s/v2/kg-indexer.yaml
+++ b/kg-indexer/k8s/v2/kg-indexer.yaml
@@ -1,0 +1,160 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kg-indexer
+  namespace: gaia-v2
+  labels:
+    app: kg-indexer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kg-indexer
+  template:
+    metadata:
+      labels:
+        app: kg-indexer
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        fsGroup: 1001
+      imagePullSecrets:
+        - name: regcred
+      volumes:
+        - name: ssl-certs
+          emptyDir: {}
+      nodeSelector:
+        doks.digitalocean.com/node-pool: gaia-v2-pool
+      tolerations:
+        - key: dedicated
+          value: gaia-v2
+          effect: NoSchedule
+      initContainers:
+        - name: setup-certs
+          image: registry.digitalocean.com/geo/kg-indexer:latest
+          imagePullPolicy: Always
+          command:
+            - sh
+            - -c
+            - |
+              echo "$DATABASE_SSL_CA" > /ssl/ca.crt
+          env:
+            - name: DATABASE_SSL_CA
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: DATABASE_SSL_CA
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: /ssl
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      containers:
+        - name: kg-indexer
+          image: registry.digitalocean.com/geo/kg-indexer:latest
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: /ssl
+              readOnly: true
+          env:
+            - name: PGSSLROOTCERT
+              value: /ssl/ca.crt
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: DATABASE_URL
+            - name: KAFKA_BROKER
+              valueFrom:
+                secretKeyRef:
+                  name: kg-indexer-secrets
+                  key: KAFKA_BROKER
+            - name: KAFKA_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: kg-indexer-secrets
+                  key: KAFKA_USERNAME
+            - name: KAFKA_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: kg-indexer-secrets
+                  key: KAFKA_PASSWORD
+            - name: KAFKA_SSL_CA_PEM
+              valueFrom:
+                secretKeyRef:
+                  name: kg-indexer-secrets
+                  key: KAFKA_SSL_CA_PEM
+            - name: ENVIRONMENT
+              value: "testnet"
+            - name: KAFKA_GROUP_ID
+              value: "kg-indexer-v8-testnet"
+            - name: BLOCK_STALE_TIMEOUT_MS
+              value: "1000"
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: kg-indexer-secrets
+                  key: SENTRY_DSN
+                  optional: true
+            - name: SENTRY_TRACES_SAMPLE_RATE
+              valueFrom:
+                secretKeyRef:
+                  name: kg-indexer-secrets
+                  key: SENTRY_TRACES_SAMPLE_RATE
+                  optional: true
+            - name: SENTRY_SEND_DEFAULT_PII
+              valueFrom:
+                secretKeyRef:
+                  name: kg-indexer-secrets
+                  key: SENTRY_SEND_DEFAULT_PII
+                  optional: true
+            - name: SENTRY_ENVIRONMENT
+              valueFrom:
+                secretKeyRef:
+                  name: kg-indexer-secrets
+                  key: SENTRY_ENVIRONMENT
+                  optional: true
+            - name: SENTRY_RELEASE
+              valueFrom:
+                secretKeyRef:
+                  name: kg-indexer-secrets
+                  key: SENTRY_RELEASE
+                  optional: true
+            - name: SENTRY_DEBUG
+              valueFrom:
+                secretKeyRef:
+                  name: kg-indexer-secrets
+                  key: SENTRY_DEBUG
+                  optional: true
+            - name: AXIOM_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: kg-indexer-secrets
+                  key: AXIOM_TOKEN
+                  optional: true
+            - name: AXIOM_DATASET
+              valueFrom:
+                secretKeyRef:
+                  name: kg-indexer-secrets
+                  key: AXIOM_DATASET
+                  optional: true
+            - name: RUST_LOG
+              value: "kg_indexer=info"
+          resources:
+            requests:
+              memory: "768Mi"
+              cpu: "250m"
+            limits:
+              memory: "2Gi"
+              cpu: "500m"
+      restartPolicy: Always

--- a/kg-indexer/k8s/v2/namespace.yaml
+++ b/kg-indexer/k8s/v2/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gaia-v2

--- a/proposal-executor/deployment/v2/cronjob.yaml
+++ b/proposal-executor/deployment/v2/cronjob.yaml
@@ -1,0 +1,107 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: proposal-executor
+  namespace: gaia-v2
+spec:
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 5
+  failedJobsHistoryLimit: 5
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 290 # 10s gap before next 5-min CronJob invocation
+      backoffLimit: 1 # Don't restart-loop on failure — try again in 5 min
+      template:
+        spec:
+          restartPolicy: Never # CronJob retries via next scheduled run, not restarts
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+          imagePullSecrets:
+            - name: regcred
+          volumes:
+            - name: ssl-certs
+              emptyDir: {}
+          nodeSelector:
+            doks.digitalocean.com/node-pool: gaia-v2-pool
+          tolerations:
+            - key: dedicated
+              value: gaia-v2
+              effect: NoSchedule
+          initContainers:
+            - name: setup-certs
+              image: registry.digitalocean.com/geo/proposal-executor:latest
+              command: ["sh", "-c", "echo \"$DATABASE_SSL_CA\" > /ssl/ca.crt"]
+              env:
+                - name: DATABASE_SSL_CA
+                  valueFrom:
+                    secretKeyRef:
+                      name: proposal-executor-credentials
+                      key: DATABASE_SSL_CA
+              volumeMounts:
+                - name: ssl-certs
+                  mountPath: /ssl
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+          containers:
+            - name: proposal-executor
+              image: registry.digitalocean.com/geo/proposal-executor:latest
+              imagePullPolicy: Always
+              env:
+                # Secrets (sensitive — from K8s Secret)
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: proposal-executor-credentials
+                      key: DATABASE_URL
+                - name: EXECUTOR_PRIVATE_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: proposal-executor-credentials
+                      key: EXECUTOR_PRIVATE_KEY
+                - name: PIMLICO_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: proposal-executor-credentials
+                      key: PIMLICO_API_KEY
+                # Config (non-sensitive — plain values)
+                - name: EXECUTOR_SPACE_ID
+                  value: "REPLACE_WITH_NEW_EXECUTOR_SPACE_ID"
+                - name: SPACE_REGISTRY_ADDRESS
+                  value: "REPLACE_WITH_NEW_SPACE_REGISTRY_ADDRESS"
+                - name: RPC_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: proposal-executor-credentials
+                      key: RPC_URL
+                - name: CHAIN_ID
+                  value: "REPLACE_WITH_NEW_CHAIN_ID"
+                # Optional: Sentry error reporting
+                - name: SENTRY_DSN
+                  valueFrom:
+                    secretKeyRef:
+                      name: proposal-executor-credentials
+                      key: SENTRY_DSN
+                      optional: true
+                # Trust DigitalOcean's CA cert for database SSL
+                - name: NODE_EXTRA_CA_CERTS
+                  value: "/ssl/ca.crt"
+              volumeMounts:
+                - name: ssl-certs
+                  mountPath: /ssl
+                  readOnly: true
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+              resources:
+                requests:
+                  memory: "256Mi"
+                  cpu: "250m"
+                limits:
+                  memory: "512Mi"
+                  cpu: "500m"

--- a/scoring-service/deployment/v2/cronjob.yaml
+++ b/scoring-service/deployment/v2/cronjob.yaml
@@ -1,0 +1,100 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: scoring-service
+  namespace: gaia-v2
+spec:
+  schedule: "0 3 * * *"  # Run at 3am every day
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          imagePullSecrets:
+            - name: regcred
+          nodeSelector:
+            doks.digitalocean.com/node-pool: gaia-v2-pool
+          tolerations:
+            - key: dedicated
+              value: gaia-v2
+              effect: NoSchedule
+          containers:
+            - name: scoring-service
+              image: registry.digitalocean.com/geo/scoring-service:latest
+              imagePullPolicy: Always
+              env:
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: scoring-service-credentials
+                      key: DATABASE_URL
+                # Output mode: postgres, kafka, or all
+                - name: OUTPUT_MODE
+                  value: "all"
+                # Kafka configuration (uses kafka-credentials secret copied to scoring namespace)
+                - name: KAFKA_BROKER
+                  valueFrom:
+                    secretKeyRef:
+                      name: kafka-credentials
+                      key: KAFKA_BROKER
+                - name: KAFKA_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: kafka-credentials
+                      key: KAFKA_USERNAME
+                - name: KAFKA_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: kafka-credentials
+                      key: KAFKA_PASSWORD
+                - name: KAFKA_SSL_CA_PEM
+                  valueFrom:
+                    secretKeyRef:
+                      name: kafka-credentials
+                      key: KAFKA_SSL_CA_PEM
+                - name: ENVIRONMENT
+                  value: "testnet"
+                - name: KAFKA_TOPIC
+                  value: "curation.scores"
+                - name: SCORE_BATCH_SIZE
+                  value: "1000"
+                - name: NORMALIZATION_METHOD
+                  value: "z_score_sigmoid"
+                - name: SENTRY_DSN
+                  valueFrom:
+                    secretKeyRef:
+                      name: scoring-cronjob-secrets
+                      key: SENTRY_DSN
+                      optional: true
+                - name: SENTRY_TRACES_SAMPLE_RATE
+                  valueFrom:
+                    secretKeyRef:
+                      name: scoring-cronjob-secrets
+                      key: SENTRY_TRACES_SAMPLE_RATE
+                      optional: true
+                - name: SENTRY_SEND_DEFAULT_PII
+                  valueFrom:
+                    secretKeyRef:
+                      name: scoring-cronjob-secrets
+                      key: SENTRY_SEND_DEFAULT_PII
+                      optional: true
+                - name: SENTRY_ENVIRONMENT
+                  valueFrom:
+                    secretKeyRef:
+                      name: scoring-cronjob-secrets
+                      key: SENTRY_ENVIRONMENT
+                      optional: true
+                - name: SENTRY_RELEASE
+                  valueFrom:
+                    secretKeyRef:
+                      name: scoring-cronjob-secrets
+                      key: SENTRY_RELEASE
+                      optional: true
+              resources:
+                requests:
+                  memory: "2048Mi"
+                  cpu: "1000m"
+                limits:
+                  memory: "4096Mi"
+                  cpu: "2000m"

--- a/scoring-service/deployment/v2/topology-indexer.yaml
+++ b/scoring-service/deployment/v2/topology-indexer.yaml
@@ -1,0 +1,124 @@
+# Topology Indexer Deployment
+#
+# Consumes CanonicalGraphDiff events from Kafka and persists space distances to PostgreSQL.
+# This daemon runs continuously alongside the scoring-service CronJob.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: topology-indexer
+  namespace: gaia-v2
+  labels:
+    app: topology-indexer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: topology-indexer
+  template:
+    metadata:
+      labels:
+        app: topology-indexer
+    spec:
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        fsGroup: 1001
+      imagePullSecrets:
+        - name: regcred
+      nodeSelector:
+        doks.digitalocean.com/node-pool: gaia-v2-pool
+      tolerations:
+        - key: dedicated
+          value: gaia-v2
+          effect: NoSchedule
+      containers:
+        - name: topology-indexer
+          image: registry.digitalocean.com/geo/topology-indexer:latest
+          imagePullPolicy: Always
+          env:
+            # Database configuration
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: scoring-service-credentials
+                  key: DATABASE_URL
+            # Kafka configuration
+            - name: KAFKA_BROKER
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-credentials
+                  key: KAFKA_BROKER
+            - name: KAFKA_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-credentials
+                  key: KAFKA_USERNAME
+                  optional: true
+            - name: KAFKA_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-credentials
+                  key: KAFKA_PASSWORD
+                  optional: true
+            - name: KAFKA_SSL_CA_PEM
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-credentials
+                  key: KAFKA_SSL_CA_PEM
+                  optional: true
+            # Consumer configuration
+            - name: ENVIRONMENT
+              value: "testnet"
+            - name: KAFKA_GROUP_ID
+              value: "topology-indexer-testnet"
+            - name: BATCH_SIZE
+              value: "10"
+            - name: BATCH_TIMEOUT_MS
+              value: "1000"
+            # Logging
+            - name: RUST_LOG
+              value: "info,topology_indexer=debug"
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: topology-indexer-secrets
+                  key: SENTRY_DSN
+                  optional: true
+            - name: SENTRY_TRACES_SAMPLE_RATE
+              valueFrom:
+                secretKeyRef:
+                  name: topology-indexer-secrets
+                  key: SENTRY_TRACES_SAMPLE_RATE
+                  optional: true
+            - name: SENTRY_SEND_DEFAULT_PII
+              valueFrom:
+                secretKeyRef:
+                  name: topology-indexer-secrets
+                  key: SENTRY_SEND_DEFAULT_PII
+                  optional: true
+            - name: SENTRY_ENVIRONMENT
+              valueFrom:
+                secretKeyRef:
+                  name: topology-indexer-secrets
+                  key: SENTRY_ENVIRONMENT
+                  optional: true
+            - name: SENTRY_RELEASE
+              valueFrom:
+                secretKeyRef:
+                  name: topology-indexer-secrets
+                  key: SENTRY_RELEASE
+                  optional: true
+            - name: SENTRY_DEBUG
+              valueFrom:
+                secretKeyRef:
+                  name: topology-indexer-secrets
+                  key: SENTRY_DEBUG
+                  optional: true
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "50m"
+            limits:
+              memory: "256Mi"
+              cpu: "250m"

--- a/scoring-service/deployment/v2/vote-indexer.yaml
+++ b/scoring-service/deployment/v2/vote-indexer.yaml
@@ -1,0 +1,124 @@
+# Vote Indexer Deployment
+#
+# Consumes vote events from Kafka and indexes them into PostgreSQL with real-time aggregation.
+# This daemon runs continuously alongside the scoring-service CronJob.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vote-indexer
+  namespace: gaia-v2
+  labels:
+    app: vote-indexer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vote-indexer
+  template:
+    metadata:
+      labels:
+        app: vote-indexer
+    spec:
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        fsGroup: 1001
+      imagePullSecrets:
+        - name: regcred
+      nodeSelector:
+        doks.digitalocean.com/node-pool: gaia-v2-pool
+      tolerations:
+        - key: dedicated
+          value: gaia-v2
+          effect: NoSchedule
+      containers:
+        - name: vote-indexer
+          image: registry.digitalocean.com/geo/vote-indexer:latest
+          imagePullPolicy: Always
+          env:
+            # Database configuration
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: scoring-service-credentials
+                  key: DATABASE_URL
+            # Kafka configuration
+            - name: KAFKA_BROKER
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-credentials
+                  key: KAFKA_BROKER
+            - name: KAFKA_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-credentials
+                  key: KAFKA_USERNAME
+                  optional: true
+            - name: KAFKA_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-credentials
+                  key: KAFKA_PASSWORD
+                  optional: true
+            - name: KAFKA_SSL_CA_PEM
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-credentials
+                  key: KAFKA_SSL_CA_PEM
+                  optional: true
+            # Consumer configuration
+            - name: ENVIRONMENT
+              value: "testnet"
+            - name: KAFKA_GROUP_ID
+              value: "vote-indexer-testnet"
+            - name: BATCH_SIZE
+              value: "100"
+            - name: BATCH_TIMEOUT_MS
+              value: "1000"
+            # Logging
+            - name: RUST_LOG
+              value: "info,vote_indexer=debug"
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: vote-indexer-secrets
+                  key: SENTRY_DSN
+                  optional: true
+            - name: SENTRY_TRACES_SAMPLE_RATE
+              valueFrom:
+                secretKeyRef:
+                  name: vote-indexer-secrets
+                  key: SENTRY_TRACES_SAMPLE_RATE
+                  optional: true
+            - name: SENTRY_SEND_DEFAULT_PII
+              valueFrom:
+                secretKeyRef:
+                  name: vote-indexer-secrets
+                  key: SENTRY_SEND_DEFAULT_PII
+                  optional: true
+            - name: SENTRY_ENVIRONMENT
+              valueFrom:
+                secretKeyRef:
+                  name: vote-indexer-secrets
+                  key: SENTRY_ENVIRONMENT
+                  optional: true
+            - name: SENTRY_RELEASE
+              valueFrom:
+                secretKeyRef:
+                  name: vote-indexer-secrets
+                  key: SENTRY_RELEASE
+                  optional: true
+            - name: SENTRY_DEBUG
+              valueFrom:
+                secretKeyRef:
+                  name: vote-indexer-secrets
+                  key: SENTRY_DEBUG
+                  optional: true
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"

--- a/search-indexer-deploy/k8s/v2/search-indexer.yaml
+++ b/search-indexer-deploy/k8s/v2/search-indexer.yaml
@@ -1,0 +1,181 @@
+# =============================================================================
+# Search Indexer Headless Service (required by StatefulSet)
+# =============================================================================
+apiVersion: v1
+kind: Service
+metadata:
+  name: search-indexer
+  namespace: gaia-v2
+  labels:
+    app: search-indexer
+spec:
+  clusterIP: None
+  selector:
+    app: search-indexer
+  ports:
+    - name: http
+      port: 8080
+      targetPort: health
+---
+# =============================================================================
+# Search Indexer StatefulSet
+# =============================================================================
+# Consumes messages from Kafka and indexes them into OpenSearch
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: search-indexer
+  namespace: gaia-v2
+  labels:
+    app: search-indexer
+spec:
+  serviceName: search-indexer
+  replicas: 1
+  selector:
+    matchLabels:
+      app: search-indexer
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: search-indexer
+    spec:
+      imagePullSecrets:
+        - name: regcred
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+      nodeSelector:
+        doks.digitalocean.com/node-pool: gaia-v2-pool
+      tolerations:
+        - key: dedicated
+          value: gaia-v2
+          effect: NoSchedule
+      containers:
+        - name: search-indexer
+          image: registry.digitalocean.com/geo/search-indexer:latest
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          env:
+            # OpenSearch connection (managed DigitalOcean OpenSearch)
+            - name: OPENSEARCH_URL
+              valueFrom:
+                secretKeyRef:
+                  name: opensearch-credentials
+                  key: OPENSEARCH_URL
+            # Index version (defaults to 0 if not set)
+            - name: ENTITIES_INDEX_VERSION
+              value: "5"
+            # Kafka connection (managed Kafka with SSL)
+            - name: KAFKA_BROKER
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-credentials
+                  key: KAFKA_BROKER
+            - name: KAFKA_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-credentials
+                  key: KAFKA_USERNAME
+            - name: KAFKA_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-credentials
+                  key: KAFKA_PASSWORD
+            - name: KAFKA_SSL_CA_PEM
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-credentials
+                  key: KAFKA_SSL_CA_PEM
+            # Database (Postgres lookup for fast score indexing)
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: search-indexer-secrets
+                  key: DATABASE_URL
+            - name: DATABASE_MAX_CONNECTIONS
+              value: "5"
+            # Relation map (SQLite-backed, for fast DeleteRelation lookups)
+            - name: RELATION_MAP_DB_PATH
+              value: "/data/relation_map.sqlite"
+            - name: RELATION_MAP_CACHE_SIZE
+              value: "500000"
+            # Kafka consumer configuration
+            - name: ENVIRONMENT
+              value: "testnet"
+            - name: KAFKA_GROUP_EDITS_ID
+              value: "search-indexer-group-edits-v4"
+            - name: KAFKA_GROUP_SCORES_ID
+              value: "search-indexer-group-scores-v3"
+            - name: KAFKA_GROUP_SPACE_TOPICS_ID
+              value: "search-indexer-group-space-topics-v3"
+            # Logging
+            - name: RUST_LOG
+              value: "info"
+              # Set with kubectl for debugging: "info,search_indexer=debug,search_indexer_repository=debug"
+            # Sentry telemetry and monitoring
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: search-indexer-secrets
+                  key: SENTRY_DSN
+                  optional: true
+            - name: SENTRY_ENVIRONMENT
+              value: "testnet"
+            - name: SENTRY_RELEASE
+              value: "search-indexer@1.0.0"
+            - name: SENTRY_TRACES_SAMPLE_RATE
+              value: "0.1"
+            - name: SENTRY_SEND_DEFAULT_PII
+              value: "false"
+            - name: SENTRY_DEBUG
+              value: "false"
+          ports:
+            - name: health
+              containerPort: 8080
+              protocol: TCP
+          resources:
+            requests:
+              memory: "2Gi"
+              cpu: "100m"
+            limits:
+              memory: "4Gi"
+              cpu: "500m"
+          volumeMounts:
+            - name: topology-data
+              mountPath: /data
+          # Liveness probe - checks if the process is alive and can respond to HTTP requests
+          # Used by Kubernetes to restart the container if it becomes unresponsive
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          # Readiness probe - checks if the service is ready to accept traffic
+          # Verifies healthy OpenSearch connectivity before routing traffic to the pod
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: health
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+      restartPolicy: Always
+  volumeClaimTemplates:
+    - metadata:
+        name: topology-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 2Gi


### PR DESCRIPTION
## What

`v2/` copies of the production manifests for the gaia-v2 stack (new-chain indexer deployment), per the [deploy runbook](https://app.notion.com/p/37c9a4c092c781e49259c39cdea3c16c) Step 9:

- Every `namespace:` → `gaia-v2` (single shared namespace); shared `namespace.yaml` under `kg-indexer/k8s/v2/`
- `ENVIRONMENT: testnet` on all workloads (shared-broker isolation from #223)
- `nodeSelector` **and** toleration on all 11 workloads, pinning them to the dedicated `gaia-v2-pool` (the pool is tainted `dedicated=gaia-v2:NoSchedule`, so the selector alone wouldn't schedule); CronJobs get it at `spec.jobTemplate.spec.template.spec`
- api: `TOPOLOGY_SERVICE_URL` → same-namespace `http://search-indexer:8080`, `replicas: 1`, HPA min 1 / max 2 (test right-sizing)
- kg-indexer / vote-indexer / topology-indexer: `*-testnet` consumer-group ids
- hermes-pipeline: explicit `SUBSTREAMS_START_BLOCK` added — the prod manifest omits it and the binary default is the **old** testnet deploy block; atlas updated likewise

## Decisions worth review

- **Ingress host**: prod's api Ingress already owns `testnet-api.geobrowser.io`, so the v2 Ingress uses `testnet-api-v2.geobrowser.io` (+ distinct TLS secret). Needs a DNS record; happy to rename.
- **Loud placeholders**: chain-specific values are `REPLACE_WITH_*` strings (SpaceRegistry deploy block ×2, executor `CHAIN_ID` / `SPACE_REGISTRY_ADDRESS` / `EXECUTOR_SPACE_ID`) so an unfilled manifest fails visibly instead of indexing the wrong chain.
- **Excluded**: secret/otel templates and the Secret embedded in `search-indexer.yaml` (secrets are created out-of-band per runbook Step 7), kafka-ui (existing one shows the shared broker), ServiceMonitors (monitoring wired post-go-live).

## Verification

- All files parse (PyYAML); kinds: Deployments, Services, StatefulSet, CronJobs, HPA, Ingress, NetworkPolicy, Namespace
- Gates: no non-`gaia-v2` namespace, no `svc.cluster.local` leftovers, no `production`/`staging` env values, all images `:latest` (deploy sed swaps to `:$SHA`), 11/11 workloads pool-pinned

Part of GEO-664.