### PR TITLE
feat(proposal-executor): wire membership auto-accept path into main()

### DIFF
--- a/proposal-executor/src/detect.ts
+++ b/proposal-executor/src/detect.ts
@@ -182,9 +182,12 @@ export function findExecutableProposals(client: PgClient, nowSeconds: number): E
  * - Not yet executed (executed_at IS NULL)
  * - Created in the past (guards against corrupt future timestamps; no age cutoff
  *   — backlog is admitted, unlike the executor's MAX_PROPOSAL_AGE)
- * - Voting period has not ended (now <= end_time) — the protocol rejects votes
- *   cast after the period closes, and an untouched Fast proposal whose period
- *   has ended is already classified REJECTED (threshold not reached)
+ * - Voting period has not ended (now <= end_time + CLOCK_SKEW_BUFFER) — the protocol
+ *   rejects votes cast after the period closes, and an untouched Fast proposal whose
+ *   period has ended is already classified REJECTED (threshold not reached). The same
+ *   60s skew buffer the stage-2 eligibility check applies (isVotingOpen, membership.ts)
+ *   is added here so detection never excludes a request that stage 2 would still vote
+ *   on — `now` must therefore be the same chain-sourced timestamp stage 2 uses.
  * - Exactly one action, an AddMember targeting the proposer itself
  *   (target_id = proposed_by) — the self-service request-to-join signature, not
  *   an editor-initiated add
@@ -205,7 +208,7 @@ WHERE p.space_id = ANY($1)
   AND p.voting_mode = 'Fast'
   AND p.executed_at IS NULL
   AND p.created_at::bigint <= $2::bigint
-  AND $2::bigint <= p.end_time
+  AND $2::bigint <= p.end_time + ${CLOCK_SKEW_BUFFER}
   AND a.action_type = 'AddMember'
   AND a.target_id = p.proposed_by
   AND NOT EXISTS (SELECT 1 FROM proposal_votes pv WHERE pv.proposal_id = p.id)
@@ -222,15 +225,19 @@ ORDER BY p.created_at::bigint ASC
  *
  * @param client - Connected pg.Client
  * @param allowlistSpaceIds - Dashed UUIDs of allowlisted DAO spaces (from bytes16 config)
+ * @param nowSeconds - Current Unix timestamp in seconds. MUST be the same chain-sourced
+ *   clock stage 2 uses (readChainTimeSeconds), so the two stages share one notion of
+ *   "now" and the same skew policy — passing the pod wall clock would reintroduce the
+ *   drift the +CLOCK_SKEW_BUFFER window is meant to absorb.
  */
 export function findMembershipRequests(
 	client: PgClient,
 	allowlistSpaceIds: string[],
+	nowSeconds: number,
 ): Effect.Effect<MembershipRequest[], InfraError> {
 	if (allowlistSpaceIds.length === 0) {
 		return Effect.succeed([])
 	}
-	const nowSeconds = Math.floor(Date.now() / 1000)
 	return Effect.tryPromise({
 		try: async () => {
 			const result = await client.query<MembershipRequest>(MEMBERSHIP_DETECTION_SQL, [

--- a/proposal-executor/src/index.ts
+++ b/proposal-executor/src/index.ts
@@ -1,9 +1,18 @@
 /**
  * Proposal Auto-Executor — Effect-TS entry point.
  *
- * Detects slow-path governance proposals in EXECUTABLE status and calls
- * enter(PROPOSAL_EXECUTED) on the Space Registry contract via a gas-sponsored
- * Safe smart account.
+ * Two independent action paths share this process and ~5-minute cadence:
+ *
+ *  1. Execute path — detects slow-path governance proposals in EXECUTABLE status and
+ *     calls enter(PROPOSAL_EXECUTED) on the Space Registry via the executor wallet.
+ *  2. Membership-accept path — detects untouched request-to-join proposals in an
+ *     allowlist of spaces and casts a single enter(PROPOSAL_VOTED, Yes) from a SECOND,
+ *     distinct bot wallet. Because allowlisted spaces run with fastPathFlatThreshold = 1,
+ *     that YES vote admits the joiner in the same transaction. A two-stage untouched
+ *     check (indexer SQL → on-chain tally) makes it safe and idempotent.
+ *
+ * The two paths never share a wallet identity and are isolated: a failure in one does
+ * not abort the other.
  *
  * Concurrency: parallel across spaces (unbounded), sequential within each space.
  * Error handling: RevertError → skip, InfraError → retry 2x then abort space.
@@ -16,8 +25,24 @@ import type {Hex} from "viem"
 import {type Address, getAddress} from "viem"
 
 import {InfraError, type RevertError, type SupportedChainId} from "./contracts.js"
-import {connectDb, disconnectDb, findExecutableProposals, MAX_PROPOSAL_AGE, type Proposal} from "./detect.js"
-import {createSmartWallet, executeProposal, type SmartWallet, verifyExecutorSetup} from "./execute.js"
+import {
+	connectDb,
+	disconnectDb,
+	findExecutableProposals,
+	findMembershipRequests,
+	MAX_PROPOSAL_AGE,
+	type MembershipRequest,
+	type Proposal,
+} from "./detect.js"
+import {createSmartWallet, executeProposal, type SmartWallet, uuidToBytes16, verifyExecutorSetup} from "./execute.js"
+import {
+	castMembershipVote,
+	isEligibleToVote,
+	type ProposalTally,
+	readChainTimeSeconds,
+	readProposalTally,
+	resolveDaoSpaceAddress,
+} from "./membership.js"
 import {flush, TelemetryLive} from "./telemetry.js"
 
 // Re-export tagged errors so tests and consumers have a single import
@@ -285,6 +310,245 @@ function executeSpaceProposals(
 }
 
 // ---------------------------------------------------------------------------
+// Membership-accept path — orchestration helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a bytes16 hex space ID (0x + 32 hex chars) back to a dashed UUID.
+ *
+ * The allowlist is configured as bytes16 (MEMBERSHIP_AUTOACCEPT_SPACE_IDS), but the
+ * indexer stores space_id as a dashed, lower-cased UUID. The detection query matches
+ * on the UUID form, so the allowlist must be converted before it is passed in. This is
+ * the inverse of execute.ts' uuidToBytes16.
+ */
+export function bytes16ToUuid(spaceId: Hex): string {
+	const hex = spaceId.startsWith("0x") ? spaceId.slice(2) : spaceId
+	if (hex.length !== 32 || !/^[0-9a-fA-F]+$/.test(hex)) {
+		throw new Error(`Invalid bytes16 for UUID conversion: ${spaceId}`)
+	}
+	const h = hex.toLowerCase()
+	return `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20)}`
+}
+
+/**
+ * Why a membership request was skipped instead of voted on. The bot only votes on a
+ * genuinely untouched, still-open request; every other state maps to a distinct, typed
+ * reason so the telemetry says *why* nothing was done:
+ * - `indexed_vote` — stage 1 (indexer): a vote is already in proposal_votes. Enforced
+ *   by the detection SQL's NOT EXISTS, so survivors reaching stage 2 have passed it;
+ *   surfaced here for taxonomy completeness (not emitted by this loop at runtime).
+ * - `already_executed` — stage 2: the proposal has already executed (resolved).
+ * - `onchain_tally_nonzero` — stage 2: a vote is already recorded in the on-chain
+ *   tally. This is also what the bot's own prior vote trips, making the job idempotent.
+ * - `voting_window_closed` — stage 2: the voting period has ended, so the protocol
+ *   would reject a late vote. An untouched-but-expired request is left alone — this is
+ *   independent of the tally, which may well be zero.
+ */
+export type MembershipSkipReason =
+	| "indexed_vote"
+	| "already_executed"
+	| "onchain_tally_nonzero"
+	| "voting_window_closed"
+
+/**
+ * The outcome of processing one membership request:
+ * - `voted`    — a YES vote was cast (the requester is admitted),
+ * - `skipped`  — ineligible at stage 2 (touched/resolved/closed) → not our business,
+ * - `reverted` — the vote reverted on-chain (e.g. already executed, or the bot lacks
+ *   the EDITOR role); logged and left for the next cycle, never aborts other requests.
+ */
+type MembershipOutcome =
+	| {status: "voted"; txHash: string}
+	| {status: "skipped"; reason: MembershipSkipReason}
+	| {status: "reverted"; expected: boolean}
+
+/** Result of processing all requests in a single space. */
+type MembershipSpaceResult =
+	| {status: "ok"; spaceId: string; outcomes: MembershipOutcome[]}
+	| {status: "infraError"; spaceId: string; outcomes: MembershipOutcome[]}
+
+interface MembershipSummary {
+	/** YES votes cast (requesters admitted this cycle). */
+	admitted: number
+	/** Requests left alone — ineligible (stage 2) or reverted. */
+	skipped: number
+	/** Spaces aborted by a persistent infrastructure error. */
+	failed: number
+	/** Candidate requests surfaced by stage-1 detection. */
+	total: number
+	/** Allowlisted spaces with at least one candidate. */
+	spaces: number
+}
+
+/**
+ * Classify a stage-1 survivor after the authoritative on-chain (stage-2) read.
+ * Returns `null` when the request is still eligible (the bot should vote), otherwise
+ * the specific reason it is ineligible. Stays in lock-step with isEligibleToVote — it
+ * returns null in exactly the cases that function returns true, then names the cause:
+ * executed first, then a non-zero tally, and finally a closed voting window (the
+ * remaining cause for an untouched, unexecuted request).
+ */
+export function classifyMembershipSkip(tally: ProposalTally, nowSeconds: bigint): MembershipSkipReason | null {
+	if (isEligibleToVote(tally, nowSeconds)) return null
+	if (tally.executed) return "already_executed"
+	if (tally.yes !== 0n || tally.no !== 0n || tally.abstain !== 0n) return "onchain_tally_nonzero"
+	return "voting_window_closed"
+}
+
+/**
+ * Aggregate per-space results into the run summary. Votes count as `admitted`;
+ * both ineligible skips and on-chain reverts count as `skipped` (non-admitting,
+ * non-failing); spaces aborted by infra count as `failed`.
+ */
+export function aggregateMembership(results: MembershipSpaceResult[]): {
+	admitted: number
+	skipped: number
+	failed: number
+} {
+	let admitted = 0
+	let skipped = 0
+	for (const r of results) {
+		for (const o of r.outcomes) {
+			if (o.status === "voted") admitted++
+			else skipped++
+		}
+	}
+	const failed = results.filter((r) => r.status === "infraError").length
+	return {admitted, skipped, failed}
+}
+
+/** Cast a membership YES vote with the same timeout + InfraError retry the executor uses. */
+function castVoteWithRetry(
+	wallet: SmartWallet,
+	request: MembershipRequest,
+	botSpaceId: Hex,
+	spaceRegistryAddress: Address,
+): Effect.Effect<string, InfraError | RevertError> {
+	return castMembershipVote(wallet, request, botSpaceId, spaceRegistryAddress).pipe(
+		Effect.timeoutFail({
+			duration: Duration.seconds(30),
+			onTimeout: () =>
+				new InfraError({proposalId: request.id, message: "Vote cast timed out after 30s", durationMs: 30_000}),
+		}),
+		Effect.retry({schedule: infraRetryPolicy, while: (e) => e._tag === "InfraError"}),
+		Effect.withSpan("proposal-executor.membership-vote", {
+			attributes: {proposalId: request.id, spaceId: request.spaceId},
+		}),
+	)
+}
+
+/** Read the on-chain tally (stage 2) with the same timeout + InfraError retry. */
+function readTallyWithRetry(
+	wallet: SmartWallet,
+	daoSpaceAddress: Address,
+	proposalId: string,
+): Effect.Effect<ProposalTally, InfraError> {
+	return readProposalTally(wallet, daoSpaceAddress, proposalId).pipe(
+		Effect.timeoutFail({
+			duration: Duration.seconds(30),
+			onTimeout: () =>
+				new InfraError({proposalId, message: "Tally read timed out after 30s", durationMs: 30_000}),
+		}),
+		Effect.retry({schedule: infraRetryPolicy, while: (e) => e._tag === "InfraError"}),
+	)
+}
+
+/**
+ * Process one membership request: stage-2 on-chain read → eligibility gate → vote.
+ * A RevertError is caught and turned into a `reverted` outcome (logged, not fatal) so
+ * it never aborts the rest of the space. An InfraError propagates to abort this space
+ * (retried next cycle), matching the executor's per-space fail-fast.
+ */
+export function processMembershipRequest(
+	wallet: SmartWallet,
+	request: MembershipRequest,
+	daoSpaceAddress: Address,
+	botSpaceId: Hex,
+	spaceRegistryAddress: Address,
+	nowSeconds: bigint,
+): Effect.Effect<MembershipOutcome, InfraError> {
+	return readTallyWithRetry(wallet, daoSpaceAddress, request.id).pipe(
+		Effect.flatMap((tally) => {
+			const skipReason = classifyMembershipSkip(tally, nowSeconds)
+			if (skipReason !== null) {
+				return Effect.logInfo("membership_skip").pipe(
+					Effect.annotateLogs({
+						proposalId: request.id,
+						spaceId: request.spaceId,
+						targetId: request.requesterId,
+						reason: skipReason,
+						yes: tally.yes.toString(),
+						no: tally.no.toString(),
+						abstain: tally.abstain.toString(),
+						executed: tally.executed,
+					}),
+					Effect.as({status: "skipped", reason: skipReason} as MembershipOutcome),
+				)
+			}
+
+			return castVoteWithRetry(wallet, request, botSpaceId, spaceRegistryAddress).pipe(
+				Effect.tap((txHash) =>
+					Effect.logInfo("membership_vote_cast").pipe(
+						Effect.annotateLogs({
+							proposalId: request.id,
+							spaceId: request.spaceId,
+							targetId: request.requesterId,
+							txHash,
+						}),
+					),
+				),
+				Effect.map((txHash) => ({status: "voted", txHash}) as MembershipOutcome),
+				Effect.catchTag("RevertError", (e) =>
+					Effect.logInfo(e.expected ? "membership_skip_expected" : "membership_vote_reverted").pipe(
+						Effect.annotateLogs({
+							proposalId: request.id,
+							spaceId: request.spaceId,
+							error: e.message,
+							expected: e.expected,
+							durationMs: e.durationMs,
+						}),
+						Effect.as({status: "reverted", expected: e.expected} as MembershipOutcome),
+					),
+				),
+			)
+		}),
+	)
+}
+
+/**
+ * Process every request in one space: resolve its DAOSpace address once (cached for
+ * the space), then run requests sequentially. An InfraError propagates to the caller,
+ * which catches it at the space boundary so one space failing doesn't cancel others.
+ */
+export function processSpaceMembership(
+	wallet: SmartWallet,
+	spaceId: string,
+	requests: MembershipRequest[],
+	botSpaceId: Hex,
+	spaceRegistryAddress: Address,
+	nowSeconds: bigint,
+): Effect.Effect<MembershipOutcome[], InfraError> {
+	return resolveDaoSpaceAddress(wallet, spaceRegistryAddress, uuidToBytes16(spaceId)).pipe(
+		Effect.retry({schedule: infraRetryPolicy, while: (e) => e._tag === "InfraError"}),
+		Effect.flatMap((daoSpaceAddress) =>
+			Effect.forEach(
+				requests,
+				(request) =>
+					processMembershipRequest(
+						wallet,
+						request,
+						daoSpaceAddress,
+						botSpaceId,
+						spaceRegistryAddress,
+						nowSeconds,
+					),
+				{concurrency: 1},
+			),
+		),
+	)
+}
+
+// ---------------------------------------------------------------------------
 // Main — orchestration, error handling, flush, exit code
 // ---------------------------------------------------------------------------
 
@@ -314,7 +578,7 @@ const main = Effect.gen(function* () {
 
 	// Membership-accept bot wallet — a SECOND, distinct identity built from the
 	// dedicated bot key + space. Verified each run so a misconfigured bot fails
-	// fast; detection/voting are wired in a later PR (this path is inert for now).
+	// fast. It casts the membership YES votes; the executor wallet never does.
 	const botWallet = yield* createSmartWallet({
 		privateKey: config.membershipBotPrivateKey,
 		pimlicoApiKey: Redacted.value(config.pimlicoApiKey),
@@ -332,74 +596,171 @@ const main = Effect.gen(function* () {
 
 	const runStart = Date.now()
 	const nowSeconds = Math.floor(runStart / 1000)
-	const proposals = yield* findExecutableProposals(db, nowSeconds).pipe(Effect.withSpan("proposal-executor.detect"))
-	const bySpace = Map.groupBy(proposals, (p) => p.spaceId)
 
-	yield* Effect.logInfo("run_start").pipe(
-		Effect.annotateLogs({
-			proposalsFound: proposals.length,
-			spaces: bySpace.size,
-			ageCutoffTimestamp: nowSeconds - MAX_PROPOSAL_AGE,
-		}),
-	)
-
-	if (proposals.length === 0) {
-		yield* Effect.logInfo("run_end").pipe(
-			Effect.annotateLogs({succeeded: 0, failed: 0, skipped: 0, total: 0, durationMs: Date.now() - runStart}),
+	// --- Execute path (executor wallet) — total: catches its own failures so it never
+	// aborts the membership path. The only uncaught source below the space boundary is
+	// the detection query; its InfraError is converted to a failed summary here. ---
+	const runExecutePath: Effect.Effect<{
+		succeeded: number
+		failed: number
+		skipped: number
+		total: number
+		spaces: number
+	}> = Effect.gen(function* () {
+		const proposals = yield* findExecutableProposals(db, nowSeconds).pipe(
+			Effect.withSpan("proposal-executor.detect"),
 		)
-		return {succeeded: 0, failed: 0}
-	}
+		const bySpace = Map.groupBy(proposals, (p) => p.spaceId)
 
-	// Parallel across spaces (capped at 10 concurrent RPC connections), sequential
-	// within each space. Each space is independent — an InfraError in one space
-	// doesn't affect others.
-	const results = yield* Effect.forEach(
-		[...bySpace.entries()],
-		([spaceId, spaceProposals]) =>
-			executeSpaceProposals(
-				spaceId,
-				spaceProposals,
-				wallet,
-				config.executorSpaceId,
-				config.spaceRegistryAddress,
-			).pipe(
-				Effect.map(
-					(outcomes) =>
-						({
-							status: "ok" as const,
-							spaceId,
-							succeeded: outcomes.filter((r) => r !== "skipped").length,
-							skipped: outcomes.filter((r) => r === "skipped").length,
-						}) as const,
-				),
-				// Catch InfraError at the space level so one space failing
-				// doesn't cancel the others
-				Effect.catchTag("InfraError", (e) =>
-					Effect.logError("space_aborted").pipe(
-						Effect.annotateLogs({spaceId, error: e.message, proposalId: e.proposalId}),
-						Effect.as({status: "infraError" as const, spaceId, succeeded: 0, skipped: 0} as const),
+		yield* Effect.logInfo("run_start").pipe(
+			Effect.annotateLogs({
+				proposalsFound: proposals.length,
+				spaces: bySpace.size,
+				ageCutoffTimestamp: nowSeconds - MAX_PROPOSAL_AGE,
+			}),
+		)
+
+		if (proposals.length === 0) {
+			return {succeeded: 0, failed: 0, skipped: 0, total: 0, spaces: 0}
+		}
+
+		// Parallel across spaces (capped at 10 concurrent RPC connections), sequential
+		// within each space. Each space is independent — an InfraError in one space
+		// doesn't affect others.
+		const results = yield* Effect.forEach(
+			[...bySpace.entries()],
+			([spaceId, spaceProposals]) =>
+				executeSpaceProposals(
+					spaceId,
+					spaceProposals,
+					wallet,
+					config.executorSpaceId,
+					config.spaceRegistryAddress,
+				).pipe(
+					Effect.map(
+						(outcomes) =>
+							({
+								status: "ok" as const,
+								spaceId,
+								succeeded: outcomes.filter((r) => r !== "skipped").length,
+								skipped: outcomes.filter((r) => r === "skipped").length,
+							}) as const,
+					),
+					// Catch InfraError at the space level so one space failing
+					// doesn't cancel the others
+					Effect.catchTag("InfraError", (e) =>
+						Effect.logError("space_aborted").pipe(
+							Effect.annotateLogs({spaceId, error: e.message, proposalId: e.proposalId}),
+							Effect.as({status: "infraError" as const, spaceId, succeeded: 0, skipped: 0} as const),
+						),
 					),
 				),
+			{concurrency: 10},
+		)
+
+		return {
+			succeeded: results.reduce((n, r) => n + r.succeeded, 0),
+			failed: results.filter((r) => r.status === "infraError").length,
+			skipped: results.reduce((n, r) => n + r.skipped, 0),
+			total: proposals.length,
+			spaces: bySpace.size,
+		}
+	}).pipe(
+		Effect.catchTag("InfraError", (e) =>
+			Effect.logError("execute_path_failed").pipe(
+				Effect.annotateLogs({error: e.message, proposalId: e.proposalId}),
+				Effect.as({succeeded: 0, failed: 1, skipped: 0, total: 0, spaces: 0}),
 			),
-		{concurrency: 10},
+		),
 	)
 
-	const succeeded = results.reduce((n, r) => n + r.succeeded, 0)
-	const failed = results.filter((r) => r.status === "infraError").length
-	const skipped = results.reduce((n, r) => n + r.skipped, 0)
+	// --- Membership-accept path (bot wallet) — total: a detection-query failure is
+	// caught here so it never aborts the execute path. Per-space infra failures are
+	// caught at the space boundary; reverts are absorbed per request. Kill switch: an
+	// empty allowlist short-circuits findMembershipRequests to [] (no query). ---
+	const runMembershipPath: Effect.Effect<MembershipSummary> = Effect.gen(function* () {
+		const allowlistUuids = config.membershipAutoacceptSpaceIds.map(bytes16ToUuid)
+		const requests = yield* findMembershipRequests(db, allowlistUuids)
+		const bySpace = Map.groupBy(requests, (r) => r.spaceId)
+
+		yield* Effect.logInfo("membership_start").pipe(
+			Effect.annotateLogs({
+				allowlistSize: allowlistUuids.length,
+				requestsFound: requests.length,
+				spaces: bySpace.size,
+			}),
+		)
+
+		if (requests.length === 0) {
+			return {admitted: 0, skipped: 0, failed: 0, total: 0, spaces: 0}
+		}
+
+		// Read chain time once and reuse across the batch — the voting-window check
+		// compares against block.timestamp, not the pod wall clock.
+		const chainNow = yield* readChainTimeSeconds(botWallet)
+
+		const results: MembershipSpaceResult[] = yield* Effect.forEach(
+			[...bySpace.entries()],
+			([spaceId, spaceRequests]) =>
+				processSpaceMembership(
+					botWallet,
+					spaceId,
+					spaceRequests,
+					config.membershipBotSpaceId,
+					config.spaceRegistryAddress,
+					chainNow,
+				).pipe(
+					Effect.map((outcomes) => ({status: "ok" as const, spaceId, outcomes})),
+					// Catch InfraError at the space level so one space failing
+					// doesn't cancel the others.
+					Effect.catchTag("InfraError", (e) =>
+						Effect.logError("membership_space_aborted").pipe(
+							Effect.annotateLogs({spaceId, error: e.message, proposalId: e.proposalId}),
+							Effect.as({status: "infraError" as const, spaceId, outcomes: []}),
+						),
+					),
+				),
+			{concurrency: 10},
+		)
+
+		const {admitted, skipped, failed} = aggregateMembership(results)
+		return {admitted, skipped, failed, total: requests.length, spaces: bySpace.size}
+	}).pipe(
+		Effect.catchTag("InfraError", (e) =>
+			Effect.logError("membership_path_failed").pipe(
+				Effect.annotateLogs({error: e.message, proposalId: e.proposalId}),
+				Effect.as({admitted: 0, skipped: 0, failed: 1, total: 0, spaces: 0}),
+			),
+		),
+	)
+
+	// Run both paths concurrently — distinct wallets, isolated error boundaries. Each
+	// is total, so Effect.all cannot interrupt one when the other settles.
+	const [exec, membership] = yield* Effect.all([runExecutePath, runMembershipPath], {concurrency: 2})
 
 	yield* Effect.logInfo("run_end").pipe(
 		Effect.annotateLogs({
-			succeeded,
-			failed,
-			skipped,
-			total: proposals.length,
-			spaces: bySpace.size,
+			succeeded: exec.succeeded,
+			failed: exec.failed,
+			skipped: exec.skipped,
+			total: exec.total,
+			spaces: exec.spaces,
+			membershipAdmitted: membership.admitted,
+			membershipSkipped: membership.skipped,
+			membershipFailed: membership.failed,
+			membershipTotal: membership.total,
+			membershipSpaces: membership.spaces,
 			durationMs: Date.now() - runStart,
 		}),
 	)
 
-	return {succeeded, failed}
+	// Fold membership outcomes into the same succeeded/failed semantics the exit code
+	// uses: an admitted request counts as a success, an aborted space as a failure.
+	// Partial success (anything admitted/executed) → exit 0.
+	return {
+		succeeded: exec.succeeded + membership.admitted,
+		failed: exec.failed + membership.failed,
+	}
 }).pipe(
 	Effect.scoped,
 	// 270s top-level timeout — leaves 20s margin before K8s SIGKILL at 290s,

--- a/proposal-executor/src/index.ts
+++ b/proposal-executor/src/index.ts
@@ -700,7 +700,22 @@ const main = Effect.gen(function* () {
 	// empty allowlist short-circuits findMembershipRequests to [] (no query). ---
 	const runMembershipPath: Effect.Effect<MembershipSummary> = Effect.gen(function* () {
 		const allowlistUuids = config.membershipAutoacceptSpaceIds.map(bytes16ToUuid)
-		const requests = yield* findMembershipRequests(db, allowlistUuids)
+
+		// Kill switch: an empty allowlist does no work at all — no chain read, no query.
+		if (allowlistUuids.length === 0) {
+			yield* Effect.logInfo("membership_start").pipe(
+				Effect.annotateLogs({allowlistSize: 0, requestsFound: 0, spaces: 0}),
+			)
+			return {admitted: 0, skipped: 0, failed: 0, total: 0, spaces: 0}
+		}
+
+		// Read chain time once, BEFORE detection, and reuse it for both stages. Stage-1
+		// detection and stage-2 eligibility must share one notion of "now" and the same
+		// +CLOCK_SKEW_BUFFER window, or a request can land where stage 2 would vote but
+		// stage 1 never surfaces it (the pod wall clock can drift from block.timestamp).
+		const chainNow = yield* readChainTimeSeconds(botWallet)
+
+		const requests = yield* findMembershipRequests(db, allowlistUuids, Number(chainNow))
 		const bySpace = Map.groupBy(requests, (r) => r.spaceId)
 
 		yield* Effect.logInfo("membership_start").pipe(
@@ -714,10 +729,6 @@ const main = Effect.gen(function* () {
 		if (requests.length === 0) {
 			return {admitted: 0, skipped: 0, failed: 0, total: 0, spaces: 0}
 		}
-
-		// Read chain time once and reuse across the batch — the voting-window check
-		// compares against block.timestamp, not the pod wall clock.
-		const chainNow = yield* readChainTimeSeconds(botWallet)
 
 		const results: MembershipSpaceResult[] = yield* Effect.forEach(
 			[...bySpace.entries()],

--- a/proposal-executor/src/index.ts
+++ b/proposal-executor/src/index.ts
@@ -454,6 +454,27 @@ function readTallyWithRetry(
 }
 
 /**
+ * Resolve a space's DAOSpace address (stage-2 prerequisite) with the same per-attempt
+ * timeout + InfraError retry as the other membership RPC reads. The timeout guards
+ * against a hung lookup that never rejects — without it a single stuck call would block
+ * the fiber until the global 270s run timeout, stalling every other space.
+ */
+function resolveDaoSpaceAddressWithRetry(
+	wallet: SmartWallet,
+	spaceRegistryAddress: Address,
+	daoSpaceId: Hex,
+): Effect.Effect<Address, InfraError> {
+	return resolveDaoSpaceAddress(wallet, spaceRegistryAddress, daoSpaceId).pipe(
+		Effect.timeoutFail({
+			duration: Duration.seconds(30),
+			onTimeout: () =>
+				new InfraError({message: "DAO space address resolution timed out after 30s", durationMs: 30_000}),
+		}),
+		Effect.retry({schedule: infraRetryPolicy, while: (e) => e._tag === "InfraError"}),
+	)
+}
+
+/**
  * Process one membership request: stage-2 on-chain read → eligibility gate → vote.
  * A RevertError is caught and turned into a `reverted` outcome (logged, not fatal) so
  * it never aborts the rest of the space. An InfraError propagates to abort this space
@@ -528,8 +549,7 @@ export function processSpaceMembership(
 	spaceRegistryAddress: Address,
 	nowSeconds: bigint,
 ): Effect.Effect<MembershipOutcome[], InfraError> {
-	return resolveDaoSpaceAddress(wallet, spaceRegistryAddress, uuidToBytes16(spaceId)).pipe(
-		Effect.retry({schedule: infraRetryPolicy, while: (e) => e._tag === "InfraError"}),
+	return resolveDaoSpaceAddressWithRetry(wallet, spaceRegistryAddress, uuidToBytes16(spaceId)).pipe(
 		Effect.flatMap((daoSpaceAddress) =>
 			Effect.forEach(
 				requests,

--- a/proposal-executor/tests/detect.test.ts
+++ b/proposal-executor/tests/detect.test.ts
@@ -136,10 +136,12 @@ describe("membership detection SQL", () => {
 		expect(membershipSql).not.toContain("MAX_PROPOSAL_AGE")
 	})
 
-	test("excludes proposals whose voting period has ended", () => {
+	test("excludes proposals whose voting period has ended, with the stage-2 skew buffer", () => {
 		// Votes cast after end_time are rejected by the protocol, and an untouched
-		// Fast proposal past its period is already classified REJECTED.
-		expect(membershipSql).toContain("$2::bigint <= p.end_time")
+		// Fast proposal past its period is already classified REJECTED. The +60s buffer
+		// mirrors stage-2's isVotingOpen so detection never excludes a request the
+		// on-chain eligibility check would still vote on.
+		expect(membershipSql).toContain("$2::bigint <= p.end_time + 60")
 	})
 })
 
@@ -158,7 +160,7 @@ describe("findMembershipRequests", () => {
 			},
 		} as never
 
-		const result = await Effect.runPromise(findMembershipRequests(fakeClient, []))
+		const result = await Effect.runPromise(findMembershipRequests(fakeClient, [], 1_700_000_000))
 		expect(result).toEqual([])
 		expect(queried).toBe(false)
 	})
@@ -174,8 +176,9 @@ describe("findMembershipRequests", () => {
 			},
 		} as never
 
-		await Effect.runPromise(findMembershipRequests(fakeClient, allowlist))
+		await Effect.runPromise(findMembershipRequests(fakeClient, allowlist, 1_700_000_000))
 		expect(boundParams[0]).toEqual(allowlist)
-		expect(typeof boundParams[1]).toBe("number") // nowSeconds guard
+		// nowSeconds is the caller-supplied (chain-sourced) timestamp, bound verbatim.
+		expect(boundParams[1]).toBe(1_700_000_000)
 	})
 })

--- a/proposal-executor/tests/index.test.ts
+++ b/proposal-executor/tests/index.test.ts
@@ -562,7 +562,7 @@ describe("kill switch", () => {
 			},
 			// biome-ignore lint/suspicious/noExplicitAny: minimal pg.Client stub
 		} as any
-		const rows = await Effect.runPromise(findMembershipRequests(fakeClient, []))
+		const rows = await Effect.runPromise(findMembershipRequests(fakeClient, [], 1_700_000_000))
 		expect(rows).toEqual([])
 		expect(queried).toBe(false)
 	})

--- a/proposal-executor/tests/index.test.ts
+++ b/proposal-executor/tests/index.test.ts
@@ -7,8 +7,20 @@
 
 import {describe, expect, test} from "bun:test"
 import {Cause, ConfigProvider, Effect, Exit, Option} from "effect"
+import type {Address, Hex} from "viem"
 import {InfraError, RevertError} from "../src/contracts.js"
-import {type ExecutorEnv, parseConfig} from "../src/index.js"
+import {findMembershipRequests, type MembershipRequest} from "../src/detect.js"
+import {type SmartWallet, uuidToBytes16} from "../src/execute.js"
+import {
+	aggregateMembership,
+	bytes16ToUuid,
+	classifyMembershipSkip,
+	type ExecutorEnv,
+	parseConfig,
+	processMembershipRequest,
+	processSpaceMembership,
+} from "../src/index.js"
+import type {ProposalTally} from "../src/membership.js"
 
 // ---------------------------------------------------------------------------
 // Tagged error construction
@@ -323,5 +335,241 @@ describe("parseConfig: membership-bot config & allowlist", () => {
 			await runParse({MEMBERSHIP_AUTOACCEPT_SPACE_IDS: `  ${ALLOW_A} , ${ALLOW_A_UPPER} ,${ALLOW_B}, `}),
 		)
 		expect(env.membershipAutoacceptSpaceIds).toEqual([ALLOW_A, ALLOW_B])
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Membership-accept orchestration
+// ---------------------------------------------------------------------------
+
+const DAO_ADDRESS: Address = "0x00000000000000000000000000000000000000aa"
+const REGISTRY_ADDRESS: Address = "0x1111111111111111111111111111111111111111"
+const BOT_SPACE: Hex = `0x${"b".repeat(32)}`
+
+const REQUEST_A: MembershipRequest = {
+	id: "550e8400-e29b-41d4-a716-446655440000",
+	spaceId: "11111111-1111-1111-1111-111111111111",
+	requesterId: "22222222-2222-2222-2222-222222222222",
+}
+const REQUEST_B: MembershipRequest = {
+	id: "660e8400-e29b-41d4-a716-446655440001",
+	spaceId: "11111111-1111-1111-1111-111111111111",
+	requesterId: "33333333-3333-3333-3333-333333333333",
+}
+
+/** A fully-eligible tally: not executed, zero votes, voting window wide open. */
+function makeTally(overrides: Partial<ProposalTally> = {}): ProposalTally {
+	return {executed: false, yes: 0n, no: 0n, abstain: 0n, startDate: 0n, lastDate: 10_000_000_000n, ...overrides}
+}
+
+interface FakeWalletOpts {
+	tally?: ProposalTally
+	daoAddress?: Address
+	/** Receives the 1-based send-transaction call index; throw to simulate a revert/infra error. */
+	sendTransaction?: (callIndex: number) => Promise<string>
+}
+
+interface FakeWallet {
+	wallet: SmartWallet
+	calls: {readContract: string[]; sendTransaction: number}
+}
+
+/**
+ * A minimal SmartWallet stub that lets the real orchestration run without infra:
+ * `readContract` dispatches on functionName (spaceIdToAddress / getLatestProposalInformation)
+ * and `sendTransaction` is scriptable per call. Records call counts for assertions.
+ */
+function makeFakeWallet(opts: FakeWalletOpts = {}): FakeWallet {
+	const tally = opts.tally ?? makeTally()
+	const calls = {readContract: [] as string[], sendTransaction: 0}
+	const wallet = {
+		chain: {id: 80451},
+		safeAddress: "0x0000000000000000000000000000000000000001",
+		publicClient: {
+			// biome-ignore lint/suspicious/noExplicitAny: minimal stub
+			readContract: async ({functionName}: any) => {
+				calls.readContract.push(functionName)
+				if (functionName === "spaceIdToAddress") return opts.daoAddress ?? DAO_ADDRESS
+				if (functionName === "getLatestProposalInformation") {
+					return [
+						tally.executed,
+						`0x${"0".repeat(32)}`,
+						{startDate: tally.startDate, lastDate: tally.lastDate},
+						{yes: tally.yes, no: tally.no, abstain: tally.abstain},
+						[],
+					]
+				}
+				throw new Error(`unexpected readContract: ${functionName}`)
+			},
+			getBlock: async () => ({timestamp: 1000n}),
+		},
+		smartAccountClient: {
+			account: {address: "0x0000000000000000000000000000000000000002"},
+			sendTransaction: async () => {
+				calls.sendTransaction += 1
+				if (opts.sendTransaction) return opts.sendTransaction(calls.sendTransaction)
+				return "0xtxhash"
+			},
+		},
+	}
+	return {wallet: wallet as unknown as SmartWallet, calls}
+}
+
+/** Build a revert-classified error (viem-style name → classifyAsRevert true). */
+function makeRevert(reason: string): Error {
+	const err = new Error(`execution reverted: ${reason}`)
+	err.name = "ContractFunctionRevertedError"
+	return err
+}
+
+describe("bytes16ToUuid (allowlist conversion)", () => {
+	test("converts a bytes16 space ID to a dashed lower-cased UUID", () => {
+		expect(bytes16ToUuid("0x550e8400e29b41d4a716446655440000")).toBe("550e8400-e29b-41d4-a716-446655440000")
+	})
+
+	test("normalizes upper-cased hex to lower case (matches indexer storage)", () => {
+		expect(bytes16ToUuid("0x550E8400E29B41D4A716446655440000")).toBe("550e8400-e29b-41d4-a716-446655440000")
+	})
+
+	test("round-trips with uuidToBytes16", () => {
+		const uuid = "550e8400-e29b-41d4-a716-446655440000"
+		expect(bytes16ToUuid(uuidToBytes16(uuid))).toBe(uuid)
+	})
+
+	test("rejects a malformed bytes16", () => {
+		expect(() => bytes16ToUuid("0xdeadbeef" as Hex)).toThrow()
+	})
+
+	test("an empty allowlist maps to no UUIDs (kill switch)", () => {
+		const empty: Hex[] = []
+		expect(empty.map(bytes16ToUuid)).toEqual([])
+	})
+})
+
+describe("classifyMembershipSkip — stage-2 skip reasons", () => {
+	test("an eligible (untouched, open) tally yields null — the bot should vote", () => {
+		expect(classifyMembershipSkip(makeTally(), 1000n)).toBeNull()
+	})
+
+	test("a non-zero tally is skipped as onchain_tally_nonzero", () => {
+		expect(classifyMembershipSkip(makeTally({yes: 1n}), 1000n)).toBe("onchain_tally_nonzero")
+		expect(classifyMembershipSkip(makeTally({no: 1n}), 1000n)).toBe("onchain_tally_nonzero")
+		expect(classifyMembershipSkip(makeTally({abstain: 1n}), 1000n)).toBe("onchain_tally_nonzero")
+	})
+
+	test("an already-executed proposal is skipped as already_executed", () => {
+		expect(classifyMembershipSkip(makeTally({executed: true}), 1000n)).toBe("already_executed")
+	})
+
+	test("a closed voting window with a zero tally is skipped as voting_window_closed", () => {
+		// now=1000, lastDate=100 (+60s skew) → window closed, yet the tally is zero:
+		// the cause is expiry, not a recorded vote.
+		expect(classifyMembershipSkip(makeTally({lastDate: 100n}), 1000n)).toBe("voting_window_closed")
+	})
+})
+
+describe("processMembershipRequest", () => {
+	test("a fresh eligible request casts exactly one YES vote", async () => {
+		const {wallet, calls} = makeFakeWallet({tally: makeTally()})
+		const outcome = await Effect.runPromise(
+			processMembershipRequest(wallet, REQUEST_A, DAO_ADDRESS, BOT_SPACE, REGISTRY_ADDRESS, 1000n),
+		)
+		expect(outcome.status).toBe("voted")
+		expect(calls.sendTransaction).toBe(1)
+	})
+
+	test("a touched request is skipped without voting", async () => {
+		const {wallet, calls} = makeFakeWallet({tally: makeTally({yes: 1n})})
+		const outcome = await Effect.runPromise(
+			processMembershipRequest(wallet, REQUEST_A, DAO_ADDRESS, BOT_SPACE, REGISTRY_ADDRESS, 1000n),
+		)
+		expect(outcome.status).toBe("skipped")
+		if (outcome.status === "skipped") expect(outcome.reason).toBe("onchain_tally_nonzero")
+		expect(calls.sendTransaction).toBe(0)
+	})
+
+	test("a revert is absorbed into a 'reverted' outcome (not a failure)", async () => {
+		const {wallet} = makeFakeWallet({
+			tally: makeTally(),
+			sendTransaction: () => Promise.reject(makeRevert("CanNotVote")),
+		})
+		const outcome = await Effect.runPromise(
+			processMembershipRequest(wallet, REQUEST_A, DAO_ADDRESS, BOT_SPACE, REGISTRY_ADDRESS, 1000n),
+		)
+		expect(outcome.status).toBe("reverted")
+	})
+})
+
+describe("processSpaceMembership — revert isolation", () => {
+	test("a RevertError on one request does not abort processing of others", async () => {
+		// First request reverts (CanNotVote), second votes successfully.
+		const {wallet, calls} = makeFakeWallet({
+			tally: makeTally(),
+			sendTransaction: (callIndex) =>
+				callIndex === 1 ? Promise.reject(makeRevert("CanNotVote")) : Promise.resolve("0xok"),
+		})
+		const outcomes = await Effect.runPromise(
+			processSpaceMembership(
+				wallet,
+				REQUEST_A.spaceId,
+				[REQUEST_A, REQUEST_B],
+				BOT_SPACE,
+				REGISTRY_ADDRESS,
+				1000n,
+			),
+		)
+		expect(outcomes.length).toBe(2)
+		expect(outcomes[0]?.status).toBe("reverted")
+		expect(outcomes[1]?.status).toBe("voted")
+		// Two vote attempts; the DAO address was resolved once for the space.
+		expect(calls.sendTransaction).toBe(2)
+		expect(calls.readContract.filter((fn) => fn === "spaceIdToAddress").length).toBe(1)
+	})
+})
+
+describe("aggregateMembership — run_end counts", () => {
+	test("counts votes as admitted, skips/reverts as skipped, infra spaces as failed", () => {
+		const results = [
+			{
+				status: "ok" as const,
+				spaceId: "s1",
+				outcomes: [
+					{status: "voted" as const, txHash: "0x1"},
+					{status: "skipped" as const, reason: "onchain_tally_nonzero" as const},
+				],
+			},
+			{status: "ok" as const, spaceId: "s2", outcomes: [{status: "reverted" as const, expected: true}]},
+			{status: "infraError" as const, spaceId: "s3", outcomes: []},
+		]
+		expect(aggregateMembership(results)).toEqual({admitted: 1, skipped: 2, failed: 1})
+	})
+
+	test("an empty run aggregates to all-zero", () => {
+		expect(aggregateMembership([])).toEqual({admitted: 0, skipped: 0, failed: 0})
+	})
+})
+
+describe("kill switch", () => {
+	// Mirrors the exit-code formula: process.exit(failed > 0 && succeeded === 0 ? 1 : 0)
+	const computeExitCode = (succeeded: number, failed: number) => (failed > 0 && succeeded === 0 ? 1 : 0)
+
+	test("an empty allowlist issues no detection query", async () => {
+		let queried = false
+		const fakeClient = {
+			query: async () => {
+				queried = true
+				return {rows: []}
+			},
+			// biome-ignore lint/suspicious/noExplicitAny: minimal pg.Client stub
+		} as any
+		const rows = await Effect.runPromise(findMembershipRequests(fakeClient, []))
+		expect(rows).toEqual([])
+		expect(queried).toBe(false)
+	})
+
+	test("with nothing admitted, membership contributes exit 0", () => {
+		const agg = aggregateMembership([])
+		expect(agg.admitted).toBe(0)
+		expect(computeExitCode(agg.admitted, agg.failed)).toBe(0)
 	})
 })


### PR DESCRIPTION
Orchestrate the membership-accept path alongside the execute path as an independent, isolated Effect: detect untouched request-to-join proposals in allowlisted spaces, read the authoritative on-chain tally (stage 2), and cast a single YES vote from the dedicated bot wallet when still eligible. Reuses the executor's per-item timeout + InfraError retry and the parallel-across-spaces / sequential-within-space model.

- Combined run_end summary with membershipAdmitted/Skipped/Failed; exit code folds membership admits into succeeded/failed (partial success -> exit 0).
- Typed skip reasons distinguish already_executed, onchain_tally_nonzero, and voting_window_closed (a closed window does not imply a non-zero tally).
- membership_vote_cast / membership_skip telemetry + membership-vote span.
- Kill switch: empty allowlist short-circuits detection (no query, no votes).
- bytes16ToUuid converts the bytes16 allowlist to the indexer's dashed UUIDs.