### PR TITLE
fix(ci): robust tag-exists check in deploy-v2 workflow

### DIFF
--- a/.github/workflows/deploy-v2.yml
+++ b/.github/workflows/deploy-v2.yml
@@ -80,12 +80,22 @@ jobs:
 
       - name: Verify image tag exists in registry
         if: inputs.service != 'valkey'
+        env:
+          TAG: ${{ inputs.tag }}
+          SERVICE: ${{ inputs.service }}
         run: |
-          doctl registry repository list-tags ${{ inputs.service }} --format Tag --no-header | \
-            grep -qx "${{ inputs.tag }}" || {
-              echo "::error::Tag ${{ inputs.tag }} not found in $REGISTRY/${{ inputs.service }} — run the build workflow first."
-              exit 1
-            }
+          # Capture doctl output separately so a doctl failure is distinguishable
+          # from "tag not found", and compare whitespace-stripped exact strings
+          # (doctl's table writer can pad lines, which broke a plain grep -qx).
+          if ! tags=$(doctl registry repository list-tags "$SERVICE" --format Tag --no-header); then
+            echo "::error::doctl failed listing tags for $REGISTRY/$SERVICE — registry/auth problem, not a missing tag."
+            exit 1
+          fi
+          if ! echo "$tags" | awk -v t="$TAG" '{gsub(/[[:space:]]+/,"")} $0==t{found=1} END{exit !found}'; then
+            echo "::error::Tag $TAG not found in $REGISTRY/$SERVICE — run the build workflow first. Tags present:"
+            echo "$tags"
+            exit 1
+          fi
 
       - name: Ensure namespace exists
         run: kubectl apply -f kg-indexer/k8s/v2/namespace.yaml


### PR DESCRIPTION
## Problem

The deploy workflow's tag guard rejected a tag that demonstrably exists: [run 27426273403](https://github.com/geobrowser/gaia/actions/runs/27426273403) failed with `Tag f2792bbc... not found in registry.digitalocean.com/geo/hermes-ipfs-cache` while `doctl registry repository list-tags hermes-ipfs-cache` shows that exact tag (pushed 15:22, deploy ran 15:41 — not a race).

Cause: the step piped doctl output into `grep -qx` (whole-line regex match). doctl's table writer can pad lines with trailing whitespace, so the exact-line match misses real tags. Bonus defect (flagged by review on #227, now observed to matter): a doctl failure printed the same misleading "tag not found" error.

## Fix

- Capture doctl output separately → distinct `::error::` for doctl/auth failures vs missing tag
- Whitespace-stripped exact-string comparison via awk (no regex semantics)
- On mismatch, print the tags actually present (debuggability)
- Inputs passed via `env:` instead of inline template interpolation

Verified the matcher against padded/tabbed input locally (matches) and a missing tag (rejects).

After merge: refresh `staging` so the dispatch ref picks this up, then re-dispatch `deploy-v2.yml`. The copy on geobrowser `main` (from #743) should be synced with the same change.

Part of GEO-664.