### PR TITLE
feat(notification-indexer): add editor/member name to add_editor & add_member notifications

### DIFF
--- a/notification-service/WEBHOOK_INTEGRATION.md
+++ b/notification-service/WEBHOOK_INTEGRATION.md
@@ -89,7 +89,8 @@ A new proposal was created in the space.
   "actions": [
     {
       "type": "add_member",
-      "target_address": "0x1234..."
+      "target_address": "0x1234...",
+      "target_name": "Alice"
     }
   ],
   "settings": {
@@ -300,11 +301,15 @@ Same structure as `bounty_allocated`.
 
 | Action type | Fields | Description |
 |---|---|---|
-| `add_member` | `target_address` | Add a member to the space |
+| `add_member` | `target_address`, `target_name`? | Add a member to the space |
 | `remove_member` | `target_address` | Remove a member |
-| `add_editor` | `target_address` | Add an editor |
+| `add_editor` | `target_address`, `target_name`? | Add an editor |
 | `remove_editor` | `target_address` | Remove an editor |
 | `unflag_editor` | `target_address` | Unflag a flagged editor |
+
+`target_name` is the added user's display name, resolved best-effort from their
+personal space. It is present only for `add_member` / `add_editor` and omitted
+when the user has no personal space or name.
 
 **Content actions:**
 

--- a/notification-service/notification-indexer/src/main.rs
+++ b/notification-service/notification-indexer/src/main.rs
@@ -1373,6 +1373,19 @@ async fn enrich_payload(
                 }
             }
 
+            // Target display name for add_editor / add_member actions — resolve the
+            // added user's name from their wallet address (best-effort).
+            if let Some(actions) = gov.actions.as_mut() {
+                for action in actions.iter_mut() {
+                    if action.action_type != "add_editor" && action.action_type != "add_member" {
+                        continue;
+                    }
+                    if let Some(address) = action.target_address.clone() {
+                        action.target_name = storage.lookup_name_by_address(&address).await;
+                    }
+                }
+            }
+
             // Vote tallies (proposal_voted events only)
             if event.event_type == NotificationEventType::ProposalVoted {
                 if let Ok(pid) = uuid::Uuid::parse_str(&gov.proposal_id) {

--- a/notification-service/notification-indexer/src/models.rs
+++ b/notification-service/notification-indexer/src/models.rs
@@ -208,6 +208,12 @@ pub struct ActionSummary {
     /// Target address (hex-encoded, for member/editor actions).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub target_address: Option<String>,
+    /// Human-readable display name of the target user (best-effort, from the KG
+    /// values table via their personal space). Currently resolved for
+    /// `add_editor` / `add_member` actions; `None` if the user has no personal
+    /// space or no name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_name: Option<String>,
     /// Target space ID (for subspace actions).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub target_space_id: Option<String>,
@@ -2338,6 +2344,38 @@ mod tests {
         let json = serde_json::to_value(&event.payload).expect("should serialize");
         assert!(json.get("bounty_name").is_none());
         assert!(json.get("curator_name").is_none());
+    }
+
+    #[test]
+    fn test_action_summary_target_name_serialization() {
+        // Omitted when unset (the default after action_to_summary; enrichment is DB-side).
+        let unset = ActionSummary {
+            action_type: "add_editor".to_string(),
+            target_address: Some("0xabc".to_string()),
+            ..ActionSummary::default()
+        };
+        let json = serde_json::to_value(&unset).expect("should serialize");
+        assert_eq!(
+            json.get("type").and_then(|v| v.as_str()),
+            Some("add_editor")
+        );
+        assert!(
+            json.get("target_name").is_none(),
+            "target_name must be omitted when None"
+        );
+
+        // Serialized when the enrichment resolved a name.
+        let enriched = ActionSummary {
+            action_type: "add_member".to_string(),
+            target_address: Some("0xabc".to_string()),
+            target_name: Some("Alice".to_string()),
+            ..ActionSummary::default()
+        };
+        let json = serde_json::to_value(&enriched).expect("should serialize");
+        assert_eq!(
+            json.get("target_name").and_then(|v| v.as_str()),
+            Some("Alice")
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/notification-service/notification-indexer/src/storage.rs
+++ b/notification-service/notification-indexer/src/storage.rs
@@ -538,6 +538,41 @@ impl Storage {
         .flatten()
     }
 
+    /// Look up a user's display name from their wallet address (best-effort).
+    ///
+    /// Resolves the user's personal space by address (`spaces.address`, stored
+    /// `0x`-prefixed lowercase, `type = 'Personal'`) and returns that space
+    /// entity's NAME value — mirroring the API's `getProfileByAddress`. Used to
+    /// attach the editor/member name to `add_editor` / `add_member` proposal
+    /// notifications. Returns `None` if the address has no personal space, no
+    /// name, or the query fails.
+    pub async fn lookup_name_by_address(&self, address: &str) -> Option<String> {
+        // `target_address` is bare hex (no `0x`); `spaces.address` is `0x`-prefixed
+        // lowercase. Normalize so the comparison matches regardless of input form.
+        let hex = address.strip_prefix("0x").unwrap_or(address).to_lowercase();
+        let normalized = format!("0x{hex}");
+        sqlx::query_scalar::<_, String>(
+            r#"
+            SELECT v.text
+            FROM spaces s
+            JOIN "values" v
+              ON v.entity_id = s.id
+             AND v.space_id = s.id
+             AND v.property_id = $2
+             AND v.text IS NOT NULL
+            WHERE LOWER(s.address) = $1
+              AND s.type = 'Personal'
+            LIMIT 1
+            "#,
+        )
+        .bind(normalized)
+        .bind(ids::name_property())
+        .fetch_optional(&self.pool)
+        .await
+        .ok()
+        .flatten()
+    }
+
     /// Look up the human-readable name for a proposal from the proposals table.
     pub async fn lookup_proposal_name(&self, proposal_id: Uuid) -> Option<String> {
         sqlx::query_scalar::<_, String>(


### PR DESCRIPTION
## What

`add_editor` and `add_member` proposal notifications currently carry only the target's `target_address`. This adds a human-readable **`target_name`** — the added user's display name — so consumers (webhooks, UI) can show "Add Alice as editor" instead of a raw `0x…`.

## How

- **`models.rs`** — new `ActionSummary.target_name: Option<String>` (`skip_serializing_if = None`, so the payload shape is unchanged when there's no name).
- **`storage.rs`** — `lookup_name_by_address(address)`: resolves the user's personal space and its NAME, mirroring the API's `getProfileByAddress`:
  ```sql
  SELECT v.text FROM spaces s
  JOIN "values" v ON v.entity_id = s.id AND v.space_id = s.id
                 AND v.property_id = <name> AND v.text IS NOT NULL
  WHERE LOWER(s.address) = $1 AND s.type = 'Personal' LIMIT 1
  ```
  `target_address` is bare hex; `spaces.address` is `0x`-prefixed lowercase, so the address is normalized (`0x` + lowercase) before matching.
- **`main.rs`** — in the existing governance enrichment pass (next to `proposer_name`/`voter_name`), loop the actions and resolve `target_name` for `add_editor` / `add_member` only.
- **`WEBHOOK_INTEGRATION.md`** — documents the new field.

## Behavior / scope

- **Best-effort:** `target_name` is omitted when the address has no personal space or no NAME — never blocks or alters the notification. Same "best-effort from KG values" convention as the existing `bounty_name` / `curator_name` / `proposer_name` fields.
- Scoped to `add_editor` and `add_member` (per the ask); `remove_*` / `unflag_editor` are unchanged.
- Additive, backward-compatible payload change.

## Testing

- Added a serialization unit test (`test_action_summary_target_name_serialization`): omitted when `None`, present when set.
- `cargo fmt --check`, `cargo clippy -- -D warnings`, and the crate tests pass locally.
