### PR TITLE
fix(docker): pin Rust builds to the workspace Cargo.lock

### DIFF
--- a/atlas/Dockerfile
+++ b/atlas/Dockerfile
@@ -22,6 +22,11 @@ COPY hermes-substream ./hermes-substream
 COPY stream ./stream
 
 # Build from the crate directory (standalone, not as workspace member)
+# Pin dependency versions to the workspace lockfile. Without it every image
+# build re-resolves crates from scratch and drifts with crates.io (e.g.
+# sentry-types 0.46.2 vs time broke all Rust image builds, 2026-06-12).
+COPY Cargo.lock ./atlas/Cargo.lock
+
 WORKDIR /app/atlas
 RUN cargo build --release
 

--- a/hermes-ipfs-cache/Dockerfile
+++ b/hermes-ipfs-cache/Dockerfile
@@ -20,6 +20,11 @@ COPY stream ./stream
 COPY ipfs ./ipfs
 
 # Build from the crate directory (standalone, not as workspace member)
+# Pin dependency versions to the workspace lockfile. Without it every image
+# build re-resolves crates from scratch and drifts with crates.io (e.g.
+# sentry-types 0.46.2 vs time broke all Rust image builds, 2026-06-12).
+COPY Cargo.lock ./hermes-ipfs-cache/Cargo.lock
+
 WORKDIR /app/hermes-ipfs-cache
 RUN cargo build --release
 

--- a/hermes-pipeline/Dockerfile
+++ b/hermes-pipeline/Dockerfile
@@ -22,6 +22,11 @@ COPY hermes-substream ./hermes-substream
 COPY stream ./stream
 
 # Build from the crate directory (standalone, not as workspace member)
+# Pin dependency versions to the workspace lockfile. Without it every image
+# build re-resolves crates from scratch and drifts with crates.io (e.g.
+# sentry-types 0.46.2 vs time broke all Rust image builds, 2026-06-12).
+COPY Cargo.lock ./hermes-pipeline/Cargo.lock
+
 WORKDIR /app/hermes-pipeline
 RUN cargo build --release
 

--- a/kg-indexer/Dockerfile
+++ b/kg-indexer/Dockerfile
@@ -21,6 +21,11 @@ COPY sdk ./sdk
 COPY kg-indexer ./kg-indexer
 
 # Build from the crate directory (standalone, not as workspace member)
+# Pin dependency versions to the workspace lockfile. Without it every image
+# build re-resolves crates from scratch and drifts with crates.io (e.g.
+# sentry-types 0.46.2 vs time broke all Rust image builds, 2026-06-12).
+COPY Cargo.lock ./kg-indexer/Cargo.lock
+
 WORKDIR /app/kg-indexer
 ENV SQLX_OFFLINE=true
 RUN cargo build --release

--- a/scoring-service/topology-indexer/Dockerfile
+++ b/scoring-service/topology-indexer/Dockerfile
@@ -19,6 +19,11 @@ COPY hermes-kafka ./hermes-kafka
 COPY scoring-service/topology-indexer ./scoring-service/topology-indexer
 
 # Build from the crate directory (standalone, not as workspace member)
+# Pin dependency versions to the workspace lockfile. Without it every image
+# build re-resolves crates from scratch and drifts with crates.io (e.g.
+# sentry-types 0.46.2 vs time broke all Rust image builds, 2026-06-12).
+COPY Cargo.lock ./scoring-service/topology-indexer/Cargo.lock
+
 WORKDIR /app/scoring-service/topology-indexer
 ENV SQLX_OFFLINE=true
 RUN cargo build --release

--- a/scoring-service/vote-indexer/Dockerfile
+++ b/scoring-service/vote-indexer/Dockerfile
@@ -20,6 +20,11 @@ COPY sdk ./sdk
 COPY scoring-service/vote-indexer ./scoring-service/vote-indexer
 
 # Build from the crate directory (standalone, not as workspace member)
+# Pin dependency versions to the workspace lockfile. Without it every image
+# build re-resolves crates from scratch and drifts with crates.io (e.g.
+# sentry-types 0.46.2 vs time broke all Rust image builds, 2026-06-12).
+COPY Cargo.lock ./scoring-service/vote-indexer/Cargo.lock
+
 WORKDIR /app/scoring-service/vote-indexer
 ENV SQLX_OFFLINE=true
 RUN cargo build --release

--- a/search-indexer/Dockerfile
+++ b/search-indexer/Dockerfile
@@ -28,6 +28,11 @@ COPY sdk ./sdk
 # Build from the crate directory (standalone, not as workspace member)
 # Note: auto_index_creation feature is disabled by default (production-safe)
 # For local dev, pass --build-arg CARGO_FEATURES="--features search-indexer-repository/auto_index_creation"
+# Pin dependency versions to the workspace lockfile. Without it every image
+# build re-resolves crates from scratch and drifts with crates.io (e.g.
+# sentry-types 0.46.2 vs time broke all Rust image builds, 2026-06-12).
+COPY Cargo.lock ./search-indexer/Cargo.lock
+
 WORKDIR /app/search-indexer
 RUN cargo build --release ${CARGO_FEATURES}
 


### PR DESCRIPTION
## Problem

All 7 Rust image builds fail with `E0119: conflicting implementations` in `sentry-types 0.46.2` — reproduced both locally and on GitHub runners ([failed run](https://github.com/geobrowser/gaia/actions/runs/27422939898): 7/10 matrix jobs failed, only the bun/python images passed).

Root cause: the Rust Dockerfiles build crates **standalone** (copy member crates, no workspace manifest) and never copy `Cargo.lock` — so every uncached image build re-resolves dependencies from latest crates.io. The repo's lockfile pins the compiling pair (`sentry-types 0.46.1` / `time 0.3.46`), but the unpinned build pulls `sentry-types 0.46.2`, whose blanket `impl<T> From<T>` collides with the latest `time`. Nothing in our code changed — the ecosystem drifted underneath an unpinned build

## Fix

`COPY Cargo.lock ./<crate>/Cargo.lock` into each crate's build directory in all 7 Dockerfiles (hermes-pipeline, hermes-ipfs-cache, kg-indexer, atlas, search-indexer, vote-indexer, topology-indexer), so cargo resolves the workspace-pinned versions.

- Verified mechanism: replicating the standalone build layout with the lock present, `cargo metadata` resolves `sentry-types 0.46.1` / `time 0.3.46` (without it: 0.46.2 → E0119).
- No `--locked` flag on purpose: standalone sub-crate builds prune unused workspace entries from the lock, which `--locked` would reject. Plain resolution with the lock present keeps the pins that matter.
- Side benefit: image builds are now reproducible