### PR TITLE
feat(proposal-executor): add membership-bot env vars to deployment

### DIFF
--- a/proposal-executor/.env.example
+++ b/proposal-executor/.env.example
@@ -9,6 +9,10 @@ DATABASE_URL=postgresql://user:password@host:5432/dbname
 # Private key for the EOA that owns the Safe smart account (0x-prefixed, 66 chars)
 EXECUTOR_PRIVATE_KEY=0x...
 
+# Private key for the membership-bot wallet (0x-prefixed, 66 chars).
+# MUST be a distinct identity from EXECUTOR_PRIVATE_KEY — startup fails if they match.
+MEMBERSHIP_BOT_PRIVATE_KEY=0x...
+
 # Pimlico bundler/paymaster API key
 PIMLICO_API_KEY=pim_...
 
@@ -19,6 +23,14 @@ RPC_URL=https://...
 
 # Personal space ID of the executor (bytes16, 0x-prefixed — public on-chain data)
 EXECUTOR_SPACE_ID=0x...
+
+# Personal space ID of the membership bot (bytes16, 0x-prefixed).
+# MUST differ from EXECUTOR_SPACE_ID — startup fails if they match.
+MEMBERSHIP_BOT_SPACE_ID=0x...
+
+# Allowlisted DAO spaces for membership auto-accept (comma-separated bytes16).
+# Empty/unset = kill switch: the membership path runs no detection and casts no votes.
+MEMBERSHIP_AUTOACCEPT_SPACE_IDS=
 
 # Space Registry contract address (0x-prefixed)
 SPACE_REGISTRY_ADDRESS=0xB01683b2f0d38d43fcD4D9aAB980166988924132

--- a/proposal-executor/deployment/production/cronjob.yaml
+++ b/proposal-executor/deployment/production/cronjob.yaml
@@ -61,9 +61,22 @@ spec:
                     secretKeyRef:
                       name: proposal-executor-credentials
                       key: PIMLICO_API_KEY
+                # Membership-bot wallet — MUST be a distinct identity from the executor
+                - name: MEMBERSHIP_BOT_PRIVATE_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: proposal-executor-credentials
+                      key: MEMBERSHIP_BOT_PRIVATE_KEY
                 # Config (non-sensitive — plain values)
                 - name: EXECUTOR_SPACE_ID
                   value: "0xb64f2e2d69be2ddbb5e3c997cf8a7d15"
+                # Membership-bot personal space — MUST differ from EXECUTOR_SPACE_ID
+                - name: MEMBERSHIP_BOT_SPACE_ID
+                  value: ""
+                # Allowlisted DAO spaces for auto-accept (comma-separated bytes16).
+                # Empty string = kill switch: no detection, no votes.
+                - name: MEMBERSHIP_AUTOACCEPT_SPACE_IDS
+                  value: ""
                 - name: SPACE_REGISTRY_ADDRESS
                   value: "0xB01683b2f0d38d43fcD4D9aAB980166988924132"
                 - name: RPC_URL

--- a/proposal-executor/deployment/production/cronjob.yaml
+++ b/proposal-executor/deployment/production/cronjob.yaml
@@ -72,7 +72,7 @@ spec:
                   value: "0xb64f2e2d69be2ddbb5e3c997cf8a7d15"
                 # Membership-bot personal space — MUST differ from EXECUTOR_SPACE_ID
                 - name: MEMBERSHIP_BOT_SPACE_ID
-                  value: ""
+                  value: "0x24208422558b4ac801e24a71a889dfad"
                 # Allowlisted DAO spaces for auto-accept (comma-separated bytes16).
                 # Empty string = kill switch: no detection, no votes.
                 - name: MEMBERSHIP_AUTOACCEPT_SPACE_IDS

--- a/proposal-executor/deployment/production/secrets.yaml.example
+++ b/proposal-executor/deployment/production/secrets.yaml.example
@@ -5,6 +5,7 @@
 #   --namespace=knowledge \
 #   --from-literal=DATABASE_URL='postgresql://...' \
 #   --from-literal=EXECUTOR_PRIVATE_KEY='0x...' \
+#   --from-literal=MEMBERSHIP_BOT_PRIVATE_KEY='0x...' \
 #   --from-literal=PIMLICO_API_KEY='pim_...'
 
 apiVersion: v1
@@ -16,5 +17,7 @@ type: Opaque
 stringData:
   DATABASE_URL: "postgresql://readonly_user:password@host:5432/dbname"
   EXECUTOR_PRIVATE_KEY: "0x..."
+  # Membership-bot wallet key — MUST differ from EXECUTOR_PRIVATE_KEY
+  MEMBERSHIP_BOT_PRIVATE_KEY: "0x..."
   PIMLICO_API_KEY: "pim_..."
   RPC_URL: "https://..."

--- a/proposal-executor/deployment/production/secrets.yaml.example
+++ b/proposal-executor/deployment/production/secrets.yaml.example
@@ -6,7 +6,8 @@
 #   --from-literal=DATABASE_URL='postgresql://...' \
 #   --from-literal=EXECUTOR_PRIVATE_KEY='0x...' \
 #   --from-literal=MEMBERSHIP_BOT_PRIVATE_KEY='0x...' \
-#   --from-literal=PIMLICO_API_KEY='pim_...'
+#   --from-literal=PIMLICO_API_KEY='pim_...' \
+#   --from-literal=RPC_URL='https://...'
 
 apiVersion: v1
 kind: Secret

--- a/proposal-executor/deployment/staging/cronjob.yaml
+++ b/proposal-executor/deployment/staging/cronjob.yaml
@@ -66,9 +66,22 @@ spec:
                     secretKeyRef:
                       name: proposal-executor-credentials
                       key: PIMLICO_API_KEY
+                # Membership-bot wallet — MUST be a distinct identity from the executor
+                - name: MEMBERSHIP_BOT_PRIVATE_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: proposal-executor-credentials
+                      key: MEMBERSHIP_BOT_PRIVATE_KEY
                 # Config (non-sensitive — plain values)
                 - name: EXECUTOR_SPACE_ID
                   value: "0xb64f2e2d69be2ddbb5e3c997cf8a7d15"
+                # Membership-bot personal space — MUST differ from EXECUTOR_SPACE_ID
+                - name: MEMBERSHIP_BOT_SPACE_ID
+                  value: ""
+                # Allowlisted DAO spaces for auto-accept (comma-separated bytes16).
+                # Empty string = kill switch: no detection, no votes.
+                - name: MEMBERSHIP_AUTOACCEPT_SPACE_IDS
+                  value: ""
                 - name: SPACE_REGISTRY_ADDRESS
                   value: "0xB01683b2f0d38d43fcD4D9aAB980166988924132"
                 - name: RPC_URL

--- a/proposal-executor/deployment/staging/cronjob.yaml
+++ b/proposal-executor/deployment/staging/cronjob.yaml
@@ -77,7 +77,7 @@ spec:
                   value: "0xb64f2e2d69be2ddbb5e3c997cf8a7d15"
                 # Membership-bot personal space — MUST differ from EXECUTOR_SPACE_ID
                 - name: MEMBERSHIP_BOT_SPACE_ID
-                  value: ""
+                  value: "0x24208422558b4ac801e24a71a889dfad"
                 # Allowlisted DAO spaces for auto-accept (comma-separated bytes16).
                 # Empty string = kill switch: no detection, no votes.
                 - name: MEMBERSHIP_AUTOACCEPT_SPACE_IDS

--- a/proposal-executor/deployment/staging/secrets.yaml.example
+++ b/proposal-executor/deployment/staging/secrets.yaml.example
@@ -5,6 +5,7 @@
 #   --namespace=knowledge \
 #   --from-literal=DATABASE_URL='postgresql://...' \
 #   --from-literal=EXECUTOR_PRIVATE_KEY='0x...' \
+#   --from-literal=MEMBERSHIP_BOT_PRIVATE_KEY='0x...' \
 #   --from-literal=PIMLICO_API_KEY='pim_...'
 
 apiVersion: v1
@@ -16,5 +17,7 @@ type: Opaque
 stringData:
   DATABASE_URL: "postgresql://readonly_user:password@host:5432/dbname"
   EXECUTOR_PRIVATE_KEY: "0x..."
+  # Membership-bot wallet key — MUST differ from EXECUTOR_PRIVATE_KEY
+  MEMBERSHIP_BOT_PRIVATE_KEY: "0x..."
   PIMLICO_API_KEY: "pim_..."
   RPC_URL: "https://..."

--- a/proposal-executor/deployment/staging/secrets.yaml.example
+++ b/proposal-executor/deployment/staging/secrets.yaml.example
@@ -6,7 +6,8 @@
 #   --from-literal=DATABASE_URL='postgresql://...' \
 #   --from-literal=EXECUTOR_PRIVATE_KEY='0x...' \
 #   --from-literal=MEMBERSHIP_BOT_PRIVATE_KEY='0x...' \
-#   --from-literal=PIMLICO_API_KEY='pim_...'
+#   --from-literal=PIMLICO_API_KEY='pim_...' \
+#   --from-literal=RPC_URL='https://...'
 
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
Add MEMBERSHIP_BOT_PRIVATE_KEY (secretKeyRef), MEMBERSHIP_BOT_SPACE_ID, and MEMBERSHIP_AUTOACCEPT_SPACE_IDS to staging and production CronJobs, the secrets.yaml.example templates, and .env.example.

The allowlist and bot space default to empty (kill switch on), so this changes no runtime behavior until an allowlist is supplied.