### PR TITLE
fix(ci): match deploy tag against first column — runner doctl ignores --format

### DIFF
--- a/.github/workflows/deploy-v2.yml
+++ b/.github/workflows/deploy-v2.yml
@@ -85,13 +85,15 @@ jobs:
           SERVICE: ${{ inputs.service }}
         run: |
           # Capture doctl output separately so a doctl failure is distinguishable
-          # from "tag not found", and compare whitespace-stripped exact strings
-          # (doctl's table writer can pad lines, which broke a plain grep -qx).
-          if ! tags=$(doctl registry repository list-tags "$SERVICE" --format Tag --no-header); then
+          # from "tag not found". Match the tag against the FIRST column only:
+          # the runner's doctl ignores --format/--no-header and prints the full
+          # table, and a substring grep could false-positive on the hex digest
+          # column. First-field exact match works with either output format.
+          if ! tags=$(doctl registry repository list-tags "$SERVICE"); then
             echo "::error::doctl failed listing tags for $REGISTRY/$SERVICE — registry/auth problem, not a missing tag."
             exit 1
           fi
-          if ! echo "$tags" | awk -v t="$TAG" '{gsub(/[[:space:]]+/,"")} $0==t{found=1} END{exit !found}'; then
+          if ! echo "$tags" | awk -v t="$TAG" '$1==t{found=1} END{exit !found}'; then
             echo "::error::Tag $TAG not found in $REGISTRY/$SERVICE — run the build workflow first. Tags present:"
             echo "$tags"
             exit 1


### PR DESCRIPTION
## Problem

Follow-up to #231, which improved the error reporting but didn't fix the match: the deploy still rejected an existing tag ([run 27427003507](https://github.com/geobrowser/gaia/actions/runs/27427003507)). The run's tag dump revealed the actual root cause — **the runner's doctl ignores `--format Tag --no-header` and prints the full 4-column table** (header, Tag, Compressed Size, Updated At, Manifest Digest). Locally doctl honors the flags, which is why the same command behaves differently on the runner. Any whole-line comparison (the original `grep -qx` and #231's whitespace-stripped match) can never match a line like `f2792bbc    40.57 MB    2026-06-12 ...`.

## Fix

Compare the tag against the **first field only**: `awk '$1==t{found=1} END{exit !found}'`.

- Works with both output formats (full table on the runner, plain column locally)
- The header line (`Tag ...`) can't match a real tag
- Unlike a substring `grep`, it cannot false-positive on the hex **Manifest Digest** column — relevant for short 8-char tags, which are valid hex substrings

## Verified locally

Matcher tested against: (1) the exact table output from the failing run → matches; (2) plain single-column output → matches; (3) a digest containing the tag as substring with no matching first field → correctly rejects.

After merge: cherry-pick/refresh onto `staging` so the dispatch ref picks it up, then re-dispatch `deploy-v2.yml`. The `main` copy on geobrowser (#743) should get the same sync.

Part of GEO-664.