### PR TITLE
ci: manual workflow to build and push gaia-v2 images (GEO-664)

### DIFF
--- a/.github/workflows/build-v2-images.yml
+++ b/.github/workflows/build-v2-images.yml
@@ -12,7 +12,7 @@ on:
 
 concurrency:
   group: build-v2-images
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   REGISTRY: registry.digitalocean.com/geo

--- a/.github/workflows/build-v2-images.yml
+++ b/.github/workflows/build-v2-images.yml
@@ -1,0 +1,87 @@
+name: Build gaia-v2 images (manual)
+
+# Builds and pushes all images needed for the gaia-v2 (chain-migration) stack.
+# Build-and-push only — deploys stay manual per the GEO-664 runbook (Step 12:
+# sed the image tag into the k8s/v2 manifests and kubectl apply).
+#
+# Images are tagged with the full commit SHA and a short 8-char SHA; use either
+# in the manifests.
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: build-v2-images
+  cancel-in-progress: true
+
+env:
+  REGISTRY: registry.digitalocean.com/geo
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: hermes-pipeline
+            dockerfile: hermes-pipeline/Dockerfile
+            context: .
+          - image: hermes-ipfs-cache
+            dockerfile: hermes-ipfs-cache/Dockerfile
+            context: .
+          - image: kg-indexer
+            dockerfile: kg-indexer/Dockerfile
+            context: .
+          - image: api
+            dockerfile: api/Dockerfile
+            context: .
+          - image: proposal-executor
+            dockerfile: proposal-executor/Dockerfile
+            context: .
+          - image: atlas
+            dockerfile: atlas/Dockerfile
+            context: .
+          - image: search-indexer
+            dockerfile: search-indexer/Dockerfile
+            context: .
+          - image: vote-indexer
+            dockerfile: scoring-service/vote-indexer/Dockerfile
+            context: .
+          - image: topology-indexer
+            dockerfile: scoring-service/topology-indexer/Dockerfile
+            context: .
+          - image: scoring-service
+            dockerfile: scoring-service/cronjob/Dockerfile
+            context: scoring-service/cronjob
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6.0.2
+
+      - name: Install doctl
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Log in to DigitalOcean Container Registry
+        run: doctl registry login --expiry-seconds 1200
+
+      - name: Build and push
+        run: |
+          SHORT_SHA="${GITHUB_SHA:0:8}"
+          docker build -t ${{ env.REGISTRY }}/${{ matrix.image }}:${{ github.sha }} \
+                       -t ${{ env.REGISTRY }}/${{ matrix.image }}:$SHORT_SHA \
+                       -f ${{ matrix.dockerfile }} ${{ matrix.context }}
+          docker push ${{ env.REGISTRY }}/${{ matrix.image }}:${{ github.sha }}
+          docker push ${{ env.REGISTRY }}/${{ matrix.image }}:$SHORT_SHA
+
+  summary:
+    needs: build
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print image tags
+        run: |
+          echo "## gaia-v2 images" >> "$GITHUB_STEP_SUMMARY"
+          echo "Tag for manifests: \`${GITHUB_SHA:0:8}\` (or full \`${GITHUB_SHA}\`)" >> "$GITHUB_STEP_SUMMARY"
+          echo "Build result: ${{ needs.build.result }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-v2-images.yml
+++ b/.github/workflows/build-v2-images.yml
@@ -35,10 +35,10 @@ jobs:
             context: .
           - image: api
             dockerfile: api/Dockerfile
-            context: .
+            context: ./api
           - image: proposal-executor
             dockerfile: proposal-executor/Dockerfile
-            context: .
+            context: proposal-executor
           - image: atlas
             dockerfile: atlas/Dockerfile
             context: .


### PR DESCRIPTION
## What

Adds `build-v2-images.yml` — a `workflow_dispatch` (button-press) workflow that builds and pushes all 10 images the gaia-v2 stack needs to `registry.digitalocean.com/geo`, tagged with the full and short (8-char) commit SHA.

- Matrix over: hermes-pipeline, hermes-ipfs-cache, kg-indexer, api, proposal-executor, atlas, search-indexer, vote-indexer, topology-indexer, scoring-service
- `fail-fast: false` — independent images still publish if one build breaks
- Mirrors the existing deploy workflows' doctl-login + docker-build pattern and reuses `DIGITALOCEAN_ACCESS_TOKEN`
- Build-and-push **only** — deploys stay manual per the [GEO-664 runbook](https://app.notion.com/p/37c9a4c092c781e49259c39cdea3c16c) Step 12; a summary job prints the tag to sed into the `k8s/v2/` manifests

## Why

Building locally from an Apple Silicon machine requires amd64 emulation (very slow for the Rust workspace builds) and just hit a dependency-drift compile failure (sentry-types 0.46.2 vs latest `time`, E0119 — the Rust Dockerfiles build without the workspace `Cargo.lock`, so every uncached build re-resolves crates). Running the build on Actions is the controlled first step; if the drift failure reproduces there, the follow-up is pinning the lockfile into the Dockerfiles.

Part of GEO-664.