### PR TITLE
docs(proposal-executor): document membership auto-accept path

### DIFF
--- a/proposal-executor/ARCHITECTURE.md
+++ b/proposal-executor/ARCHITECTURE.md
@@ -185,7 +185,10 @@ in two stages, indexer first then on-chain, to be both cheap and authoritative:
 
 1. **Stage 1 — indexer (`detect.ts`, `findMembershipRequests`).** A SQL `NOT EXISTS` against
    `proposal_votes` excludes any request that already has an indexed vote. Cheap, batched, but
-   subject to indexing lag. Skip reason: `indexed_vote`.
+   subject to indexing lag. This is a *filter* at detection time — excluded requests simply never
+   enter the membership loop, so **no per-request skip event is emitted** for them. (`indexed_vote`
+   exists in the `MembershipSkipReason` taxonomy for completeness but is never logged at runtime;
+   only stage-2 reasons appear in `membership_skip`.)
 2. **Stage 2 — on-chain (`membership.ts`, `readProposalTally`).** For each stage-1 survivor, read
    the live tally from the per-space DAOSpace contract via
    `getLatestProposalInformation(bytes16) → (executed, creator, parameters, tally, actions)`. The
@@ -269,7 +272,7 @@ does nothing.
 |---|---|---|
 | `wallet_ready` (`identity: membership-bot`) | INFO | Bot wallet built + verified. Check `safeAddress`. |
 | `membership_vote_cast` | INFO | YES vote submitted. `{proposalId, spaceId, targetId, txHash}`. |
-| `membership_skip` | INFO | Ineligible at stage 2. `reason` ∈ {`already_executed`, `onchain_tally_nonzero`, `voting_window_closed`}. (`indexed_vote` skips happen at stage 1 and never reach stage 2.) |
+| `membership_skip` | INFO | Ineligible at stage 2. `reason` ∈ {`already_executed`, `onchain_tally_nonzero`, `voting_window_closed`}. (Stage-1 indexed-vote exclusions are filtered out at detection time and emit no event — `indexed_vote` is never logged.) |
 | `membership_skip_expected` | INFO | Expected revert at cast time (already executed / resolved). Not an error. |
 | `membership_vote_reverted` | INFO | Unexpected revert (e.g. bot lacks EDITOR → `CanNotVote`). Skipped, retried next cycle. |
 | `membership_path_failed` | ERROR | The membership path's own InfraError boundary tripped; the execute path is unaffected. |

--- a/proposal-executor/ARCHITECTURE.md
+++ b/proposal-executor/ARCHITECTURE.md
@@ -7,15 +7,17 @@
 ```
 proposal-executor/
 ├── src/
-│   ├── index.ts        # Effect orchestration, config parsing, entry point
-│   ├── detect.ts       # DB connection + detection SQL query
+│   ├── index.ts        # Effect orchestration, config parsing, entry point (both paths)
+│   ├── detect.ts       # DB connection + detection SQL (executable proposals + membership requests)
 │   ├── execute.ts      # Smart wallet, encoding helpers, on-chain execution
+│   ├── membership.ts   # Membership stage-2 on-chain read + PROPOSAL_VOTED (Yes) vote cast
 │   ├── contracts.ts    # ABI subset, chain defs, tagged errors, governance constants
 │   └── telemetry.ts    # OTel tracing + Sentry error tracking (adapted from api/)
 ├── tests/
-│   ├── detect.test.ts  # RATIO_BASE cross-validation, SQL structure, Proposal shape
-│   ├── execute.test.ts # Encoding correctness, constant validation, error classification
-│   └── index.test.ts   # Tagged error discrimination, exit code logic, concurrency model
+│   ├── detect.test.ts     # RATIO_BASE cross-validation, SQL structure, Proposal + MembershipRequest shape
+│   ├── execute.test.ts    # Encoding correctness, constant validation, error classification
+│   ├── membership.test.ts # Vote encoding (VoteOption=1), tally decoding, two-stage eligibility
+│   └── index.test.ts      # Tagged error discrimination, exit code logic, concurrency, dual-wallet config
 ├── deployment/         # Both environments deploy into the 'knowledge' namespace
 │   ├── staging/        # Testnet (chain 19411) manifests
 │   │   ├── cronjob.yaml
@@ -37,6 +39,8 @@ proposal-executor/
 - `db.ts` → folded into `detect.ts` (5 lines of `pg.Client` connect/query/end)
 
 Each file has enough substance (~30–100 lines) to justify its existence without artificial splitting.
+
+The membership-accept feature added a fifth source file, `membership.ts`, rather than folding into `execute.ts`. It is a distinct concern (vote cast + on-chain tally read, not slow-path execution) with its own substance (~330 lines), so it earns its own file by the same single-responsibility rule. It still *reuses* `execute.ts`'s smart-wallet factory, encoding helpers (`uuidToBytes16`, `padBytes16ToBytes32`), and `classifyAsRevert` — no duplication.
 
 ## Concurrency Model
 
@@ -141,6 +145,141 @@ The Safe smart account address is deterministic from the owner EOA. The same pri
 
 The testnet uses custom Safe deployment addresses (defined in `contracts.ts`, forked from `geo-cli/src/wallet.ts:54-61`). These are selected via `config.chainId === 19411`.
 
+## Membership Auto-Accept Path
+
+A second action path runs in the same CronJob alongside slow-path execution: it detects
+untouched **request-to-join** proposals in an explicit allowlist of spaces and casts a single
+**YES vote** on each. Because allowlisted spaces are configured with `fastPathFlatThreshold = 1`,
+that one YES vote meets the threshold and the DAOSpace contract executes the `AddMember` action in
+the *same* transaction — admitting the joiner with no human in the loop. There is no separate
+`PROPOSAL_EXECUTED` step for these.
+
+The two paths share the process, the cycle, and the DB connection, but **never share a wallet
+identity**. They run concurrently (`Effect.all`, concurrency 2) with isolated error boundaries —
+each path is total (catches its own failures), so a failure in one cannot abort or interrupt the
+other.
+
+### Dual-Wallet Identity Isolation
+
+The membership path acts under a **dedicated bot identity whose wallet is distinct from the
+slow-path executor wallet** — a separate private key (`MEMBERSHIP_BOT_PRIVATE_KEY`) and a separate
+registered personal space (`MEMBERSHIP_BOT_SPACE_ID`). This is a hard requirement, enforced at
+startup:
+
+- `parseConfig` fails fast with `InfraError` if `MEMBERSHIP_BOT_PRIVATE_KEY === EXECUTOR_PRIVATE_KEY`
+  or `MEMBERSHIP_BOT_SPACE_ID === EXECUTOR_SPACE_ID`.
+- Both wallets are built via the same `createSmartWallet` factory and each is verified every run
+  (`verifyExecutorSetup`), so a misconfigured bot fails fast. Two `wallet_ready` logs are emitted,
+  tagged `identity: "executor"` and `identity: "membership-bot"`.
+
+Why a separate identity: least privilege. The bot holds the **EDITOR** role in each allowlisted
+space (the authority a YES vote requires); the executor does not need and should not have it. The
+bot gets its own key, its own authority, its own kill switch, and its own blast radius — fully
+isolated from the executor. The executor wallet never casts a membership vote; the bot wallet never
+executes a slow-path proposal.
+
+### Two-Stage "Untouched" Eligibility
+
+The bot only votes on a request that **no one has touched** — no vote of any kind. This is checked
+in two stages, indexer first then on-chain, to be both cheap and authoritative:
+
+1. **Stage 1 — indexer (`detect.ts`, `findMembershipRequests`).** A SQL `NOT EXISTS` against
+   `proposal_votes` excludes any request that already has an indexed vote. Cheap, batched, but
+   subject to indexing lag. Skip reason: `indexed_vote`.
+2. **Stage 2 — on-chain (`membership.ts`, `readProposalTally`).** For each stage-1 survivor, read
+   the live tally from the per-space DAOSpace contract via
+   `getLatestProposalInformation(bytes16) → (executed, creator, parameters, tally, actions)`. The
+   request is eligible to vote **iff** `!executed && yes == 0 && no == 0 && abstain == 0` **and**
+   the voting window is still open. This RPC read closes the indexing-lag window left by stage 1.
+
+Reading the authoritative on-chain tally is also what makes the job **idempotent** across cycles:
+the moment the bot votes, its own vote is in the on-chain `Tally` — even before the indexer surfaces
+it — so the next cycle reads `yes >= 1` and skips. No duplicate vote, no shared mutable state, no
+tracking column. (This is the membership-path analogue of the executor's "let it revert" stance,
+but here the duplicate is prevented *before* submission rather than absorbed as a free revert.)
+
+`classifyMembershipSkip` maps an ineligible tally to one of three stage-2 reasons, in priority
+order, so telemetry says *why* nothing was done:
+
+| Reason | Condition | Meaning |
+|---|---|---|
+| `already_executed` | `executed == true` | Request already resolved (admitted or otherwise). |
+| `onchain_tally_nonzero` | any of `yes/no/abstain != 0` | A vote is already recorded (human's, or the bot's own prior vote → idempotency). |
+| `voting_window_closed` | window closed | Voting period ended; the protocol would reject the vote. |
+
+### Voting-Window Guard (Clock Skew)
+
+`getLatestProposalInformation` also returns `ProposalParameters.startDate` / `lastDate`. The
+protocol rejects a vote whose `block.timestamp` falls outside `[startDate, lastDate]`, so stage-2
+eligibility honours the window (`isVotingOpen`). Two deliberate choices:
+
+- **Chain time, not wall clock.** The check compares against the latest block's timestamp
+  (`readChainTimeSeconds`, read once per run), the same clock the contract enforces — not the pod's
+  wall clock, which can drift. On an RPC hiccup it falls back to the pod clock rather than failing
+  the batch; the skew buffer absorbs the drift.
+- **The close is widened, not narrowed** (`CLOCK_SKEW_BUFFER_SECONDS = 60`, mirroring the detection
+  query). During the final 60s — and up to 60s past `lastDate` — the bot still votes, accepting a
+  possible at-most-60s-late revert over wrongly skipping a still-open request. Missing a genuinely
+  open request is worse than a free, sponsored late revert.
+
+### Vote Cast Encoding
+
+The vote reuses the executor's gas-sponsored `enter()` UserOperation pattern. The deployed
+SpaceRegistry ABI takes `bytes16` space IDs:
+
+```
+enter(
+  botSpaceId,                                 // bytes16  _fromSpaceId (MEMBERSHIP_BOT_SPACE_ID)
+  uuidToBytes16(request.spaceId),             // bytes16  _toSpaceId   (DAO space being joined)
+  PROPOSAL_VOTED,                             // bytes32  0x4ebf5f29...d5819e
+  padBytes16ToBytes32(uuidToBytes16(id)),     // bytes32  topic = bytes32(proposalId), left-aligned
+  encodeVoteData(uuidToBytes16(id), VOTE_YES),// bytes    abi.encode(bytes16 proposalId, uint8 1)
+  "0x"                                        // bytes    _signature (ignored; msg.sender == _fromSpace)
+)
+```
+
+**`VoteOption.Yes = 1`** — from the deployed `IDAOSpace` interface
+(`enum VoteOption { None=0, Yes=1, No=2, Abstain=3 }`). A unit test asserts `VOTE_YES === 1` to
+guard this value, because `docs/protocol/dao-space.md` previously documented the enum incorrectly
+(now corrected). The DAOSpace tally getters live on the **per-space** contract, not the
+SpaceRegistry, so the address is resolved first via `SpaceRegistry.spaceIdToAddress(daoSpaceId)`
+(a zero address ⇒ unregistered space ⇒ `InfraError`).
+
+### Request-to-Join Detection Signature
+
+A membership request, per stage-1 SQL, is a proposal that is **all** of: `Fast` voting mode; a
+single action; that action is `AddMember`; the action targets the proposer itself
+(`proposals.proposed_by = proposal_actions.target_id` — a *self*-request, not an editor adding
+someone); not executed; in an allowlisted space; and with no row in `proposal_votes` (stage-1
+untouched). There is **no creation-time cutoff** — a pre-existing backlog is admitted. When the
+allowlist is empty the query short-circuits to `[]` (kill switch — no DB query issued).
+
+### Kill Switch & Blast Radius
+
+`MEMBERSHIP_AUTOACCEPT_SPACE_IDS` is an explicit, auditable, comma-separated allowlist of bytes16
+space IDs (trimmed, de-duped). It is read **once at startup**; changes require a redeploy/restart.
+An empty or unset list is valid and means the membership path is a complete no-op — the feature
+ships "off" and is flipped on only when product supplies an allowlist. This is why PR-A…PR-E could
+merge to `main` without changing production behaviour: until the allowlist is populated, the path
+does nothing.
+
+### Membership Telemetry
+
+| Event / Span | Kind | Meaning |
+|---|---|---|
+| `wallet_ready` (`identity: membership-bot`) | INFO | Bot wallet built + verified. Check `safeAddress`. |
+| `membership_vote_cast` | INFO | YES vote submitted. `{proposalId, spaceId, targetId, txHash}`. |
+| `membership_skip` | INFO | Ineligible at stage 2. `reason` ∈ {`already_executed`, `onchain_tally_nonzero`, `voting_window_closed`}. (`indexed_vote` skips happen at stage 1 and never reach stage 2.) |
+| `membership_skip_expected` | INFO | Expected revert at cast time (already executed / resolved). Not an error. |
+| `membership_vote_reverted` | INFO | Unexpected revert (e.g. bot lacks EDITOR → `CanNotVote`). Skipped, retried next cycle. |
+| `membership_path_failed` | ERROR | The membership path's own InfraError boundary tripped; the execute path is unaffected. |
+| `proposal-executor.membership-vote` | span | Per-request vote attempt. |
+| `run_end` fields | INFO | `membershipAdmitted`, `membershipSkipped`, `membershipFailed`, `membershipTotal`, `membershipSpaces`. |
+
+Exit code: membership outcomes fold into the existing `succeeded`/`failed` semantics —
+`membershipAdmitted` adds to `succeeded`, an aborted membership space adds to `failed`. Partial
+success (anything admitted or executed) still exits `0`.
+
 ## Race Condition: Double Execution
 
 After the executor submits `enter(PROPOSAL_EXECUTED)` on-chain, the proposal's `executed_at` remains NULL until the kg-indexer processes the event (seconds to minutes). During this window, the next CronJob run re-detects and re-submits. The contract reverts ("already executed").
@@ -168,8 +307,11 @@ If revert noise becomes a problem at scale, the best future option is a local tr
 | `SPACE_REGISTRY_ADDRESS` | Valid Ethereum address (viem `getAddress()` checksum). |
 | `RPC_URL` | Non-empty, starts with `http://` or `https://`. |
 | `CHAIN_ID` | Must be `80451` or `19411` (exhaustive check). |
+| `MEMBERSHIP_BOT_PRIVATE_KEY` | 0x-prefixed, 64 hex chars (auto-prefix). **Must differ from `EXECUTOR_PRIVATE_KEY`.** |
+| `MEMBERSHIP_BOT_SPACE_ID` | 0x-prefixed bytes16 (34 chars). **Must differ from `EXECUTOR_SPACE_ID`.** |
+| `MEMBERSHIP_AUTOACCEPT_SPACE_IDS` | Comma-separated bytes16 (trimmed, de-duped). Empty/unset is valid = kill switch (no-op). |
 
-Sensitive values use `Config.redacted` (matches API + geo-cli patterns). All validation failures are fail-fast `InfraError` with descriptive messages.
+Sensitive values use `Config.redacted` (matches API + geo-cli patterns). All validation failures are fail-fast `InfraError` with descriptive messages. The two `Must differ` checks enforce dual-wallet identity isolation (see "Membership Auto-Accept Path").
 
 ## Telemetry
 
@@ -190,6 +332,7 @@ Adapted from `api/src/services/telemetry.ts` for a short-lived CronJob.
 | `proposal-executor.run` | Entire CronJob invocation (top-level) |
 | `proposal-executor.detect` | PostgreSQL detection query |
 | `proposal-executor.execute-proposal` | Per-proposal execution (attributes: `proposalId`, `spaceId`) |
+| `proposal-executor.membership-vote` | Per-request membership YES vote (attributes: `proposalId`, `spaceId`) |
 
 **Effect Logger routing:**
 - `ERROR` / `FATAL` → `Sentry.captureMessage` (creates Sentry issues)
@@ -248,6 +391,8 @@ securityContext:
 ### enter() Permission Model
 
 `enter()` with `PROPOSAL_EXECUTED` is **permissionless** — anyone can call it once criteria are met (confirmed in `docs/protocol/dao-space.md:179`). No membership or editorship required. The executor's personal space just needs to be registered.
+
+`enter()` with `PROPOSAL_VOTED` (the membership path) is **permissioned** — the caller must hold the **EDITOR** role in the target DAO space, which is exactly the authority a YES vote carries. This is why the membership bot is a distinct identity granted EDITOR in each allowlisted space, and why a missing role surfaces as a `CanNotVote` revert (`membership_vote_reverted`) rather than silently succeeding.
 
 ## Forked Code from geo-cli
 

--- a/proposal-executor/RUNBOOK.md
+++ b/proposal-executor/RUNBOOK.md
@@ -2,12 +2,22 @@
 
 ## What This Service Does
 
-Detects slow-path governance proposals in EXECUTABLE status and calls `enter(PROPOSAL_EXECUTED)` on the Space Registry contract to execute them on-chain. Runs as a K8s CronJob every 5 minutes.
+Runs as a K8s CronJob every 5 minutes and performs **two independent action paths**:
 
-- **Fast-path proposals** don't need this — they auto-execute in the smart contract when the decisive YES vote lands
-- **Slow-path proposals** require an explicit on-chain call after voting ends and quorum + threshold conditions are met — that's what this service does
+1. **Execute path** — detects slow-path governance proposals in EXECUTABLE status and calls
+   `enter(PROPOSAL_EXECUTED)` on the Space Registry contract to execute them on-chain.
+2. **Membership-accept path** — detects untouched **request-to-join** proposals in an explicit
+   allowlist of spaces and casts a single `enter(PROPOSAL_VOTED, Yes)` vote on each. Because
+   allowlisted spaces run with `fastPathFlatThreshold = 1`, that one YES vote admits the joiner in
+   the same transaction. See "Membership Auto-Accept" below.
 
-The executor uses a Safe smart account with Pimlico gas sponsorship, so it needs **no ETH balance**.
+Details:
+
+- **Fast-path proposals** don't need the execute path — they auto-execute in the smart contract when the decisive YES vote lands
+- **Slow-path proposals** require an explicit on-chain call after voting ends and quorum + threshold conditions are met — that's the execute path
+- The two paths run concurrently under **separate wallet identities** and isolated error boundaries — a failure in one never aborts the other
+
+Both wallets use a Safe smart account with Pimlico gas sponsorship, so they need **no ETH balance**.
 
 ## Architecture
 
@@ -33,6 +43,11 @@ Parallel across spaces, sequential within each. The bottleneck is the slowest si
 | `SPACE_REGISTRY_ADDRESS` | No | Space Registry contract address. |
 | `RPC_URL` | Yes | Chain RPC endpoint (must be `http://` or `https://`). May contain API keys in the path. |
 | `CHAIN_ID` | No | `19411` (testnet). Mainnet (`80451`) is not yet deployed. |
+| `MEMBERSHIP_BOT_PRIVATE_KEY` | Yes | 0x-prefixed, 64 hex chars. Private key for the membership bot's EOA. **Must differ from `EXECUTOR_PRIVATE_KEY`.** |
+| `MEMBERSHIP_BOT_SPACE_ID` | No | bytes16, 0x-prefixed. The bot's personal space ID. **Must differ from `EXECUTOR_SPACE_ID`.** |
+| `MEMBERSHIP_AUTOACCEPT_SPACE_IDS` | No | Comma-separated bytes16 space IDs the bot auto-accepts into. **Empty/unset = kill switch** (membership path does nothing). |
+
+> **Membership bot is a distinct identity.** The service fails fast at startup if the bot private key equals `EXECUTOR_PRIVATE_KEY` or the bot space ID equals `EXECUTOR_SPACE_ID`. The bot must hold the **EDITOR** role in each allowlisted space — see "Membership Auto-Accept" below.
 
 > **Sentry** is optional. When `SENTRY_DSN` is set, ERROR/FATAL logs create Sentry issues and all logs become breadcrumbs. OTel spans are routed through Sentry for tracing. When not set, falls back to structured JSON console logging only.
 
@@ -99,6 +114,82 @@ Look for:
 - `run_end` with succeeded/failed/skipped counts
 - Exit code 0
 
+## Membership Auto-Accept
+
+The membership path auto-admits **request-to-join** proposals in allowlisted spaces by casting a
+single YES vote from a dedicated bot wallet. It is **off by default** — it does nothing until
+`MEMBERSHIP_AUTOACCEPT_SPACE_IDS` is populated.
+
+### Onboarding a Space (preconditions)
+
+Before adding a space ID to `MEMBERSHIP_AUTOACCEPT_SPACE_IDS`, **both** of these must hold, or
+auto-accept will not work correctly:
+
+1. **The bot holds the EDITOR role in the target DAO space.** `enter(PROPOSAL_VOTED)` is
+   permissioned — only an editor may vote. Without it, every vote reverts with `CanNotVote`
+   (logged as `membership_vote_reverted`) and no one is admitted.
+2. **The space's `fastPathFlatThreshold = 1`.** Auto-accept relies on a *single* YES vote being
+   decisive so the `AddMember` action executes in the same transaction. This is the core assumption
+   of the feature.
+
+To onboard the bot itself (one-time, mirrors the executor's First-Time Setup):
+
+1. Generate a private key for the bot (distinct from `EXECUTOR_PRIVATE_KEY`).
+2. Derive its Safe address — run locally with the bot key set; it logs `wallet_ready`
+   (`identity: membership-bot`) with the `safeAddress`.
+3. Register a personal space for that Safe address (`geo space create`) and set
+   `MEMBERSHIP_BOT_SPACE_ID` (distinct from `EXECUTOR_SPACE_ID`).
+4. Grant that bot space the **EDITOR** role in each space you intend to allowlist.
+
+> ⚠️ **`fastPathFlatThreshold > 1` hazard — "touch without admit".** If an allowlisted space needs
+> more than one YES vote, the bot's single vote is recorded but the member is **not** admitted. Worse,
+> that vote now "touches" the request: on the next cycle the on-chain tally is non-zero, so stage-2
+> eligibility skips it (`onchain_tally_nonzero`) and the bot never revisits it — and the original
+> request-to-join may now look "acted upon" to humans too. **Only allowlist spaces with
+> `fastPathFlatThreshold = 1`.** If a space's threshold is later raised above 1, remove it from the
+> allowlist.
+
+### How Eligibility Works (two stages)
+
+The bot votes only on a request **no one has touched** (no vote of any kind):
+
+1. **Stage 1 (indexer):** the detection SQL excludes any request that already has a row in
+   `proposal_votes` (skip reason `indexed_vote`, never reaches stage 2).
+2. **Stage 2 (on-chain):** the live tally is read from the DAOSpace contract. The bot votes only if
+   `!executed && yes==0 && no==0 && abstain==0` **and** the voting window is still open. This closes
+   the indexer-lag gap and makes the job idempotent — once the bot votes, its own vote is in the
+   tally, so the next cycle skips (`onchain_tally_nonzero`). No second vote is ever cast.
+
+### Kill Switch
+
+`MEMBERSHIP_AUTOACCEPT_SPACE_IDS` is read **once at startup**; changes require a redeploy/restart.
+
+```bash
+# Disable auto-accept entirely: set the allowlist empty and restart.
+# Edit deployment/<env>/cronjob.yaml → MEMBERSHIP_AUTOACCEPT_SPACE_IDS: ""
+kubectl apply -f deployment/<env>/cronjob.yaml
+```
+
+When empty/unset, the membership path issues **no detection query** and admits no one
+(`membershipAdmitted: 0`), while the execute path runs normally. To stop *both* paths immediately
+during an incident, suspend the CronJob (see "Suspend / Resume").
+
+### Compromised Bot Key
+
+The bot key is independent of the executor key, so its blast radius is limited to membership votes
+in allowlisted spaces. If the bot key is compromised:
+
+0. **Suspend the CronJob immediately** (see "Suspend / Resume") — or, to stop only auto-accept while
+   leaving the execute path running, empty `MEMBERSHIP_AUTOACCEPT_SPACE_IDS` and apply.
+1. Generate a new bot private key.
+2. Derive the new bot Safe address (run locally with the new key — see onboarding step 2 above).
+3. Register a new personal space for it (`geo space create`) and grant it EDITOR in each allowlisted
+   space; revoke EDITOR from the old bot space.
+4. Update `MEMBERSHIP_BOT_SPACE_ID` in `cronjob.yaml` and `MEMBERSHIP_BOT_PRIVATE_KEY` in the K8s
+   Secret.
+5. Apply the updated resources and resume (if suspended); trigger a manual run to verify two
+   `wallet_ready` logs (`executor` and `membership-bot`) with the expected Safe addresses.
+
 ## How to Read the Logs
 
 All logs are structured JSON with a `runId` UUID that correlates events within a single CronJob invocation.
@@ -109,13 +200,18 @@ All logs are structured JSON with a `runId` UUID that correlates events within a
 
 | Event | Level | Meaning |
 |---|---|---|
-| `wallet_ready` | INFO | Smart wallet initialized. Check `safeAddress`. |
+| `wallet_ready` | INFO | A smart wallet initialized. Check `identity` (`executor` or `membership-bot`) and `safeAddress`. Two are emitted per run. |
 | `run_start` | INFO | Detection complete. `proposalsFound` and `spaces` show scope. |
 | `proposal_executed` | INFO | Success. Contains `txHash`, `proposalId`, `spaceId`. |
 | `proposal_skip_expected` | INFO | Expected revert (e.g., already executed). **Not an error.** |
 | `proposal_reverted` | INFO | Unexpected revert. Proposal skipped, execution continues. |
+| `membership_vote_cast` | INFO | Membership YES vote submitted. `{proposalId, spaceId, targetId, txHash}`. Admits the joiner. |
+| `membership_skip` | INFO | Request ineligible at stage 2. `reason` ∈ `already_executed` / `onchain_tally_nonzero` / `voting_window_closed`. **Not an error.** |
+| `membership_skip_expected` | INFO | Expected revert at vote time (already executed/resolved). **Not an error.** |
+| `membership_vote_reverted` | INFO | Unexpected revert (e.g. bot lacks EDITOR → `CanNotVote`). Skipped, retried next cycle. |
+| `membership_path_failed` | ERROR | The membership path's InfraError boundary tripped. The execute path is unaffected. |
 | `space_aborted` | ERROR | InfraError exhausted retries for a space. Other spaces continue. |
-| `run_end` | INFO | Summary: `succeeded`, `failed` (spaces aborted, not proposals), `skipped`, `total`, `durationMs`. |
+| `run_end` | INFO | Summary: execute path (`succeeded`, `failed` = spaces aborted, `skipped`, `total`, `spaces`) + membership path (`membershipAdmitted`, `membershipSkipped`, `membershipFailed`, `membershipTotal`, `membershipSpaces`) + `durationMs`. |
 | `run_failed` | ERROR | Top-level failure (config error, DB unreachable, timeout). |
 | `fatal` | ERROR | Unhandled defect (bug). May lack `runId` — occurs outside Effect runtime. |
 | `db_disconnected` | DEBUG | Finalizer ran, DB connection closed. |
@@ -158,10 +254,10 @@ To add new revert patterns to the classification, update `REVERT_ERROR_NAMES` or
 
 | Code | Meaning |
 |---|---|
-| `0` | At least one proposal succeeded, OR no proposals found, OR partial success |
-| `1` | Every attempt failed (systemic issue — all spaces aborted) |
+| `0` | At least one proposal executed OR member admitted, OR nothing to do, OR partial success |
+| `1` | Every attempt failed (systemic issue — all spaces aborted across both paths) |
 
-Partial success exits `0` because individual proposal failures don't indicate systemic problems.
+Partial success exits `0` because individual proposal failures don't indicate systemic problems. Membership outcomes fold into the same semantics: `membershipAdmitted` counts toward `succeeded`, an aborted membership space counts toward `failed`.
 
 ## K8s Configuration
 
@@ -275,6 +371,11 @@ If the proposals table contains a malformed proposal or space ID, `uuidToBytes16
 | `DB connect failed: [ECONNREFUSED]` | DB unreachable | Check DATABASE_URL, network policies, PgBouncer |
 | `Executor Safe ... has no registered personal space` | Personal space not created | Run `geo space create` for the Safe address |
 | `On-chain space ID ... does not match configured EXECUTOR_SPACE_ID` | Wrong EXECUTOR_SPACE_ID | Verify against on-chain `addressToSpaceId(safeAddress)` |
+| `Invalid MEMBERSHIP_BOT_PRIVATE_KEY` | Not 0x-prefixed 64 hex chars | Check key format, add 0x prefix if missing |
+| `Invalid MEMBERSHIP_BOT_SPACE_ID` | Not 0x-prefixed bytes16 (34 chars) | UUID → strip dashes → prefix 0x |
+| `Invalid MEMBERSHIP_AUTOACCEPT_SPACE_IDS entry` | A list entry isn't bytes16 | Comma-separated 0x-prefixed bytes16; fix or remove the bad entry |
+| `MEMBERSHIP_BOT_PRIVATE_KEY must differ from EXECUTOR_PRIVATE_KEY` | Bot reuses executor key | Use a distinct key for the bot identity |
+| `MEMBERSHIP_BOT_SPACE_ID must differ from EXECUTOR_SPACE_ID` | Bot reuses executor space | Use a distinct personal space for the bot |
 
 ### All proposals revert
 

--- a/proposal-executor/RUNBOOK.md
+++ b/proposal-executor/RUNBOOK.md
@@ -371,7 +371,7 @@ If the proposals table contains a malformed proposal or space ID, `uuidToBytes16
 | `DB connect failed: [ECONNREFUSED]` | DB unreachable | Check DATABASE_URL, network policies, PgBouncer |
 | `Executor Safe ... has no registered personal space` | Personal space not created | Run `geo space create` for the Safe address |
 | `On-chain space ID ... does not match configured EXECUTOR_SPACE_ID` | Wrong EXECUTOR_SPACE_ID | Verify against on-chain `addressToSpaceId(safeAddress)` |
-| `Invalid MEMBERSHIP_BOT_PRIVATE_KEY` | Not 0x-prefixed 64 hex chars | Check key format, add 0x prefix if missing |
+| `Invalid MEMBERSHIP_BOT_PRIVATE_KEY` | Not a 32-byte (64 hex char) key | Check the key is 64 hex chars; the `0x` prefix is auto-added, so length/hex content is the real issue |
 | `Invalid MEMBERSHIP_BOT_SPACE_ID` | Not 0x-prefixed bytes16 (34 chars) | UUID → strip dashes → prefix 0x |
 | `Invalid MEMBERSHIP_AUTOACCEPT_SPACE_IDS entry` | A list entry isn't bytes16 | Comma-separated 0x-prefixed bytes16; fix or remove the bad entry |
 | `MEMBERSHIP_BOT_PRIVATE_KEY must differ from EXECUTOR_PRIVATE_KEY` | Bot reuses executor key | Use a distinct key for the bot identity |

--- a/proposal-executor/RUNBOOK.md
+++ b/proposal-executor/RUNBOOK.md
@@ -154,7 +154,9 @@ To onboard the bot itself (one-time, mirrors the executor's First-Time Setup):
 The bot votes only on a request **no one has touched** (no vote of any kind):
 
 1. **Stage 1 (indexer):** the detection SQL excludes any request that already has a row in
-   `proposal_votes` (skip reason `indexed_vote`, never reaches stage 2).
+   `proposal_votes`. These are filtered out at detection time — they never enter the membership
+   loop, so **no skip event is emitted** for them (you won't see an `indexed_vote` reason in the
+   logs; only stage-2 reasons appear in `membership_skip`).
 2. **Stage 2 (on-chain):** the live tally is read from the DAOSpace contract. The bot votes only if
    `!executed && yes==0 && no==0 && abstain==0` **and** the voting window is still open. This closes
    the indexer-lag gap and makes the job idempotent — once the bot votes, its own vote is in the


### PR DESCRIPTION
Extend ARCHITECTURE.md and RUNBOOK.md to cover the membership-accept feature shipped alongside the slow-path executor:

- Dual-wallet identity isolation (dedicated bot key + space, distinct from the executor; enforced at startup)
- Two-stage "untouched" eligibility: stage-1 indexer NOT EXISTS, then authoritative on-chain getLatestProposalInformation tally read
- Voting-window guard using chain time + clock-skew buffer
- VoteOption.Yes = 1 enter(PROPOSAL_VOTED) encoding and the permissioned (EDITOR-required) vote vs permissionless PROPOSAL_EXECUTED distinction
- Kill switch (empty allowlist), bot onboarding preconditions (EDITOR role + fastPathFlatThreshold = 1), the threshold>1 "touch without admit" hazard, and the compromised-key procedure
- Membership config validation, telemetry events/span, run_end fields, exit-code folding, and startup-troubleshooting rows