### PR TITLE
feat(proposal-executor): auto-accept membership requests

### DIFF
--- a/docs/protocol/dao-space.md
+++ b/docs/protocol/dao-space.md
@@ -27,9 +27,9 @@ enum VotingMode {
 ```solidity
 enum VoteOption {
     None,    // 0 - Invalid/not voted
-    Abstain, // 1
-    Yes,     // 2
-    No       // 3
+    Yes,     // 1
+    No,      // 2
+    Abstain  // 3
 }
 ```
 

--- a/proposal-executor/.env.example
+++ b/proposal-executor/.env.example
@@ -9,6 +9,10 @@ DATABASE_URL=postgresql://user:password@host:5432/dbname
 # Private key for the EOA that owns the Safe smart account (0x-prefixed, 66 chars)
 EXECUTOR_PRIVATE_KEY=0x...
 
+# Private key for the membership-bot wallet (0x-prefixed, 66 chars).
+# MUST be a distinct identity from EXECUTOR_PRIVATE_KEY — startup fails if they match.
+MEMBERSHIP_BOT_PRIVATE_KEY=0x...
+
 # Pimlico bundler/paymaster API key
 PIMLICO_API_KEY=pim_...
 
@@ -19,6 +23,14 @@ RPC_URL=https://...
 
 # Personal space ID of the executor (bytes16, 0x-prefixed — public on-chain data)
 EXECUTOR_SPACE_ID=0x...
+
+# Personal space ID of the membership bot (bytes16, 0x-prefixed).
+# MUST differ from EXECUTOR_SPACE_ID — startup fails if they match.
+MEMBERSHIP_BOT_SPACE_ID=0x...
+
+# Allowlisted DAO spaces for membership auto-accept (comma-separated bytes16).
+# Empty/unset = kill switch: the membership path runs no detection and casts no votes.
+MEMBERSHIP_AUTOACCEPT_SPACE_IDS=
 
 # Space Registry contract address (0x-prefixed)
 SPACE_REGISTRY_ADDRESS=0xB01683b2f0d38d43fcD4D9aAB980166988924132

--- a/proposal-executor/ARCHITECTURE.md
+++ b/proposal-executor/ARCHITECTURE.md
@@ -185,7 +185,10 @@ in two stages, indexer first then on-chain, to be both cheap and authoritative:
 
 1. **Stage 1 — indexer (`detect.ts`, `findMembershipRequests`).** A SQL `NOT EXISTS` against
    `proposal_votes` excludes any request that already has an indexed vote. Cheap, batched, but
-   subject to indexing lag. Skip reason: `indexed_vote`.
+   subject to indexing lag. This is a *filter* at detection time — excluded requests simply never
+   enter the membership loop, so **no per-request skip event is emitted** for them. (`indexed_vote`
+   exists in the `MembershipSkipReason` taxonomy for completeness but is never logged at runtime;
+   only stage-2 reasons appear in `membership_skip`.)
 2. **Stage 2 — on-chain (`membership.ts`, `readProposalTally`).** For each stage-1 survivor, read
    the live tally from the per-space DAOSpace contract via
    `getLatestProposalInformation(bytes16) → (executed, creator, parameters, tally, actions)`. The
@@ -269,7 +272,7 @@ does nothing.
 |---|---|---|
 | `wallet_ready` (`identity: membership-bot`) | INFO | Bot wallet built + verified. Check `safeAddress`. |
 | `membership_vote_cast` | INFO | YES vote submitted. `{proposalId, spaceId, targetId, txHash}`. |
-| `membership_skip` | INFO | Ineligible at stage 2. `reason` ∈ {`already_executed`, `onchain_tally_nonzero`, `voting_window_closed`}. (`indexed_vote` skips happen at stage 1 and never reach stage 2.) |
+| `membership_skip` | INFO | Ineligible at stage 2. `reason` ∈ {`already_executed`, `onchain_tally_nonzero`, `voting_window_closed`}. (Stage-1 indexed-vote exclusions are filtered out at detection time and emit no event — `indexed_vote` is never logged.) |
 | `membership_skip_expected` | INFO | Expected revert at cast time (already executed / resolved). Not an error. |
 | `membership_vote_reverted` | INFO | Unexpected revert (e.g. bot lacks EDITOR → `CanNotVote`). Skipped, retried next cycle. |
 | `membership_path_failed` | ERROR | The membership path's own InfraError boundary tripped; the execute path is unaffected. |

--- a/proposal-executor/ARCHITECTURE.md
+++ b/proposal-executor/ARCHITECTURE.md
@@ -7,15 +7,17 @@
 ```
 proposal-executor/
 ├── src/
-│   ├── index.ts        # Effect orchestration, config parsing, entry point
-│   ├── detect.ts       # DB connection + detection SQL query
+│   ├── index.ts        # Effect orchestration, config parsing, entry point (both paths)
+│   ├── detect.ts       # DB connection + detection SQL (executable proposals + membership requests)
 │   ├── execute.ts      # Smart wallet, encoding helpers, on-chain execution
+│   ├── membership.ts   # Membership stage-2 on-chain read + PROPOSAL_VOTED (Yes) vote cast
 │   ├── contracts.ts    # ABI subset, chain defs, tagged errors, governance constants
 │   └── telemetry.ts    # OTel tracing + Sentry error tracking (adapted from api/)
 ├── tests/
-│   ├── detect.test.ts  # RATIO_BASE cross-validation, SQL structure, Proposal shape
-│   ├── execute.test.ts # Encoding correctness, constant validation, error classification
-│   └── index.test.ts   # Tagged error discrimination, exit code logic, concurrency model
+│   ├── detect.test.ts     # RATIO_BASE cross-validation, SQL structure, Proposal + MembershipRequest shape
+│   ├── execute.test.ts    # Encoding correctness, constant validation, error classification
+│   ├── membership.test.ts # Vote encoding (VoteOption=1), tally decoding, two-stage eligibility
+│   └── index.test.ts      # Tagged error discrimination, exit code logic, concurrency, dual-wallet config
 ├── deployment/         # Both environments deploy into the 'knowledge' namespace
 │   ├── staging/        # Testnet (chain 19411) manifests
 │   │   ├── cronjob.yaml
@@ -37,6 +39,8 @@ proposal-executor/
 - `db.ts` → folded into `detect.ts` (5 lines of `pg.Client` connect/query/end)
 
 Each file has enough substance (~30–100 lines) to justify its existence without artificial splitting.
+
+The membership-accept feature added a fifth source file, `membership.ts`, rather than folding into `execute.ts`. It is a distinct concern (vote cast + on-chain tally read, not slow-path execution) with its own substance (~330 lines), so it earns its own file by the same single-responsibility rule. It still *reuses* `execute.ts`'s smart-wallet factory, encoding helpers (`uuidToBytes16`, `padBytes16ToBytes32`), and `classifyAsRevert` — no duplication.
 
 ## Concurrency Model
 
@@ -141,6 +145,141 @@ The Safe smart account address is deterministic from the owner EOA. The same pri
 
 The testnet uses custom Safe deployment addresses (defined in `contracts.ts`, forked from `geo-cli/src/wallet.ts:54-61`). These are selected via `config.chainId === 19411`.
 
+## Membership Auto-Accept Path
+
+A second action path runs in the same CronJob alongside slow-path execution: it detects
+untouched **request-to-join** proposals in an explicit allowlist of spaces and casts a single
+**YES vote** on each. Because allowlisted spaces are configured with `fastPathFlatThreshold = 1`,
+that one YES vote meets the threshold and the DAOSpace contract executes the `AddMember` action in
+the *same* transaction — admitting the joiner with no human in the loop. There is no separate
+`PROPOSAL_EXECUTED` step for these.
+
+The two paths share the process, the cycle, and the DB connection, but **never share a wallet
+identity**. They run concurrently (`Effect.all`, concurrency 2) with isolated error boundaries —
+each path is total (catches its own failures), so a failure in one cannot abort or interrupt the
+other.
+
+### Dual-Wallet Identity Isolation
+
+The membership path acts under a **dedicated bot identity whose wallet is distinct from the
+slow-path executor wallet** — a separate private key (`MEMBERSHIP_BOT_PRIVATE_KEY`) and a separate
+registered personal space (`MEMBERSHIP_BOT_SPACE_ID`). This is a hard requirement, enforced at
+startup:
+
+- `parseConfig` fails fast with `InfraError` if `MEMBERSHIP_BOT_PRIVATE_KEY === EXECUTOR_PRIVATE_KEY`
+  or `MEMBERSHIP_BOT_SPACE_ID === EXECUTOR_SPACE_ID`.
+- Both wallets are built via the same `createSmartWallet` factory and each is verified every run
+  (`verifyExecutorSetup`), so a misconfigured bot fails fast. Two `wallet_ready` logs are emitted,
+  tagged `identity: "executor"` and `identity: "membership-bot"`.
+
+Why a separate identity: least privilege. The bot holds the **EDITOR** role in each allowlisted
+space (the authority a YES vote requires); the executor does not need and should not have it. The
+bot gets its own key, its own authority, its own kill switch, and its own blast radius — fully
+isolated from the executor. The executor wallet never casts a membership vote; the bot wallet never
+executes a slow-path proposal.
+
+### Two-Stage "Untouched" Eligibility
+
+The bot only votes on a request that **no one has touched** — no vote of any kind. This is checked
+in two stages, indexer first then on-chain, to be both cheap and authoritative:
+
+1. **Stage 1 — indexer (`detect.ts`, `findMembershipRequests`).** A SQL `NOT EXISTS` against
+   `proposal_votes` excludes any request that already has an indexed vote. Cheap, batched, but
+   subject to indexing lag. Skip reason: `indexed_vote`.
+2. **Stage 2 — on-chain (`membership.ts`, `readProposalTally`).** For each stage-1 survivor, read
+   the live tally from the per-space DAOSpace contract via
+   `getLatestProposalInformation(bytes16) → (executed, creator, parameters, tally, actions)`. The
+   request is eligible to vote **iff** `!executed && yes == 0 && no == 0 && abstain == 0` **and**
+   the voting window is still open. This RPC read closes the indexing-lag window left by stage 1.
+
+Reading the authoritative on-chain tally is also what makes the job **idempotent** across cycles:
+the moment the bot votes, its own vote is in the on-chain `Tally` — even before the indexer surfaces
+it — so the next cycle reads `yes >= 1` and skips. No duplicate vote, no shared mutable state, no
+tracking column. (This is the membership-path analogue of the executor's "let it revert" stance,
+but here the duplicate is prevented *before* submission rather than absorbed as a free revert.)
+
+`classifyMembershipSkip` maps an ineligible tally to one of three stage-2 reasons, in priority
+order, so telemetry says *why* nothing was done:
+
+| Reason | Condition | Meaning |
+|---|---|---|
+| `already_executed` | `executed == true` | Request already resolved (admitted or otherwise). |
+| `onchain_tally_nonzero` | any of `yes/no/abstain != 0` | A vote is already recorded (human's, or the bot's own prior vote → idempotency). |
+| `voting_window_closed` | window closed | Voting period ended; the protocol would reject the vote. |
+
+### Voting-Window Guard (Clock Skew)
+
+`getLatestProposalInformation` also returns `ProposalParameters.startDate` / `lastDate`. The
+protocol rejects a vote whose `block.timestamp` falls outside `[startDate, lastDate]`, so stage-2
+eligibility honours the window (`isVotingOpen`). Two deliberate choices:
+
+- **Chain time, not wall clock.** The check compares against the latest block's timestamp
+  (`readChainTimeSeconds`, read once per run), the same clock the contract enforces — not the pod's
+  wall clock, which can drift. On an RPC hiccup it falls back to the pod clock rather than failing
+  the batch; the skew buffer absorbs the drift.
+- **The close is widened, not narrowed** (`CLOCK_SKEW_BUFFER_SECONDS = 60`, mirroring the detection
+  query). During the final 60s — and up to 60s past `lastDate` — the bot still votes, accepting a
+  possible at-most-60s-late revert over wrongly skipping a still-open request. Missing a genuinely
+  open request is worse than a free, sponsored late revert.
+
+### Vote Cast Encoding
+
+The vote reuses the executor's gas-sponsored `enter()` UserOperation pattern. The deployed
+SpaceRegistry ABI takes `bytes16` space IDs:
+
+```
+enter(
+  botSpaceId,                                 // bytes16  _fromSpaceId (MEMBERSHIP_BOT_SPACE_ID)
+  uuidToBytes16(request.spaceId),             // bytes16  _toSpaceId   (DAO space being joined)
+  PROPOSAL_VOTED,                             // bytes32  0x4ebf5f29...d5819e
+  padBytes16ToBytes32(uuidToBytes16(id)),     // bytes32  topic = bytes32(proposalId), left-aligned
+  encodeVoteData(uuidToBytes16(id), VOTE_YES),// bytes    abi.encode(bytes16 proposalId, uint8 1)
+  "0x"                                        // bytes    _signature (ignored; msg.sender == _fromSpace)
+)
+```
+
+**`VoteOption.Yes = 1`** — from the deployed `IDAOSpace` interface
+(`enum VoteOption { None=0, Yes=1, No=2, Abstain=3 }`). A unit test asserts `VOTE_YES === 1` to
+guard this value, because `docs/protocol/dao-space.md` previously documented the enum incorrectly
+(now corrected). The DAOSpace tally getters live on the **per-space** contract, not the
+SpaceRegistry, so the address is resolved first via `SpaceRegistry.spaceIdToAddress(daoSpaceId)`
+(a zero address ⇒ unregistered space ⇒ `InfraError`).
+
+### Request-to-Join Detection Signature
+
+A membership request, per stage-1 SQL, is a proposal that is **all** of: `Fast` voting mode; a
+single action; that action is `AddMember`; the action targets the proposer itself
+(`proposals.proposed_by = proposal_actions.target_id` — a *self*-request, not an editor adding
+someone); not executed; in an allowlisted space; and with no row in `proposal_votes` (stage-1
+untouched). There is **no creation-time cutoff** — a pre-existing backlog is admitted. When the
+allowlist is empty the query short-circuits to `[]` (kill switch — no DB query issued).
+
+### Kill Switch & Blast Radius
+
+`MEMBERSHIP_AUTOACCEPT_SPACE_IDS` is an explicit, auditable, comma-separated allowlist of bytes16
+space IDs (trimmed, de-duped). It is read **once at startup**; changes require a redeploy/restart.
+An empty or unset list is valid and means the membership path is a complete no-op — the feature
+ships "off" and is flipped on only when product supplies an allowlist. This is why PR-A…PR-E could
+merge to `main` without changing production behaviour: until the allowlist is populated, the path
+does nothing.
+
+### Membership Telemetry
+
+| Event / Span | Kind | Meaning |
+|---|---|---|
+| `wallet_ready` (`identity: membership-bot`) | INFO | Bot wallet built + verified. Check `safeAddress`. |
+| `membership_vote_cast` | INFO | YES vote submitted. `{proposalId, spaceId, targetId, txHash}`. |
+| `membership_skip` | INFO | Ineligible at stage 2. `reason` ∈ {`already_executed`, `onchain_tally_nonzero`, `voting_window_closed`}. (`indexed_vote` skips happen at stage 1 and never reach stage 2.) |
+| `membership_skip_expected` | INFO | Expected revert at cast time (already executed / resolved). Not an error. |
+| `membership_vote_reverted` | INFO | Unexpected revert (e.g. bot lacks EDITOR → `CanNotVote`). Skipped, retried next cycle. |
+| `membership_path_failed` | ERROR | The membership path's own InfraError boundary tripped; the execute path is unaffected. |
+| `proposal-executor.membership-vote` | span | Per-request vote attempt. |
+| `run_end` fields | INFO | `membershipAdmitted`, `membershipSkipped`, `membershipFailed`, `membershipTotal`, `membershipSpaces`. |
+
+Exit code: membership outcomes fold into the existing `succeeded`/`failed` semantics —
+`membershipAdmitted` adds to `succeeded`, an aborted membership space adds to `failed`. Partial
+success (anything admitted or executed) still exits `0`.
+
 ## Race Condition: Double Execution
 
 After the executor submits `enter(PROPOSAL_EXECUTED)` on-chain, the proposal's `executed_at` remains NULL until the kg-indexer processes the event (seconds to minutes). During this window, the next CronJob run re-detects and re-submits. The contract reverts ("already executed").
@@ -168,8 +307,11 @@ If revert noise becomes a problem at scale, the best future option is a local tr
 | `SPACE_REGISTRY_ADDRESS` | Valid Ethereum address (viem `getAddress()` checksum). |
 | `RPC_URL` | Non-empty, starts with `http://` or `https://`. |
 | `CHAIN_ID` | Must be `80451` or `19411` (exhaustive check). |
+| `MEMBERSHIP_BOT_PRIVATE_KEY` | 0x-prefixed, 64 hex chars (auto-prefix). **Must differ from `EXECUTOR_PRIVATE_KEY`.** |
+| `MEMBERSHIP_BOT_SPACE_ID` | 0x-prefixed bytes16 (34 chars). **Must differ from `EXECUTOR_SPACE_ID`.** |
+| `MEMBERSHIP_AUTOACCEPT_SPACE_IDS` | Comma-separated bytes16 (trimmed, de-duped). Empty/unset is valid = kill switch (no-op). |
 
-Sensitive values use `Config.redacted` (matches API + geo-cli patterns). All validation failures are fail-fast `InfraError` with descriptive messages.
+Sensitive values use `Config.redacted` (matches API + geo-cli patterns). All validation failures are fail-fast `InfraError` with descriptive messages. The two `Must differ` checks enforce dual-wallet identity isolation (see "Membership Auto-Accept Path").
 
 ## Telemetry
 
@@ -190,6 +332,7 @@ Adapted from `api/src/services/telemetry.ts` for a short-lived CronJob.
 | `proposal-executor.run` | Entire CronJob invocation (top-level) |
 | `proposal-executor.detect` | PostgreSQL detection query |
 | `proposal-executor.execute-proposal` | Per-proposal execution (attributes: `proposalId`, `spaceId`) |
+| `proposal-executor.membership-vote` | Per-request membership YES vote (attributes: `proposalId`, `spaceId`) |
 
 **Effect Logger routing:**
 - `ERROR` / `FATAL` → `Sentry.captureMessage` (creates Sentry issues)
@@ -248,6 +391,8 @@ securityContext:
 ### enter() Permission Model
 
 `enter()` with `PROPOSAL_EXECUTED` is **permissionless** — anyone can call it once criteria are met (confirmed in `docs/protocol/dao-space.md:179`). No membership or editorship required. The executor's personal space just needs to be registered.
+
+`enter()` with `PROPOSAL_VOTED` (the membership path) is **permissioned** — the caller must hold the **EDITOR** role in the target DAO space, which is exactly the authority a YES vote carries. This is why the membership bot is a distinct identity granted EDITOR in each allowlisted space, and why a missing role surfaces as a `CanNotVote` revert (`membership_vote_reverted`) rather than silently succeeding.
 
 ## Forked Code from geo-cli
 

--- a/proposal-executor/RUNBOOK.md
+++ b/proposal-executor/RUNBOOK.md
@@ -2,12 +2,22 @@
 
 ## What This Service Does
 
-Detects slow-path governance proposals in EXECUTABLE status and calls `enter(PROPOSAL_EXECUTED)` on the Space Registry contract to execute them on-chain. Runs as a K8s CronJob every 5 minutes.
+Runs as a K8s CronJob every 5 minutes and performs **two independent action paths**:
 
-- **Fast-path proposals** don't need this — they auto-execute in the smart contract when the decisive YES vote lands
-- **Slow-path proposals** require an explicit on-chain call after voting ends and quorum + threshold conditions are met — that's what this service does
+1. **Execute path** — detects slow-path governance proposals in EXECUTABLE status and calls
+   `enter(PROPOSAL_EXECUTED)` on the Space Registry contract to execute them on-chain.
+2. **Membership-accept path** — detects untouched **request-to-join** proposals in an explicit
+   allowlist of spaces and casts a single `enter(PROPOSAL_VOTED, Yes)` vote on each. Because
+   allowlisted spaces run with `fastPathFlatThreshold = 1`, that one YES vote admits the joiner in
+   the same transaction. See "Membership Auto-Accept" below.
 
-The executor uses a Safe smart account with Pimlico gas sponsorship, so it needs **no ETH balance**.
+Details:
+
+- **Fast-path proposals** don't need the execute path — they auto-execute in the smart contract when the decisive YES vote lands
+- **Slow-path proposals** require an explicit on-chain call after voting ends and quorum + threshold conditions are met — that's the execute path
+- The two paths run concurrently under **separate wallet identities** and isolated error boundaries — a failure in one never aborts the other
+
+Both wallets use a Safe smart account with Pimlico gas sponsorship, so they need **no ETH balance**.
 
 ## Architecture
 
@@ -33,6 +43,11 @@ Parallel across spaces, sequential within each. The bottleneck is the slowest si
 | `SPACE_REGISTRY_ADDRESS` | No | Space Registry contract address. |
 | `RPC_URL` | Yes | Chain RPC endpoint (must be `http://` or `https://`). May contain API keys in the path. |
 | `CHAIN_ID` | No | `19411` (testnet). Mainnet (`80451`) is not yet deployed. |
+| `MEMBERSHIP_BOT_PRIVATE_KEY` | Yes | 0x-prefixed, 64 hex chars. Private key for the membership bot's EOA. **Must differ from `EXECUTOR_PRIVATE_KEY`.** |
+| `MEMBERSHIP_BOT_SPACE_ID` | No | bytes16, 0x-prefixed. The bot's personal space ID. **Must differ from `EXECUTOR_SPACE_ID`.** |
+| `MEMBERSHIP_AUTOACCEPT_SPACE_IDS` | No | Comma-separated bytes16 space IDs the bot auto-accepts into. **Empty/unset = kill switch** (membership path does nothing). |
+
+> **Membership bot is a distinct identity.** The service fails fast at startup if the bot private key equals `EXECUTOR_PRIVATE_KEY` or the bot space ID equals `EXECUTOR_SPACE_ID`. The bot must hold the **EDITOR** role in each allowlisted space — see "Membership Auto-Accept" below.
 
 > **Sentry** is optional. When `SENTRY_DSN` is set, ERROR/FATAL logs create Sentry issues and all logs become breadcrumbs. OTel spans are routed through Sentry for tracing. When not set, falls back to structured JSON console logging only.
 
@@ -99,6 +114,82 @@ Look for:
 - `run_end` with succeeded/failed/skipped counts
 - Exit code 0
 
+## Membership Auto-Accept
+
+The membership path auto-admits **request-to-join** proposals in allowlisted spaces by casting a
+single YES vote from a dedicated bot wallet. It is **off by default** — it does nothing until
+`MEMBERSHIP_AUTOACCEPT_SPACE_IDS` is populated.
+
+### Onboarding a Space (preconditions)
+
+Before adding a space ID to `MEMBERSHIP_AUTOACCEPT_SPACE_IDS`, **both** of these must hold, or
+auto-accept will not work correctly:
+
+1. **The bot holds the EDITOR role in the target DAO space.** `enter(PROPOSAL_VOTED)` is
+   permissioned — only an editor may vote. Without it, every vote reverts with `CanNotVote`
+   (logged as `membership_vote_reverted`) and no one is admitted.
+2. **The space's `fastPathFlatThreshold = 1`.** Auto-accept relies on a *single* YES vote being
+   decisive so the `AddMember` action executes in the same transaction. This is the core assumption
+   of the feature.
+
+To onboard the bot itself (one-time, mirrors the executor's First-Time Setup):
+
+1. Generate a private key for the bot (distinct from `EXECUTOR_PRIVATE_KEY`).
+2. Derive its Safe address — run locally with the bot key set; it logs `wallet_ready`
+   (`identity: membership-bot`) with the `safeAddress`.
+3. Register a personal space for that Safe address (`geo space create`) and set
+   `MEMBERSHIP_BOT_SPACE_ID` (distinct from `EXECUTOR_SPACE_ID`).
+4. Grant that bot space the **EDITOR** role in each space you intend to allowlist.
+
+> ⚠️ **`fastPathFlatThreshold > 1` hazard — "touch without admit".** If an allowlisted space needs
+> more than one YES vote, the bot's single vote is recorded but the member is **not** admitted. Worse,
+> that vote now "touches" the request: on the next cycle the on-chain tally is non-zero, so stage-2
+> eligibility skips it (`onchain_tally_nonzero`) and the bot never revisits it — and the original
+> request-to-join may now look "acted upon" to humans too. **Only allowlist spaces with
+> `fastPathFlatThreshold = 1`.** If a space's threshold is later raised above 1, remove it from the
+> allowlist.
+
+### How Eligibility Works (two stages)
+
+The bot votes only on a request **no one has touched** (no vote of any kind):
+
+1. **Stage 1 (indexer):** the detection SQL excludes any request that already has a row in
+   `proposal_votes` (skip reason `indexed_vote`, never reaches stage 2).
+2. **Stage 2 (on-chain):** the live tally is read from the DAOSpace contract. The bot votes only if
+   `!executed && yes==0 && no==0 && abstain==0` **and** the voting window is still open. This closes
+   the indexer-lag gap and makes the job idempotent — once the bot votes, its own vote is in the
+   tally, so the next cycle skips (`onchain_tally_nonzero`). No second vote is ever cast.
+
+### Kill Switch
+
+`MEMBERSHIP_AUTOACCEPT_SPACE_IDS` is read **once at startup**; changes require a redeploy/restart.
+
+```bash
+# Disable auto-accept entirely: set the allowlist empty and restart.
+# Edit deployment/<env>/cronjob.yaml → MEMBERSHIP_AUTOACCEPT_SPACE_IDS: ""
+kubectl apply -f deployment/<env>/cronjob.yaml
+```
+
+When empty/unset, the membership path issues **no detection query** and admits no one
+(`membershipAdmitted: 0`), while the execute path runs normally. To stop *both* paths immediately
+during an incident, suspend the CronJob (see "Suspend / Resume").
+
+### Compromised Bot Key
+
+The bot key is independent of the executor key, so its blast radius is limited to membership votes
+in allowlisted spaces. If the bot key is compromised:
+
+0. **Suspend the CronJob immediately** (see "Suspend / Resume") — or, to stop only auto-accept while
+   leaving the execute path running, empty `MEMBERSHIP_AUTOACCEPT_SPACE_IDS` and apply.
+1. Generate a new bot private key.
+2. Derive the new bot Safe address (run locally with the new key — see onboarding step 2 above).
+3. Register a new personal space for it (`geo space create`) and grant it EDITOR in each allowlisted
+   space; revoke EDITOR from the old bot space.
+4. Update `MEMBERSHIP_BOT_SPACE_ID` in `cronjob.yaml` and `MEMBERSHIP_BOT_PRIVATE_KEY` in the K8s
+   Secret.
+5. Apply the updated resources and resume (if suspended); trigger a manual run to verify two
+   `wallet_ready` logs (`executor` and `membership-bot`) with the expected Safe addresses.
+
 ## How to Read the Logs
 
 All logs are structured JSON with a `runId` UUID that correlates events within a single CronJob invocation.
@@ -109,13 +200,18 @@ All logs are structured JSON with a `runId` UUID that correlates events within a
 
 | Event | Level | Meaning |
 |---|---|---|
-| `wallet_ready` | INFO | Smart wallet initialized. Check `safeAddress`. |
+| `wallet_ready` | INFO | A smart wallet initialized. Check `identity` (`executor` or `membership-bot`) and `safeAddress`. Two are emitted per run. |
 | `run_start` | INFO | Detection complete. `proposalsFound` and `spaces` show scope. |
 | `proposal_executed` | INFO | Success. Contains `txHash`, `proposalId`, `spaceId`. |
 | `proposal_skip_expected` | INFO | Expected revert (e.g., already executed). **Not an error.** |
 | `proposal_reverted` | INFO | Unexpected revert. Proposal skipped, execution continues. |
+| `membership_vote_cast` | INFO | Membership YES vote submitted. `{proposalId, spaceId, targetId, txHash}`. Admits the joiner. |
+| `membership_skip` | INFO | Request ineligible at stage 2. `reason` ∈ `already_executed` / `onchain_tally_nonzero` / `voting_window_closed`. **Not an error.** |
+| `membership_skip_expected` | INFO | Expected revert at vote time (already executed/resolved). **Not an error.** |
+| `membership_vote_reverted` | INFO | Unexpected revert (e.g. bot lacks EDITOR → `CanNotVote`). Skipped, retried next cycle. |
+| `membership_path_failed` | ERROR | The membership path's InfraError boundary tripped. The execute path is unaffected. |
 | `space_aborted` | ERROR | InfraError exhausted retries for a space. Other spaces continue. |
-| `run_end` | INFO | Summary: `succeeded`, `failed` (spaces aborted, not proposals), `skipped`, `total`, `durationMs`. |
+| `run_end` | INFO | Summary: execute path (`succeeded`, `failed` = spaces aborted, `skipped`, `total`, `spaces`) + membership path (`membershipAdmitted`, `membershipSkipped`, `membershipFailed`, `membershipTotal`, `membershipSpaces`) + `durationMs`. |
 | `run_failed` | ERROR | Top-level failure (config error, DB unreachable, timeout). |
 | `fatal` | ERROR | Unhandled defect (bug). May lack `runId` — occurs outside Effect runtime. |
 | `db_disconnected` | DEBUG | Finalizer ran, DB connection closed. |
@@ -158,10 +254,10 @@ To add new revert patterns to the classification, update `REVERT_ERROR_NAMES` or
 
 | Code | Meaning |
 |---|---|
-| `0` | At least one proposal succeeded, OR no proposals found, OR partial success |
-| `1` | Every attempt failed (systemic issue — all spaces aborted) |
+| `0` | At least one proposal executed OR member admitted, OR nothing to do, OR partial success |
+| `1` | Every attempt failed (systemic issue — all spaces aborted across both paths) |
 
-Partial success exits `0` because individual proposal failures don't indicate systemic problems.
+Partial success exits `0` because individual proposal failures don't indicate systemic problems. Membership outcomes fold into the same semantics: `membershipAdmitted` counts toward `succeeded`, an aborted membership space counts toward `failed`.
 
 ## K8s Configuration
 
@@ -275,6 +371,11 @@ If the proposals table contains a malformed proposal or space ID, `uuidToBytes16
 | `DB connect failed: [ECONNREFUSED]` | DB unreachable | Check DATABASE_URL, network policies, PgBouncer |
 | `Executor Safe ... has no registered personal space` | Personal space not created | Run `geo space create` for the Safe address |
 | `On-chain space ID ... does not match configured EXECUTOR_SPACE_ID` | Wrong EXECUTOR_SPACE_ID | Verify against on-chain `addressToSpaceId(safeAddress)` |
+| `Invalid MEMBERSHIP_BOT_PRIVATE_KEY` | Not 0x-prefixed 64 hex chars | Check key format, add 0x prefix if missing |
+| `Invalid MEMBERSHIP_BOT_SPACE_ID` | Not 0x-prefixed bytes16 (34 chars) | UUID → strip dashes → prefix 0x |
+| `Invalid MEMBERSHIP_AUTOACCEPT_SPACE_IDS entry` | A list entry isn't bytes16 | Comma-separated 0x-prefixed bytes16; fix or remove the bad entry |
+| `MEMBERSHIP_BOT_PRIVATE_KEY must differ from EXECUTOR_PRIVATE_KEY` | Bot reuses executor key | Use a distinct key for the bot identity |
+| `MEMBERSHIP_BOT_SPACE_ID must differ from EXECUTOR_SPACE_ID` | Bot reuses executor space | Use a distinct personal space for the bot |
 
 ### All proposals revert
 

--- a/proposal-executor/RUNBOOK.md
+++ b/proposal-executor/RUNBOOK.md
@@ -371,7 +371,7 @@ If the proposals table contains a malformed proposal or space ID, `uuidToBytes16
 | `DB connect failed: [ECONNREFUSED]` | DB unreachable | Check DATABASE_URL, network policies, PgBouncer |
 | `Executor Safe ... has no registered personal space` | Personal space not created | Run `geo space create` for the Safe address |
 | `On-chain space ID ... does not match configured EXECUTOR_SPACE_ID` | Wrong EXECUTOR_SPACE_ID | Verify against on-chain `addressToSpaceId(safeAddress)` |
-| `Invalid MEMBERSHIP_BOT_PRIVATE_KEY` | Not 0x-prefixed 64 hex chars | Check key format, add 0x prefix if missing |
+| `Invalid MEMBERSHIP_BOT_PRIVATE_KEY` | Not a 32-byte (64 hex char) key | Check the key is 64 hex chars; the `0x` prefix is auto-added, so length/hex content is the real issue |
 | `Invalid MEMBERSHIP_BOT_SPACE_ID` | Not 0x-prefixed bytes16 (34 chars) | UUID → strip dashes → prefix 0x |
 | `Invalid MEMBERSHIP_AUTOACCEPT_SPACE_IDS entry` | A list entry isn't bytes16 | Comma-separated 0x-prefixed bytes16; fix or remove the bad entry |
 | `MEMBERSHIP_BOT_PRIVATE_KEY must differ from EXECUTOR_PRIVATE_KEY` | Bot reuses executor key | Use a distinct key for the bot identity |

--- a/proposal-executor/RUNBOOK.md
+++ b/proposal-executor/RUNBOOK.md
@@ -154,7 +154,9 @@ To onboard the bot itself (one-time, mirrors the executor's First-Time Setup):
 The bot votes only on a request **no one has touched** (no vote of any kind):
 
 1. **Stage 1 (indexer):** the detection SQL excludes any request that already has a row in
-   `proposal_votes` (skip reason `indexed_vote`, never reaches stage 2).
+   `proposal_votes`. These are filtered out at detection time — they never enter the membership
+   loop, so **no skip event is emitted** for them (you won't see an `indexed_vote` reason in the
+   logs; only stage-2 reasons appear in `membership_skip`).
 2. **Stage 2 (on-chain):** the live tally is read from the DAOSpace contract. The bot votes only if
    `!executed && yes==0 && no==0 && abstain==0` **and** the voting window is still open. This closes
    the indexer-lag gap and makes the job idempotent — once the bot votes, its own vote is in the

--- a/proposal-executor/deployment/production/cronjob.yaml
+++ b/proposal-executor/deployment/production/cronjob.yaml
@@ -76,7 +76,7 @@ spec:
                 # Allowlisted DAO spaces for auto-accept (comma-separated bytes16).
                 # Empty string = kill switch: no detection, no votes.
                 - name: MEMBERSHIP_AUTOACCEPT_SPACE_IDS
-                  value: ""
+                  value: "0xc9f267dcb0d270718c2a3c45a64afd32,0x84a679ce188f061ac9a92380bac2bab5"
                 - name: SPACE_REGISTRY_ADDRESS
                   value: "0xB01683b2f0d38d43fcD4D9aAB980166988924132"
                 - name: RPC_URL

--- a/proposal-executor/deployment/production/cronjob.yaml
+++ b/proposal-executor/deployment/production/cronjob.yaml
@@ -61,9 +61,22 @@ spec:
                     secretKeyRef:
                       name: proposal-executor-credentials
                       key: PIMLICO_API_KEY
+                # Membership-bot wallet — MUST be a distinct identity from the executor
+                - name: MEMBERSHIP_BOT_PRIVATE_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: proposal-executor-credentials
+                      key: MEMBERSHIP_BOT_PRIVATE_KEY
                 # Config (non-sensitive — plain values)
                 - name: EXECUTOR_SPACE_ID
                   value: "0xb64f2e2d69be2ddbb5e3c997cf8a7d15"
+                # Membership-bot personal space — MUST differ from EXECUTOR_SPACE_ID
+                - name: MEMBERSHIP_BOT_SPACE_ID
+                  value: ""
+                # Allowlisted DAO spaces for auto-accept (comma-separated bytes16).
+                # Empty string = kill switch: no detection, no votes.
+                - name: MEMBERSHIP_AUTOACCEPT_SPACE_IDS
+                  value: ""
                 - name: SPACE_REGISTRY_ADDRESS
                   value: "0xB01683b2f0d38d43fcD4D9aAB980166988924132"
                 - name: RPC_URL

--- a/proposal-executor/deployment/production/cronjob.yaml
+++ b/proposal-executor/deployment/production/cronjob.yaml
@@ -72,7 +72,7 @@ spec:
                   value: "0xb64f2e2d69be2ddbb5e3c997cf8a7d15"
                 # Membership-bot personal space — MUST differ from EXECUTOR_SPACE_ID
                 - name: MEMBERSHIP_BOT_SPACE_ID
-                  value: ""
+                  value: "0x24208422558b4ac801e24a71a889dfad"
                 # Allowlisted DAO spaces for auto-accept (comma-separated bytes16).
                 # Empty string = kill switch: no detection, no votes.
                 - name: MEMBERSHIP_AUTOACCEPT_SPACE_IDS

--- a/proposal-executor/deployment/production/secrets.yaml.example
+++ b/proposal-executor/deployment/production/secrets.yaml.example
@@ -5,6 +5,7 @@
 #   --namespace=knowledge \
 #   --from-literal=DATABASE_URL='postgresql://...' \
 #   --from-literal=EXECUTOR_PRIVATE_KEY='0x...' \
+#   --from-literal=MEMBERSHIP_BOT_PRIVATE_KEY='0x...' \
 #   --from-literal=PIMLICO_API_KEY='pim_...'
 
 apiVersion: v1
@@ -16,5 +17,7 @@ type: Opaque
 stringData:
   DATABASE_URL: "postgresql://readonly_user:password@host:5432/dbname"
   EXECUTOR_PRIVATE_KEY: "0x..."
+  # Membership-bot wallet key — MUST differ from EXECUTOR_PRIVATE_KEY
+  MEMBERSHIP_BOT_PRIVATE_KEY: "0x..."
   PIMLICO_API_KEY: "pim_..."
   RPC_URL: "https://..."

--- a/proposal-executor/deployment/production/secrets.yaml.example
+++ b/proposal-executor/deployment/production/secrets.yaml.example
@@ -6,7 +6,8 @@
 #   --from-literal=DATABASE_URL='postgresql://...' \
 #   --from-literal=EXECUTOR_PRIVATE_KEY='0x...' \
 #   --from-literal=MEMBERSHIP_BOT_PRIVATE_KEY='0x...' \
-#   --from-literal=PIMLICO_API_KEY='pim_...'
+#   --from-literal=PIMLICO_API_KEY='pim_...' \
+#   --from-literal=RPC_URL='https://...'
 
 apiVersion: v1
 kind: Secret

--- a/proposal-executor/deployment/staging/cronjob.yaml
+++ b/proposal-executor/deployment/staging/cronjob.yaml
@@ -66,9 +66,22 @@ spec:
                     secretKeyRef:
                       name: proposal-executor-credentials
                       key: PIMLICO_API_KEY
+                # Membership-bot wallet — MUST be a distinct identity from the executor
+                - name: MEMBERSHIP_BOT_PRIVATE_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: proposal-executor-credentials
+                      key: MEMBERSHIP_BOT_PRIVATE_KEY
                 # Config (non-sensitive — plain values)
                 - name: EXECUTOR_SPACE_ID
                   value: "0xb64f2e2d69be2ddbb5e3c997cf8a7d15"
+                # Membership-bot personal space — MUST differ from EXECUTOR_SPACE_ID
+                - name: MEMBERSHIP_BOT_SPACE_ID
+                  value: ""
+                # Allowlisted DAO spaces for auto-accept (comma-separated bytes16).
+                # Empty string = kill switch: no detection, no votes.
+                - name: MEMBERSHIP_AUTOACCEPT_SPACE_IDS
+                  value: ""
                 - name: SPACE_REGISTRY_ADDRESS
                   value: "0xB01683b2f0d38d43fcD4D9aAB980166988924132"
                 - name: RPC_URL

--- a/proposal-executor/deployment/staging/cronjob.yaml
+++ b/proposal-executor/deployment/staging/cronjob.yaml
@@ -77,7 +77,7 @@ spec:
                   value: "0xb64f2e2d69be2ddbb5e3c997cf8a7d15"
                 # Membership-bot personal space — MUST differ from EXECUTOR_SPACE_ID
                 - name: MEMBERSHIP_BOT_SPACE_ID
-                  value: ""
+                  value: "0x24208422558b4ac801e24a71a889dfad"
                 # Allowlisted DAO spaces for auto-accept (comma-separated bytes16).
                 # Empty string = kill switch: no detection, no votes.
                 - name: MEMBERSHIP_AUTOACCEPT_SPACE_IDS

--- a/proposal-executor/deployment/staging/secrets.yaml.example
+++ b/proposal-executor/deployment/staging/secrets.yaml.example
@@ -5,6 +5,7 @@
 #   --namespace=knowledge \
 #   --from-literal=DATABASE_URL='postgresql://...' \
 #   --from-literal=EXECUTOR_PRIVATE_KEY='0x...' \
+#   --from-literal=MEMBERSHIP_BOT_PRIVATE_KEY='0x...' \
 #   --from-literal=PIMLICO_API_KEY='pim_...'
 
 apiVersion: v1
@@ -16,5 +17,7 @@ type: Opaque
 stringData:
   DATABASE_URL: "postgresql://readonly_user:password@host:5432/dbname"
   EXECUTOR_PRIVATE_KEY: "0x..."
+  # Membership-bot wallet key — MUST differ from EXECUTOR_PRIVATE_KEY
+  MEMBERSHIP_BOT_PRIVATE_KEY: "0x..."
   PIMLICO_API_KEY: "pim_..."
   RPC_URL: "https://..."

--- a/proposal-executor/deployment/staging/secrets.yaml.example
+++ b/proposal-executor/deployment/staging/secrets.yaml.example
@@ -6,7 +6,8 @@
 #   --from-literal=DATABASE_URL='postgresql://...' \
 #   --from-literal=EXECUTOR_PRIVATE_KEY='0x...' \
 #   --from-literal=MEMBERSHIP_BOT_PRIVATE_KEY='0x...' \
-#   --from-literal=PIMLICO_API_KEY='pim_...'
+#   --from-literal=PIMLICO_API_KEY='pim_...' \
+#   --from-literal=RPC_URL='https://...'
 
 apiVersion: v1
 kind: Secret

--- a/proposal-executor/src/contracts.ts
+++ b/proposal-executor/src/contracts.ts
@@ -89,14 +89,11 @@ export const DAOSpaceAbi = [
 			{internalType: "bytes16", name: "_creator", type: "bytes16"},
 			{
 				components: [
-					{internalType: "uint8", name: "votingMode", type: "uint8"},
-					{internalType: "uint256", name: "partialPercentageSupportThreshold", type: "uint256"},
-					{internalType: "uint256", name: "universalPercentageSupportThreshold", type: "uint256"},
-					{internalType: "uint256", name: "flatSupportThreshold", type: "uint256"},
+					{internalType: "enum IDAOSpace.VotingMode", name: "votingMode", type: "uint8"},
+					{internalType: "uint256", name: "supportThreshold", type: "uint256"},
 					{internalType: "uint256", name: "quorum", type: "uint256"},
 					{internalType: "uint256", name: "startDate", type: "uint256"},
 					{internalType: "uint256", name: "lastDate", type: "uint256"},
-					{internalType: "uint256", name: "executeBy", type: "uint256"},
 				],
 				internalType: "struct IDAOSpace.ProposalParameters",
 				name: "_parameters",

--- a/proposal-executor/src/contracts.ts
+++ b/proposal-executor/src/contracts.ts
@@ -47,6 +47,13 @@ export const SpaceRegistryAbi = [
 		type: "function",
 	},
 	{
+		inputs: [{internalType: "bytes16", name: "_spaceId", type: "bytes16"}],
+		name: "spaceIdToAddress",
+		outputs: [{internalType: "address", name: "_account", type: "address"}],
+		stateMutability: "view",
+		type: "function",
+	},
+	{
 		inputs: [
 			{internalType: "bytes16", name: "_fromSpaceId", type: "bytes16"},
 			{internalType: "bytes16", name: "_toSpaceId", type: "bytes16"},
@@ -58,6 +65,63 @@ export const SpaceRegistryAbi = [
 		name: "enter",
 		outputs: [],
 		stateMutability: "nonpayable",
+		type: "function",
+	},
+] as const
+
+// ---------------------------------------------------------------------------
+// DAOSpace ABI — minimal subset (only getLatestProposalInformation)
+// Source: geo-contracts-foundry/src/interfaces/IDAOSpace.sol
+//
+// The vote-tally getters live on the per-space DAOSpace contract (resolved via
+// SpaceRegistry.spaceIdToAddress), NOT on the SpaceRegistry. The membership
+// path reads this for the stage-2 authoritative "untouched" check.
+// ---------------------------------------------------------------------------
+
+export const DAOSpaceAbi = [
+	{
+		inputs: [{internalType: "bytes16", name: "_proposalId", type: "bytes16"}],
+		name: "getLatestProposalInformation",
+		outputs: [
+			{internalType: "bool", name: "_executed", type: "bool"},
+			{internalType: "bytes16", name: "_creator", type: "bytes16"},
+			{
+				components: [
+					{internalType: "uint8", name: "votingMode", type: "uint8"},
+					{internalType: "uint256", name: "partialPercentageSupportThreshold", type: "uint256"},
+					{internalType: "uint256", name: "universalPercentageSupportThreshold", type: "uint256"},
+					{internalType: "uint256", name: "flatSupportThreshold", type: "uint256"},
+					{internalType: "uint256", name: "quorum", type: "uint256"},
+					{internalType: "uint256", name: "startDate", type: "uint256"},
+					{internalType: "uint256", name: "lastDate", type: "uint256"},
+					{internalType: "uint256", name: "executeBy", type: "uint256"},
+				],
+				internalType: "struct IDAOSpace.ProposalParameters",
+				name: "_parameters",
+				type: "tuple",
+			},
+			{
+				components: [
+					{internalType: "uint256", name: "yes", type: "uint256"},
+					{internalType: "uint256", name: "no", type: "uint256"},
+					{internalType: "uint256", name: "abstain", type: "uint256"},
+				],
+				internalType: "struct IDAOSpace.Tally",
+				name: "_tally",
+				type: "tuple",
+			},
+			{
+				components: [
+					{internalType: "address", name: "to", type: "address"},
+					{internalType: "uint256", name: "value", type: "uint256"},
+					{internalType: "bytes", name: "data", type: "bytes"},
+				],
+				internalType: "struct IDAOSpace.Action[]",
+				name: "_actions",
+				type: "tuple[]",
+			},
+		],
+		stateMutability: "view",
 		type: "function",
 	},
 ] as const
@@ -117,6 +181,15 @@ export const TESTNET_SAFE_ADDRESSES = {
 
 /** keccak256('GOVERNANCE.PROPOSAL_EXECUTED') — action hash for enter() */
 export const PROPOSAL_EXECUTED_ACTION = "0x62a60c0a9681612871e0dafa0f24bb0c83cbdde8be5a6299979c88d382369e96" as Hex
+
+/** keccak256('GOVERNANCE.PROPOSAL_VOTED') — action hash for casting a vote via enter() */
+export const PROPOSAL_VOTED_ACTION = "0x4ebf5f29676cedf7e2e4d346a8433289278f95a9fda73691dc1ce24574d5819e" as Hex
+
+/**
+ * IDAOSpace.VoteOption.Yes — the on-chain enum value for a YES vote.
+ * Authoritative enum (geo-contracts-foundry IDAOSpace): None=0, Yes=1, No=2, Abstain=3.
+ */
+export const VOTE_YES = 1
 
 /** Empty signature — ignored when msg.sender == _fromSpace */
 export const EMPTY_SIGNATURE = "0x" as Hex

--- a/proposal-executor/src/contracts.ts
+++ b/proposal-executor/src/contracts.ts
@@ -2,7 +2,8 @@
  * Contract ABIs, chain definitions, and governance constants for the proposal executor.
  *
  * FORKED from geo-cli (v0.1.0):
- * - ABI subset: geo-cli/src/contracts.ts (SpaceRegistryAbi — enter, addressToSpaceId)
+ * - ABI subset: geo-cli/src/contracts.ts (SpaceRegistryAbi — enter, addressToSpaceId;
+ *   spaceIdToAddress added locally for the membership-accept path)
  * - Chain defs: geo-cli/src/network.ts (mainnetChain, testnetChain)
  * - Governance: geo-cli/src/governance.ts (GOVERNANCE_ACTIONS, encoding helpers)
  * - Safe addrs: geo-cli/src/wallet.ts:54-61 (TESTNET_SAFE_ADDRESSES)
@@ -34,8 +35,9 @@ export class InfraError extends Data.TaggedError("InfraError")<{
 }> {}
 
 // ---------------------------------------------------------------------------
-// SpaceRegistry ABI — minimal subset (only enter + addressToSpaceId)
-// Source: geo-cli/src/contracts.ts:125-152
+// SpaceRegistry ABI — minimal subset (enter + addressToSpaceId + spaceIdToAddress)
+// Source: geo-cli/src/contracts.ts (enter, addressToSpaceId);
+//         spaceIdToAddress added locally to resolve a space's DAOSpace address.
 // ---------------------------------------------------------------------------
 
 export const SpaceRegistryAbi = [

--- a/proposal-executor/src/detect.ts
+++ b/proposal-executor/src/detect.ts
@@ -182,9 +182,12 @@ export function findExecutableProposals(client: PgClient, nowSeconds: number): E
  * - Not yet executed (executed_at IS NULL)
  * - Created in the past (guards against corrupt future timestamps; no age cutoff
  *   — backlog is admitted, unlike the executor's MAX_PROPOSAL_AGE)
- * - Voting period has not ended (now <= end_time) — the protocol rejects votes
- *   cast after the period closes, and an untouched Fast proposal whose period
- *   has ended is already classified REJECTED (threshold not reached)
+ * - Voting period has not ended (now <= end_time + CLOCK_SKEW_BUFFER) — the protocol
+ *   rejects votes cast after the period closes, and an untouched Fast proposal whose
+ *   period has ended is already classified REJECTED (threshold not reached). The same
+ *   60s skew buffer the stage-2 eligibility check applies (isVotingOpen, membership.ts)
+ *   is added here so detection never excludes a request that stage 2 would still vote
+ *   on — `now` must therefore be the same chain-sourced timestamp stage 2 uses.
  * - Exactly one action, an AddMember targeting the proposer itself
  *   (target_id = proposed_by) — the self-service request-to-join signature, not
  *   an editor-initiated add
@@ -205,7 +208,7 @@ WHERE p.space_id = ANY($1)
   AND p.voting_mode = 'Fast'
   AND p.executed_at IS NULL
   AND p.created_at::bigint <= $2::bigint
-  AND $2::bigint <= p.end_time
+  AND $2::bigint <= p.end_time + ${CLOCK_SKEW_BUFFER}
   AND a.action_type = 'AddMember'
   AND a.target_id = p.proposed_by
   AND NOT EXISTS (SELECT 1 FROM proposal_votes pv WHERE pv.proposal_id = p.id)
@@ -222,15 +225,19 @@ ORDER BY p.created_at::bigint ASC
  *
  * @param client - Connected pg.Client
  * @param allowlistSpaceIds - Dashed UUIDs of allowlisted DAO spaces (from bytes16 config)
+ * @param nowSeconds - Current Unix timestamp in seconds. MUST be the same chain-sourced
+ *   clock stage 2 uses (readChainTimeSeconds), so the two stages share one notion of
+ *   "now" and the same skew policy — passing the pod wall clock would reintroduce the
+ *   drift the +CLOCK_SKEW_BUFFER window is meant to absorb.
  */
 export function findMembershipRequests(
 	client: PgClient,
 	allowlistSpaceIds: string[],
+	nowSeconds: number,
 ): Effect.Effect<MembershipRequest[], InfraError> {
 	if (allowlistSpaceIds.length === 0) {
 		return Effect.succeed([])
 	}
-	const nowSeconds = Math.floor(Date.now() / 1000)
 	return Effect.tryPromise({
 		try: async () => {
 			const result = await client.query<MembershipRequest>(MEMBERSHIP_DETECTION_SQL, [

--- a/proposal-executor/src/detect.ts
+++ b/proposal-executor/src/detect.ts
@@ -182,6 +182,9 @@ export function findExecutableProposals(client: PgClient, nowSeconds: number): E
  * - Not yet executed (executed_at IS NULL)
  * - Created in the past (guards against corrupt future timestamps; no age cutoff
  *   — backlog is admitted, unlike the executor's MAX_PROPOSAL_AGE)
+ * - Voting period has not ended (now <= end_time) — the protocol rejects votes
+ *   cast after the period closes, and an untouched Fast proposal whose period
+ *   has ended is already classified REJECTED (threshold not reached)
  * - Exactly one action, an AddMember targeting the proposer itself
  *   (target_id = proposed_by) — the self-service request-to-join signature, not
  *   an editor-initiated add
@@ -202,6 +205,7 @@ WHERE p.space_id = ANY($1)
   AND p.voting_mode = 'Fast'
   AND p.executed_at IS NULL
   AND p.created_at::bigint <= $2::bigint
+  AND $2::bigint <= p.end_time
   AND a.action_type = 'AddMember'
   AND a.target_id = p.proposed_by
   AND NOT EXISTS (SELECT 1 FROM proposal_votes pv WHERE pv.proposal_id = p.id)

--- a/proposal-executor/src/detect.ts
+++ b/proposal-executor/src/detect.ts
@@ -26,6 +26,19 @@ export interface Proposal {
 	spaceId: string
 }
 
+/**
+ * A request-to-join proposal: a Fast-mode proposal whose single action admits
+ * its own proposer (self-service join). Candidate for an auto-accept YES vote.
+ */
+export interface MembershipRequest {
+	/** Proposal UUID (with dashes) */
+	id: string
+	/** DAO space UUID being joined (with dashes); always in the allowlist */
+	spaceId: string
+	/** Member space UUID being added (== proposedBy for a self-service request) */
+	requesterId: string
+}
+
 // ---------------------------------------------------------------------------
 // Clock skew buffer
 // ---------------------------------------------------------------------------
@@ -153,6 +166,82 @@ export function findExecutableProposals(client: PgClient, nowSeconds: number): E
 					? error.message.replace(/postgresql?:\/\/[^\s]+/gi, "<redacted>")
 					: "unknown error"
 			return new InfraError({message: `Detection query failed: ${safe}`, durationMs: 0})
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Membership-request detection (stage 1)
+// ---------------------------------------------------------------------------
+
+/**
+ * Finds open, untouched, allowlisted request-to-join proposals (stage 1 of the
+ * two-stage untouched check — the indexer side). A row qualifies iff:
+ * - space_id is in the allowlist ($1)
+ * - Fast voting mode (a single YES vote can execute via the fast-path threshold)
+ * - Not yet executed (executed_at IS NULL)
+ * - Created in the past (guards against corrupt future timestamps; no age cutoff
+ *   — backlog is admitted, unlike the executor's MAX_PROPOSAL_AGE)
+ * - Exactly one action, an AddMember targeting the proposer itself
+ *   (target_id = proposed_by) — the self-service request-to-join signature, not
+ *   an editor-initiated add
+ * - No indexed votes (NOT EXISTS in proposal_votes) — checks raw indexed votes,
+ *   not the async-denormalized yes_count/no_count/abstain_count columns
+ *
+ * This filters voting_mode = 'Fast' while the executor's query filters 'Slow',
+ * so the two paths never return the same proposal.
+ *
+ * ORDER BY created_at::bigint ASC for FIFO ordering (created_at is text Unix
+ * seconds, so the ::bigint cast ensures numeric ordering).
+ */
+export const MEMBERSHIP_DETECTION_SQL = `
+SELECT p.id, p.space_id AS "spaceId", a.target_id AS "requesterId"
+FROM proposals p
+JOIN proposal_actions a ON a.proposal_id = p.id
+WHERE p.space_id = ANY($1)
+  AND p.voting_mode = 'Fast'
+  AND p.executed_at IS NULL
+  AND p.created_at::bigint <= $2::bigint
+  AND a.action_type = 'AddMember'
+  AND a.target_id = p.proposed_by
+  AND NOT EXISTS (SELECT 1 FROM proposal_votes pv WHERE pv.proposal_id = p.id)
+  AND (SELECT COUNT(*) FROM proposal_actions a2 WHERE a2.proposal_id = p.id) = 1
+ORDER BY p.created_at::bigint ASC
+`
+
+/**
+ * Find all untouched request-to-join proposals in allowlisted spaces that are
+ * candidates for an auto-accept YES vote.
+ *
+ * Short-circuits to [] without querying when the allowlist is empty — the
+ * kill switch (an emptied MEMBERSHIP_AUTOACCEPT_SPACE_IDS stops all activity).
+ *
+ * @param client - Connected pg.Client
+ * @param allowlistSpaceIds - Dashed UUIDs of allowlisted DAO spaces (from bytes16 config)
+ */
+export function findMembershipRequests(
+	client: PgClient,
+	allowlistSpaceIds: string[],
+): Effect.Effect<MembershipRequest[], InfraError> {
+	if (allowlistSpaceIds.length === 0) {
+		return Effect.succeed([])
+	}
+	const nowSeconds = Math.floor(Date.now() / 1000)
+	return Effect.tryPromise({
+		try: async () => {
+			const result = await client.query<MembershipRequest>(MEMBERSHIP_DETECTION_SQL, [
+				allowlistSpaceIds,
+				nowSeconds,
+			])
+			return result.rows
+		},
+		catch: (error) => {
+			// Sanitize: pg errors on broken connections may contain the connection string (with password).
+			const safe =
+				error instanceof Error
+					? error.message.replace(/postgresql?:\/\/[^\s]+/gi, "<redacted>")
+					: "unknown error"
+			return new InfraError({message: `Membership detection query failed: ${safe}`, durationMs: 0})
 		},
 	})
 }

--- a/proposal-executor/src/execute.ts
+++ b/proposal-executor/src/execute.ts
@@ -225,7 +225,7 @@ const REVERT_ERROR_NAMES = new Set([
 /** Fallback string patterns when structured error types aren't available */
 const REVERT_MESSAGE_PATTERNS = ["revert", "execution reverted", "CALL_EXCEPTION", "UserOperation reverted"]
 
-function classifyAsRevert(error: unknown, errorName: string, message: string): boolean {
+export function classifyAsRevert(error: unknown, errorName: string, message: string): boolean {
 	// 1. Check structured error name (most reliable)
 	if (REVERT_ERROR_NAMES.has(errorName)) return true
 

--- a/proposal-executor/src/index.ts
+++ b/proposal-executor/src/index.ts
@@ -55,7 +55,8 @@ export {InfraError, RevertError} from "./contracts.js"
 export interface ExecutorEnv {
 	/** Redacted — unwrap with Redacted.value() only at the point of use */
 	databaseUrl: Redacted.Redacted
-	privateKey: `0x${string}`
+	/** Redacted — unwrap with Redacted.value() only at the point of use */
+	privateKey: Redacted.Redacted<`0x${string}`>
 	/** Redacted — unwrap with Redacted.value() only at the point of use */
 	pimlicoApiKey: Redacted.Redacted
 	executorSpaceId: Hex
@@ -65,8 +66,11 @@ export interface ExecutorEnv {
 	chainId: SupportedChainId
 
 	// --- Membership-accept path (dedicated bot identity, distinct from the executor) ---
-	/** Dedicated bot signing key — MUST differ from `privateKey`. Auto-prefixed 0x. */
-	membershipBotPrivateKey: `0x${string}`
+	/**
+	 * Redacted — unwrap with Redacted.value() only at the point of use.
+	 * Dedicated bot signing key — MUST differ from `privateKey`. Auto-prefixed 0x.
+	 */
+	membershipBotPrivateKey: Redacted.Redacted<`0x${string}`>
 	/** Bot's registered personal space (bytes16) — MUST differ from `executorSpaceId`. */
 	membershipBotSpaceId: Hex
 	/**
@@ -101,7 +105,7 @@ export const parseConfig: Effect.Effect<ExecutorEnv, InfraError> = Effect.gen(fu
 		Config.withDefault(""),
 	)
 
-	// --- Validate private key ---
+	// --- Validate private key (on a plain temporary; re-wrapped before storing) ---
 	let privateKey = Redacted.value(rawPrivateKey)
 	if (!privateKey.startsWith("0x")) {
 		privateKey = `0x${privateKey}`
@@ -159,7 +163,8 @@ export const parseConfig: Effect.Effect<ExecutorEnv, InfraError> = Effect.gen(fu
 		)
 	}
 
-	// --- Validate membership-bot private key (auto-prefix 0x like the executor key) ---
+	// --- Validate membership-bot private key (auto-prefix 0x like the executor key;
+	// validated on a plain temporary, then re-wrapped before storing) ---
 	let membershipBotPrivateKey = Redacted.value(rawMembershipBotPrivateKey)
 	if (!membershipBotPrivateKey.startsWith("0x")) {
 		membershipBotPrivateKey = `0x${membershipBotPrivateKey}`
@@ -226,13 +231,15 @@ export const parseConfig: Effect.Effect<ExecutorEnv, InfraError> = Effect.gen(fu
 
 	return {
 		databaseUrl,
-		privateKey: privateKey as `0x${string}`,
+		// Re-wrap the validated keys so they stay redacted in the long-lived config and
+		// are unwrapped only at the createSmartWallet call sites.
+		privateKey: Redacted.make(privateKey as `0x${string}`),
 		pimlicoApiKey,
 		executorSpaceId: rawExecutorSpaceId as Hex,
 		spaceRegistryAddress,
 		rpcUrl,
 		chainId: chainId as SupportedChainId,
-		membershipBotPrivateKey: membershipBotPrivateKey as `0x${string}`,
+		membershipBotPrivateKey: Redacted.make(membershipBotPrivateKey as `0x${string}`),
 		membershipBotSpaceId: rawMembershipBotSpaceId as Hex,
 		membershipAutoacceptSpaceIds,
 	}
@@ -582,7 +589,7 @@ const main = Effect.gen(function* () {
 	yield* Effect.addFinalizer(() => disconnectDb(db).pipe(Effect.tap(() => Effect.logDebug("db_disconnected"))))
 
 	const wallet = yield* createSmartWallet({
-		privateKey: config.privateKey,
+		privateKey: Redacted.value(config.privateKey),
 		pimlicoApiKey: Redacted.value(config.pimlicoApiKey),
 		executorSpaceId: config.executorSpaceId,
 		spaceRegistryAddress: config.spaceRegistryAddress,
@@ -700,7 +707,7 @@ const main = Effect.gen(function* () {
 		// Verified each run so a misconfigured bot fails fast. It casts the membership YES
 		// votes; the executor wallet never does.
 		const botWallet = yield* createSmartWallet({
-			privateKey: config.membershipBotPrivateKey,
+			privateKey: Redacted.value(config.membershipBotPrivateKey),
 			pimlicoApiKey: Redacted.value(config.pimlicoApiKey),
 			executorSpaceId: config.membershipBotSpaceId,
 			spaceRegistryAddress: config.spaceRegistryAddress,

--- a/proposal-executor/src/index.ts
+++ b/proposal-executor/src/index.ts
@@ -27,7 +27,7 @@ export {InfraError, RevertError} from "./contracts.js"
 // Config parsing — uses Effect Config module (matches API + geo-cli patterns)
 // ---------------------------------------------------------------------------
 
-interface ExecutorEnv {
+export interface ExecutorEnv {
 	/** Redacted — unwrap with Redacted.value() only at the point of use */
 	databaseUrl: Redacted.Redacted
 	privateKey: `0x${string}`
@@ -38,6 +38,17 @@ interface ExecutorEnv {
 	/** Redacted — may contain API keys in the path */
 	rpcUrl: Redacted.Redacted
 	chainId: SupportedChainId
+
+	// --- Membership-accept path (dedicated bot identity, distinct from the executor) ---
+	/** Dedicated bot signing key — MUST differ from `privateKey`. Auto-prefixed 0x. */
+	membershipBotPrivateKey: `0x${string}`
+	/** Bot's registered personal space (bytes16) — MUST differ from `executorSpaceId`. */
+	membershipBotSpaceId: Hex
+	/**
+	 * Spaces whose request-to-join proposals are auto-admitted. Empty ⇒ kill switch
+	 * (no detection, no votes). Trimmed, validated, and de-duplicated at parse time.
+	 */
+	membershipAutoacceptSpaceIds: Hex[]
 }
 
 /** bytes16 hex: 0x-prefixed, 32 hex chars, 34 total */
@@ -46,11 +57,12 @@ const BYTES16_RE = /^0x[0-9a-fA-F]{32}$/
 /** 0x-prefixed 64 hex chars (32 bytes) */
 const PRIVATE_KEY_RE = /^0x[0-9a-fA-F]{64}$/
 
-const parseConfig: Effect.Effect<ExecutorEnv, InfraError> = Effect.gen(function* () {
+export const parseConfig: Effect.Effect<ExecutorEnv, InfraError> = Effect.gen(function* () {
 	// Sensitive — wrapped in Redacted to prevent accidental logging/serialization
 	const databaseUrl = yield* Config.redacted("DATABASE_URL")
 	const rawPrivateKey = yield* Config.redacted("EXECUTOR_PRIVATE_KEY")
 	const pimlicoApiKey = yield* Config.redacted("PIMLICO_API_KEY")
+	const rawMembershipBotPrivateKey = yield* Config.redacted("MEMBERSHIP_BOT_PRIVATE_KEY")
 
 	const rpcUrl = yield* Config.redacted("RPC_URL")
 
@@ -58,6 +70,11 @@ const parseConfig: Effect.Effect<ExecutorEnv, InfraError> = Effect.gen(function*
 	const rawExecutorSpaceId = yield* Config.string("EXECUTOR_SPACE_ID")
 	const rawSpaceRegistryAddress = yield* Config.string("SPACE_REGISTRY_ADDRESS")
 	const chainId = yield* Config.integer("CHAIN_ID")
+	const rawMembershipBotSpaceId = yield* Config.string("MEMBERSHIP_BOT_SPACE_ID")
+	// Empty/unset is valid — it is the kill switch (no detection, no votes).
+	const rawMembershipAutoacceptSpaceIds = yield* Config.string("MEMBERSHIP_AUTOACCEPT_SPACE_IDS").pipe(
+		Config.withDefault(""),
+	)
 
 	// --- Validate private key ---
 	let privateKey = Redacted.value(rawPrivateKey)
@@ -117,6 +134,71 @@ const parseConfig: Effect.Effect<ExecutorEnv, InfraError> = Effect.gen(function*
 		)
 	}
 
+	// --- Validate membership-bot private key (auto-prefix 0x like the executor key) ---
+	let membershipBotPrivateKey = Redacted.value(rawMembershipBotPrivateKey)
+	if (!membershipBotPrivateKey.startsWith("0x")) {
+		membershipBotPrivateKey = `0x${membershipBotPrivateKey}`
+	}
+	if (!PRIVATE_KEY_RE.test(membershipBotPrivateKey)) {
+		return yield* Effect.fail(
+			new InfraError({
+				message: "Invalid MEMBERSHIP_BOT_PRIVATE_KEY: expected a 32-byte hex-encoded key with 0x prefix",
+				durationMs: 0,
+			}),
+		)
+	}
+
+	// --- Validate membership-bot space ID (bytes16) ---
+	if (!BYTES16_RE.test(rawMembershipBotSpaceId)) {
+		return yield* Effect.fail(
+			new InfraError({
+				message: `Invalid MEMBERSHIP_BOT_SPACE_ID: expected 0x-prefixed bytes16 (34 chars), got "${rawMembershipBotSpaceId}"`,
+				durationMs: 0,
+			}),
+		)
+	}
+
+	// --- Distinct-identity guard: the bot MUST NOT reuse the executor's identity ---
+	if (membershipBotPrivateKey.toLowerCase() === privateKey.toLowerCase()) {
+		return yield* Effect.fail(
+			new InfraError({
+				message:
+					"MEMBERSHIP_BOT_PRIVATE_KEY must differ from EXECUTOR_PRIVATE_KEY (distinct bot identity required)",
+				durationMs: 0,
+			}),
+		)
+	}
+	if (rawMembershipBotSpaceId.toLowerCase() === rawExecutorSpaceId.toLowerCase()) {
+		return yield* Effect.fail(
+			new InfraError({
+				message: "MEMBERSHIP_BOT_SPACE_ID must differ from EXECUTOR_SPACE_ID (distinct bot identity required)",
+				durationMs: 0,
+			}),
+		)
+	}
+
+	// --- Parse & validate the auto-accept allowlist (kill switch when empty) ---
+	// Trim each entry, drop blanks, validate as bytes16, and de-duplicate
+	// case-insensitively (first-seen casing wins).
+	const seenSpaceIds = new Set<string>()
+	const membershipAutoacceptSpaceIds: Hex[] = []
+	for (const raw of rawMembershipAutoacceptSpaceIds.split(",")) {
+		const entry = raw.trim()
+		if (entry.length === 0) continue
+		if (!BYTES16_RE.test(entry)) {
+			return yield* Effect.fail(
+				new InfraError({
+					message: `Invalid MEMBERSHIP_AUTOACCEPT_SPACE_IDS entry: expected 0x-prefixed bytes16 (34 chars), got "${entry}"`,
+					durationMs: 0,
+				}),
+			)
+		}
+		const key = entry.toLowerCase()
+		if (seenSpaceIds.has(key)) continue
+		seenSpaceIds.add(key)
+		membershipAutoacceptSpaceIds.push(entry as Hex)
+	}
+
 	return {
 		databaseUrl,
 		privateKey: privateKey as `0x${string}`,
@@ -125,6 +207,9 @@ const parseConfig: Effect.Effect<ExecutorEnv, InfraError> = Effect.gen(function*
 		spaceRegistryAddress,
 		rpcUrl,
 		chainId: chainId as SupportedChainId,
+		membershipBotPrivateKey: membershipBotPrivateKey as `0x${string}`,
+		membershipBotSpaceId: rawMembershipBotSpaceId as Hex,
+		membershipAutoacceptSpaceIds,
 	}
 }).pipe(
 	Effect.catchTag("ConfigError", (e) =>
@@ -221,9 +306,29 @@ const main = Effect.gen(function* () {
 		chainId: config.chainId,
 	})
 
-	yield* Effect.logInfo("wallet_ready").pipe(Effect.annotateLogs({safeAddress: wallet.safeAddress}))
+	yield* Effect.logInfo("wallet_ready").pipe(
+		Effect.annotateLogs({identity: "executor", safeAddress: wallet.safeAddress}),
+	)
 
 	yield* verifyExecutorSetup(wallet, config.executorSpaceId, config.spaceRegistryAddress)
+
+	// Membership-accept bot wallet — a SECOND, distinct identity built from the
+	// dedicated bot key + space. Verified each run so a misconfigured bot fails
+	// fast; detection/voting are wired in a later PR (this path is inert for now).
+	const botWallet = yield* createSmartWallet({
+		privateKey: config.membershipBotPrivateKey,
+		pimlicoApiKey: Redacted.value(config.pimlicoApiKey),
+		executorSpaceId: config.membershipBotSpaceId,
+		spaceRegistryAddress: config.spaceRegistryAddress,
+		rpcUrl: Redacted.value(config.rpcUrl),
+		chainId: config.chainId,
+	})
+
+	yield* Effect.logInfo("wallet_ready").pipe(
+		Effect.annotateLogs({identity: "membership-bot", safeAddress: botWallet.safeAddress}),
+	)
+
+	yield* verifyExecutorSetup(botWallet, config.membershipBotSpaceId, config.spaceRegistryAddress)
 
 	const runStart = Date.now()
 	const nowSeconds = Math.floor(runStart / 1000)
@@ -325,9 +430,13 @@ const main = Effect.gen(function* () {
 
 // Total failure (all failed, none succeeded) → exit 1 so K8s marks the job as failed.
 // Partial success → exit 0; the next CronJob run will retry the remaining proposals.
-Effect.runPromise(main)
-	.then(({succeeded, failed}) => process.exit(failed > 0 && succeeded === 0 ? 1 : 0))
-	.catch((err) => {
-		console.error(JSON.stringify({level: "fatal", message: "unhandled_defect", error: String(err)}))
-		process.exit(1)
-	})
+// Guarded by import.meta.main so importing this module (e.g. from tests to exercise
+// parseConfig) does not kick off a run or call process.exit().
+if (import.meta.main) {
+	Effect.runPromise(main)
+		.then(({succeeded, failed}) => process.exit(failed > 0 && succeeded === 0 ? 1 : 0))
+		.catch((err) => {
+			console.error(JSON.stringify({level: "fatal", message: "unhandled_defect", error: String(err)}))
+			process.exit(1)
+		})
+}

--- a/proposal-executor/src/index.ts
+++ b/proposal-executor/src/index.ts
@@ -1,9 +1,18 @@
 /**
  * Proposal Auto-Executor — Effect-TS entry point.
  *
- * Detects slow-path governance proposals in EXECUTABLE status and calls
- * enter(PROPOSAL_EXECUTED) on the Space Registry contract via a gas-sponsored
- * Safe smart account.
+ * Two independent action paths share this process and ~5-minute cadence:
+ *
+ *  1. Execute path — detects slow-path governance proposals in EXECUTABLE status and
+ *     calls enter(PROPOSAL_EXECUTED) on the Space Registry via the executor wallet.
+ *  2. Membership-accept path — detects untouched request-to-join proposals in an
+ *     allowlist of spaces and casts a single enter(PROPOSAL_VOTED, Yes) from a SECOND,
+ *     distinct bot wallet. Because allowlisted spaces run with fastPathFlatThreshold = 1,
+ *     that YES vote admits the joiner in the same transaction. A two-stage untouched
+ *     check (indexer SQL → on-chain tally) makes it safe and idempotent.
+ *
+ * The two paths never share a wallet identity and are isolated: a failure in one does
+ * not abort the other.
  *
  * Concurrency: parallel across spaces (unbounded), sequential within each space.
  * Error handling: RevertError → skip, InfraError → retry 2x then abort space.
@@ -16,8 +25,24 @@ import type {Hex} from "viem"
 import {type Address, getAddress} from "viem"
 
 import {InfraError, type RevertError, type SupportedChainId} from "./contracts.js"
-import {connectDb, disconnectDb, findExecutableProposals, MAX_PROPOSAL_AGE, type Proposal} from "./detect.js"
-import {createSmartWallet, executeProposal, type SmartWallet, verifyExecutorSetup} from "./execute.js"
+import {
+	connectDb,
+	disconnectDb,
+	findExecutableProposals,
+	findMembershipRequests,
+	MAX_PROPOSAL_AGE,
+	type MembershipRequest,
+	type Proposal,
+} from "./detect.js"
+import {createSmartWallet, executeProposal, type SmartWallet, uuidToBytes16, verifyExecutorSetup} from "./execute.js"
+import {
+	castMembershipVote,
+	isEligibleToVote,
+	type ProposalTally,
+	readChainTimeSeconds,
+	readProposalTally,
+	resolveDaoSpaceAddress,
+} from "./membership.js"
 import {flush, TelemetryLive} from "./telemetry.js"
 
 // Re-export tagged errors so tests and consumers have a single import
@@ -285,6 +310,245 @@ function executeSpaceProposals(
 }
 
 // ---------------------------------------------------------------------------
+// Membership-accept path — orchestration helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a bytes16 hex space ID (0x + 32 hex chars) back to a dashed UUID.
+ *
+ * The allowlist is configured as bytes16 (MEMBERSHIP_AUTOACCEPT_SPACE_IDS), but the
+ * indexer stores space_id as a dashed, lower-cased UUID. The detection query matches
+ * on the UUID form, so the allowlist must be converted before it is passed in. This is
+ * the inverse of execute.ts' uuidToBytes16.
+ */
+export function bytes16ToUuid(spaceId: Hex): string {
+	const hex = spaceId.startsWith("0x") ? spaceId.slice(2) : spaceId
+	if (hex.length !== 32 || !/^[0-9a-fA-F]+$/.test(hex)) {
+		throw new Error(`Invalid bytes16 for UUID conversion: ${spaceId}`)
+	}
+	const h = hex.toLowerCase()
+	return `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20)}`
+}
+
+/**
+ * Why a membership request was skipped instead of voted on. The bot only votes on a
+ * genuinely untouched, still-open request; every other state maps to a distinct, typed
+ * reason so the telemetry says *why* nothing was done:
+ * - `indexed_vote` — stage 1 (indexer): a vote is already in proposal_votes. Enforced
+ *   by the detection SQL's NOT EXISTS, so survivors reaching stage 2 have passed it;
+ *   surfaced here for taxonomy completeness (not emitted by this loop at runtime).
+ * - `already_executed` — stage 2: the proposal has already executed (resolved).
+ * - `onchain_tally_nonzero` — stage 2: a vote is already recorded in the on-chain
+ *   tally. This is also what the bot's own prior vote trips, making the job idempotent.
+ * - `voting_window_closed` — stage 2: the voting period has ended, so the protocol
+ *   would reject a late vote. An untouched-but-expired request is left alone — this is
+ *   independent of the tally, which may well be zero.
+ */
+export type MembershipSkipReason =
+	| "indexed_vote"
+	| "already_executed"
+	| "onchain_tally_nonzero"
+	| "voting_window_closed"
+
+/**
+ * The outcome of processing one membership request:
+ * - `voted`    — a YES vote was cast (the requester is admitted),
+ * - `skipped`  — ineligible at stage 2 (touched/resolved/closed) → not our business,
+ * - `reverted` — the vote reverted on-chain (e.g. already executed, or the bot lacks
+ *   the EDITOR role); logged and left for the next cycle, never aborts other requests.
+ */
+type MembershipOutcome =
+	| {status: "voted"; txHash: string}
+	| {status: "skipped"; reason: MembershipSkipReason}
+	| {status: "reverted"; expected: boolean}
+
+/** Result of processing all requests in a single space. */
+type MembershipSpaceResult =
+	| {status: "ok"; spaceId: string; outcomes: MembershipOutcome[]}
+	| {status: "infraError"; spaceId: string; outcomes: MembershipOutcome[]}
+
+interface MembershipSummary {
+	/** YES votes cast (requesters admitted this cycle). */
+	admitted: number
+	/** Requests left alone — ineligible (stage 2) or reverted. */
+	skipped: number
+	/** Spaces aborted by a persistent infrastructure error. */
+	failed: number
+	/** Candidate requests surfaced by stage-1 detection. */
+	total: number
+	/** Allowlisted spaces with at least one candidate. */
+	spaces: number
+}
+
+/**
+ * Classify a stage-1 survivor after the authoritative on-chain (stage-2) read.
+ * Returns `null` when the request is still eligible (the bot should vote), otherwise
+ * the specific reason it is ineligible. Stays in lock-step with isEligibleToVote — it
+ * returns null in exactly the cases that function returns true, then names the cause:
+ * executed first, then a non-zero tally, and finally a closed voting window (the
+ * remaining cause for an untouched, unexecuted request).
+ */
+export function classifyMembershipSkip(tally: ProposalTally, nowSeconds: bigint): MembershipSkipReason | null {
+	if (isEligibleToVote(tally, nowSeconds)) return null
+	if (tally.executed) return "already_executed"
+	if (tally.yes !== 0n || tally.no !== 0n || tally.abstain !== 0n) return "onchain_tally_nonzero"
+	return "voting_window_closed"
+}
+
+/**
+ * Aggregate per-space results into the run summary. Votes count as `admitted`;
+ * both ineligible skips and on-chain reverts count as `skipped` (non-admitting,
+ * non-failing); spaces aborted by infra count as `failed`.
+ */
+export function aggregateMembership(results: MembershipSpaceResult[]): {
+	admitted: number
+	skipped: number
+	failed: number
+} {
+	let admitted = 0
+	let skipped = 0
+	for (const r of results) {
+		for (const o of r.outcomes) {
+			if (o.status === "voted") admitted++
+			else skipped++
+		}
+	}
+	const failed = results.filter((r) => r.status === "infraError").length
+	return {admitted, skipped, failed}
+}
+
+/** Cast a membership YES vote with the same timeout + InfraError retry the executor uses. */
+function castVoteWithRetry(
+	wallet: SmartWallet,
+	request: MembershipRequest,
+	botSpaceId: Hex,
+	spaceRegistryAddress: Address,
+): Effect.Effect<string, InfraError | RevertError> {
+	return castMembershipVote(wallet, request, botSpaceId, spaceRegistryAddress).pipe(
+		Effect.timeoutFail({
+			duration: Duration.seconds(30),
+			onTimeout: () =>
+				new InfraError({proposalId: request.id, message: "Vote cast timed out after 30s", durationMs: 30_000}),
+		}),
+		Effect.retry({schedule: infraRetryPolicy, while: (e) => e._tag === "InfraError"}),
+		Effect.withSpan("proposal-executor.membership-vote", {
+			attributes: {proposalId: request.id, spaceId: request.spaceId},
+		}),
+	)
+}
+
+/** Read the on-chain tally (stage 2) with the same timeout + InfraError retry. */
+function readTallyWithRetry(
+	wallet: SmartWallet,
+	daoSpaceAddress: Address,
+	proposalId: string,
+): Effect.Effect<ProposalTally, InfraError> {
+	return readProposalTally(wallet, daoSpaceAddress, proposalId).pipe(
+		Effect.timeoutFail({
+			duration: Duration.seconds(30),
+			onTimeout: () =>
+				new InfraError({proposalId, message: "Tally read timed out after 30s", durationMs: 30_000}),
+		}),
+		Effect.retry({schedule: infraRetryPolicy, while: (e) => e._tag === "InfraError"}),
+	)
+}
+
+/**
+ * Process one membership request: stage-2 on-chain read → eligibility gate → vote.
+ * A RevertError is caught and turned into a `reverted` outcome (logged, not fatal) so
+ * it never aborts the rest of the space. An InfraError propagates to abort this space
+ * (retried next cycle), matching the executor's per-space fail-fast.
+ */
+export function processMembershipRequest(
+	wallet: SmartWallet,
+	request: MembershipRequest,
+	daoSpaceAddress: Address,
+	botSpaceId: Hex,
+	spaceRegistryAddress: Address,
+	nowSeconds: bigint,
+): Effect.Effect<MembershipOutcome, InfraError> {
+	return readTallyWithRetry(wallet, daoSpaceAddress, request.id).pipe(
+		Effect.flatMap((tally) => {
+			const skipReason = classifyMembershipSkip(tally, nowSeconds)
+			if (skipReason !== null) {
+				return Effect.logInfo("membership_skip").pipe(
+					Effect.annotateLogs({
+						proposalId: request.id,
+						spaceId: request.spaceId,
+						targetId: request.requesterId,
+						reason: skipReason,
+						yes: tally.yes.toString(),
+						no: tally.no.toString(),
+						abstain: tally.abstain.toString(),
+						executed: tally.executed,
+					}),
+					Effect.as({status: "skipped", reason: skipReason} as MembershipOutcome),
+				)
+			}
+
+			return castVoteWithRetry(wallet, request, botSpaceId, spaceRegistryAddress).pipe(
+				Effect.tap((txHash) =>
+					Effect.logInfo("membership_vote_cast").pipe(
+						Effect.annotateLogs({
+							proposalId: request.id,
+							spaceId: request.spaceId,
+							targetId: request.requesterId,
+							txHash,
+						}),
+					),
+				),
+				Effect.map((txHash) => ({status: "voted", txHash}) as MembershipOutcome),
+				Effect.catchTag("RevertError", (e) =>
+					Effect.logInfo(e.expected ? "membership_skip_expected" : "membership_vote_reverted").pipe(
+						Effect.annotateLogs({
+							proposalId: request.id,
+							spaceId: request.spaceId,
+							error: e.message,
+							expected: e.expected,
+							durationMs: e.durationMs,
+						}),
+						Effect.as({status: "reverted", expected: e.expected} as MembershipOutcome),
+					),
+				),
+			)
+		}),
+	)
+}
+
+/**
+ * Process every request in one space: resolve its DAOSpace address once (cached for
+ * the space), then run requests sequentially. An InfraError propagates to the caller,
+ * which catches it at the space boundary so one space failing doesn't cancel others.
+ */
+export function processSpaceMembership(
+	wallet: SmartWallet,
+	spaceId: string,
+	requests: MembershipRequest[],
+	botSpaceId: Hex,
+	spaceRegistryAddress: Address,
+	nowSeconds: bigint,
+): Effect.Effect<MembershipOutcome[], InfraError> {
+	return resolveDaoSpaceAddress(wallet, spaceRegistryAddress, uuidToBytes16(spaceId)).pipe(
+		Effect.retry({schedule: infraRetryPolicy, while: (e) => e._tag === "InfraError"}),
+		Effect.flatMap((daoSpaceAddress) =>
+			Effect.forEach(
+				requests,
+				(request) =>
+					processMembershipRequest(
+						wallet,
+						request,
+						daoSpaceAddress,
+						botSpaceId,
+						spaceRegistryAddress,
+						nowSeconds,
+					),
+				{concurrency: 1},
+			),
+		),
+	)
+}
+
+// ---------------------------------------------------------------------------
 // Main — orchestration, error handling, flush, exit code
 // ---------------------------------------------------------------------------
 
@@ -314,7 +578,7 @@ const main = Effect.gen(function* () {
 
 	// Membership-accept bot wallet — a SECOND, distinct identity built from the
 	// dedicated bot key + space. Verified each run so a misconfigured bot fails
-	// fast; detection/voting are wired in a later PR (this path is inert for now).
+	// fast. It casts the membership YES votes; the executor wallet never does.
 	const botWallet = yield* createSmartWallet({
 		privateKey: config.membershipBotPrivateKey,
 		pimlicoApiKey: Redacted.value(config.pimlicoApiKey),
@@ -332,74 +596,171 @@ const main = Effect.gen(function* () {
 
 	const runStart = Date.now()
 	const nowSeconds = Math.floor(runStart / 1000)
-	const proposals = yield* findExecutableProposals(db, nowSeconds).pipe(Effect.withSpan("proposal-executor.detect"))
-	const bySpace = Map.groupBy(proposals, (p) => p.spaceId)
 
-	yield* Effect.logInfo("run_start").pipe(
-		Effect.annotateLogs({
-			proposalsFound: proposals.length,
-			spaces: bySpace.size,
-			ageCutoffTimestamp: nowSeconds - MAX_PROPOSAL_AGE,
-		}),
-	)
-
-	if (proposals.length === 0) {
-		yield* Effect.logInfo("run_end").pipe(
-			Effect.annotateLogs({succeeded: 0, failed: 0, skipped: 0, total: 0, durationMs: Date.now() - runStart}),
+	// --- Execute path (executor wallet) — total: catches its own failures so it never
+	// aborts the membership path. The only uncaught source below the space boundary is
+	// the detection query; its InfraError is converted to a failed summary here. ---
+	const runExecutePath: Effect.Effect<{
+		succeeded: number
+		failed: number
+		skipped: number
+		total: number
+		spaces: number
+	}> = Effect.gen(function* () {
+		const proposals = yield* findExecutableProposals(db, nowSeconds).pipe(
+			Effect.withSpan("proposal-executor.detect"),
 		)
-		return {succeeded: 0, failed: 0}
-	}
+		const bySpace = Map.groupBy(proposals, (p) => p.spaceId)
 
-	// Parallel across spaces (capped at 10 concurrent RPC connections), sequential
-	// within each space. Each space is independent — an InfraError in one space
-	// doesn't affect others.
-	const results = yield* Effect.forEach(
-		[...bySpace.entries()],
-		([spaceId, spaceProposals]) =>
-			executeSpaceProposals(
-				spaceId,
-				spaceProposals,
-				wallet,
-				config.executorSpaceId,
-				config.spaceRegistryAddress,
-			).pipe(
-				Effect.map(
-					(outcomes) =>
-						({
-							status: "ok" as const,
-							spaceId,
-							succeeded: outcomes.filter((r) => r !== "skipped").length,
-							skipped: outcomes.filter((r) => r === "skipped").length,
-						}) as const,
-				),
-				// Catch InfraError at the space level so one space failing
-				// doesn't cancel the others
-				Effect.catchTag("InfraError", (e) =>
-					Effect.logError("space_aborted").pipe(
-						Effect.annotateLogs({spaceId, error: e.message, proposalId: e.proposalId}),
-						Effect.as({status: "infraError" as const, spaceId, succeeded: 0, skipped: 0} as const),
+		yield* Effect.logInfo("run_start").pipe(
+			Effect.annotateLogs({
+				proposalsFound: proposals.length,
+				spaces: bySpace.size,
+				ageCutoffTimestamp: nowSeconds - MAX_PROPOSAL_AGE,
+			}),
+		)
+
+		if (proposals.length === 0) {
+			return {succeeded: 0, failed: 0, skipped: 0, total: 0, spaces: 0}
+		}
+
+		// Parallel across spaces (capped at 10 concurrent RPC connections), sequential
+		// within each space. Each space is independent — an InfraError in one space
+		// doesn't affect others.
+		const results = yield* Effect.forEach(
+			[...bySpace.entries()],
+			([spaceId, spaceProposals]) =>
+				executeSpaceProposals(
+					spaceId,
+					spaceProposals,
+					wallet,
+					config.executorSpaceId,
+					config.spaceRegistryAddress,
+				).pipe(
+					Effect.map(
+						(outcomes) =>
+							({
+								status: "ok" as const,
+								spaceId,
+								succeeded: outcomes.filter((r) => r !== "skipped").length,
+								skipped: outcomes.filter((r) => r === "skipped").length,
+							}) as const,
+					),
+					// Catch InfraError at the space level so one space failing
+					// doesn't cancel the others
+					Effect.catchTag("InfraError", (e) =>
+						Effect.logError("space_aborted").pipe(
+							Effect.annotateLogs({spaceId, error: e.message, proposalId: e.proposalId}),
+							Effect.as({status: "infraError" as const, spaceId, succeeded: 0, skipped: 0} as const),
+						),
 					),
 				),
+			{concurrency: 10},
+		)
+
+		return {
+			succeeded: results.reduce((n, r) => n + r.succeeded, 0),
+			failed: results.filter((r) => r.status === "infraError").length,
+			skipped: results.reduce((n, r) => n + r.skipped, 0),
+			total: proposals.length,
+			spaces: bySpace.size,
+		}
+	}).pipe(
+		Effect.catchTag("InfraError", (e) =>
+			Effect.logError("execute_path_failed").pipe(
+				Effect.annotateLogs({error: e.message, proposalId: e.proposalId}),
+				Effect.as({succeeded: 0, failed: 1, skipped: 0, total: 0, spaces: 0}),
 			),
-		{concurrency: 10},
+		),
 	)
 
-	const succeeded = results.reduce((n, r) => n + r.succeeded, 0)
-	const failed = results.filter((r) => r.status === "infraError").length
-	const skipped = results.reduce((n, r) => n + r.skipped, 0)
+	// --- Membership-accept path (bot wallet) — total: a detection-query failure is
+	// caught here so it never aborts the execute path. Per-space infra failures are
+	// caught at the space boundary; reverts are absorbed per request. Kill switch: an
+	// empty allowlist short-circuits findMembershipRequests to [] (no query). ---
+	const runMembershipPath: Effect.Effect<MembershipSummary> = Effect.gen(function* () {
+		const allowlistUuids = config.membershipAutoacceptSpaceIds.map(bytes16ToUuid)
+		const requests = yield* findMembershipRequests(db, allowlistUuids)
+		const bySpace = Map.groupBy(requests, (r) => r.spaceId)
+
+		yield* Effect.logInfo("membership_start").pipe(
+			Effect.annotateLogs({
+				allowlistSize: allowlistUuids.length,
+				requestsFound: requests.length,
+				spaces: bySpace.size,
+			}),
+		)
+
+		if (requests.length === 0) {
+			return {admitted: 0, skipped: 0, failed: 0, total: 0, spaces: 0}
+		}
+
+		// Read chain time once and reuse across the batch — the voting-window check
+		// compares against block.timestamp, not the pod wall clock.
+		const chainNow = yield* readChainTimeSeconds(botWallet)
+
+		const results: MembershipSpaceResult[] = yield* Effect.forEach(
+			[...bySpace.entries()],
+			([spaceId, spaceRequests]) =>
+				processSpaceMembership(
+					botWallet,
+					spaceId,
+					spaceRequests,
+					config.membershipBotSpaceId,
+					config.spaceRegistryAddress,
+					chainNow,
+				).pipe(
+					Effect.map((outcomes) => ({status: "ok" as const, spaceId, outcomes})),
+					// Catch InfraError at the space level so one space failing
+					// doesn't cancel the others.
+					Effect.catchTag("InfraError", (e) =>
+						Effect.logError("membership_space_aborted").pipe(
+							Effect.annotateLogs({spaceId, error: e.message, proposalId: e.proposalId}),
+							Effect.as({status: "infraError" as const, spaceId, outcomes: []}),
+						),
+					),
+				),
+			{concurrency: 10},
+		)
+
+		const {admitted, skipped, failed} = aggregateMembership(results)
+		return {admitted, skipped, failed, total: requests.length, spaces: bySpace.size}
+	}).pipe(
+		Effect.catchTag("InfraError", (e) =>
+			Effect.logError("membership_path_failed").pipe(
+				Effect.annotateLogs({error: e.message, proposalId: e.proposalId}),
+				Effect.as({admitted: 0, skipped: 0, failed: 1, total: 0, spaces: 0}),
+			),
+		),
+	)
+
+	// Run both paths concurrently — distinct wallets, isolated error boundaries. Each
+	// is total, so Effect.all cannot interrupt one when the other settles.
+	const [exec, membership] = yield* Effect.all([runExecutePath, runMembershipPath], {concurrency: 2})
 
 	yield* Effect.logInfo("run_end").pipe(
 		Effect.annotateLogs({
-			succeeded,
-			failed,
-			skipped,
-			total: proposals.length,
-			spaces: bySpace.size,
+			succeeded: exec.succeeded,
+			failed: exec.failed,
+			skipped: exec.skipped,
+			total: exec.total,
+			spaces: exec.spaces,
+			membershipAdmitted: membership.admitted,
+			membershipSkipped: membership.skipped,
+			membershipFailed: membership.failed,
+			membershipTotal: membership.total,
+			membershipSpaces: membership.spaces,
 			durationMs: Date.now() - runStart,
 		}),
 	)
 
-	return {succeeded, failed}
+	// Fold membership outcomes into the same succeeded/failed semantics the exit code
+	// uses: an admitted request counts as a success, an aborted space as a failure.
+	// Partial success (anything admitted/executed) → exit 0.
+	return {
+		succeeded: exec.succeeded + membership.admitted,
+		failed: exec.failed + membership.failed,
+	}
 }).pipe(
 	Effect.scoped,
 	// 270s top-level timeout — leaves 20s margin before K8s SIGKILL at 290s,

--- a/proposal-executor/src/index.ts
+++ b/proposal-executor/src/index.ts
@@ -700,7 +700,22 @@ const main = Effect.gen(function* () {
 	// empty allowlist short-circuits findMembershipRequests to [] (no query). ---
 	const runMembershipPath: Effect.Effect<MembershipSummary> = Effect.gen(function* () {
 		const allowlistUuids = config.membershipAutoacceptSpaceIds.map(bytes16ToUuid)
-		const requests = yield* findMembershipRequests(db, allowlistUuids)
+
+		// Kill switch: an empty allowlist does no work at all — no chain read, no query.
+		if (allowlistUuids.length === 0) {
+			yield* Effect.logInfo("membership_start").pipe(
+				Effect.annotateLogs({allowlistSize: 0, requestsFound: 0, spaces: 0}),
+			)
+			return {admitted: 0, skipped: 0, failed: 0, total: 0, spaces: 0}
+		}
+
+		// Read chain time once, BEFORE detection, and reuse it for both stages. Stage-1
+		// detection and stage-2 eligibility must share one notion of "now" and the same
+		// +CLOCK_SKEW_BUFFER window, or a request can land where stage 2 would vote but
+		// stage 1 never surfaces it (the pod wall clock can drift from block.timestamp).
+		const chainNow = yield* readChainTimeSeconds(botWallet)
+
+		const requests = yield* findMembershipRequests(db, allowlistUuids, Number(chainNow))
 		const bySpace = Map.groupBy(requests, (r) => r.spaceId)
 
 		yield* Effect.logInfo("membership_start").pipe(
@@ -714,10 +729,6 @@ const main = Effect.gen(function* () {
 		if (requests.length === 0) {
 			return {admitted: 0, skipped: 0, failed: 0, total: 0, spaces: 0}
 		}
-
-		// Read chain time once and reuse across the batch — the voting-window check
-		// compares against block.timestamp, not the pod wall clock.
-		const chainNow = yield* readChainTimeSeconds(botWallet)
 
 		const results: MembershipSpaceResult[] = yield* Effect.forEach(
 			[...bySpace.entries()],

--- a/proposal-executor/src/index.ts
+++ b/proposal-executor/src/index.ts
@@ -596,24 +596,6 @@ const main = Effect.gen(function* () {
 
 	yield* verifyExecutorSetup(wallet, config.executorSpaceId, config.spaceRegistryAddress)
 
-	// Membership-accept bot wallet — a SECOND, distinct identity built from the
-	// dedicated bot key + space. Verified each run so a misconfigured bot fails
-	// fast. It casts the membership YES votes; the executor wallet never does.
-	const botWallet = yield* createSmartWallet({
-		privateKey: config.membershipBotPrivateKey,
-		pimlicoApiKey: Redacted.value(config.pimlicoApiKey),
-		executorSpaceId: config.membershipBotSpaceId,
-		spaceRegistryAddress: config.spaceRegistryAddress,
-		rpcUrl: Redacted.value(config.rpcUrl),
-		chainId: config.chainId,
-	})
-
-	yield* Effect.logInfo("wallet_ready").pipe(
-		Effect.annotateLogs({identity: "membership-bot", safeAddress: botWallet.safeAddress}),
-	)
-
-	yield* verifyExecutorSetup(botWallet, config.membershipBotSpaceId, config.spaceRegistryAddress)
-
 	const runStart = Date.now()
 	const nowSeconds = Math.floor(runStart / 1000)
 
@@ -701,13 +683,36 @@ const main = Effect.gen(function* () {
 	const runMembershipPath: Effect.Effect<MembershipSummary> = Effect.gen(function* () {
 		const allowlistUuids = config.membershipAutoacceptSpaceIds.map(bytes16ToUuid)
 
-		// Kill switch: an empty allowlist does no work at all — no chain read, no query.
+		// Kill switch: an empty allowlist does no work at all — no chain read, no query,
+		// and no bot wallet setup. This fully disables the membership-bot dependency
+		// (key, space, Pimlico/RPC), so misconfiguration there can never affect a run.
 		if (allowlistUuids.length === 0) {
 			yield* Effect.logInfo("membership_start").pipe(
 				Effect.annotateLogs({allowlistSize: 0, requestsFound: 0, spaces: 0}),
 			)
 			return {admitted: 0, skipped: 0, failed: 0, total: 0, spaces: 0}
 		}
+
+		// Membership-accept bot wallet — a SECOND, distinct identity built from the
+		// dedicated bot key + space. Built and verified inside this path (not main) so a
+		// misconfigured bot or transient infra failure (Pimlico/bundler/RPC) is caught by
+		// the membership path's own InfraError boundary and never aborts the execute path.
+		// Verified each run so a misconfigured bot fails fast. It casts the membership YES
+		// votes; the executor wallet never does.
+		const botWallet = yield* createSmartWallet({
+			privateKey: config.membershipBotPrivateKey,
+			pimlicoApiKey: Redacted.value(config.pimlicoApiKey),
+			executorSpaceId: config.membershipBotSpaceId,
+			spaceRegistryAddress: config.spaceRegistryAddress,
+			rpcUrl: Redacted.value(config.rpcUrl),
+			chainId: config.chainId,
+		})
+
+		yield* Effect.logInfo("wallet_ready").pipe(
+			Effect.annotateLogs({identity: "membership-bot", safeAddress: botWallet.safeAddress}),
+		)
+
+		yield* verifyExecutorSetup(botWallet, config.membershipBotSpaceId, config.spaceRegistryAddress)
 
 		// Read chain time once, BEFORE detection, and reuse it for both stages. Stage-1
 		// detection and stage-2 eligibility must share one notion of "now" and the same

--- a/proposal-executor/src/index.ts
+++ b/proposal-executor/src/index.ts
@@ -454,6 +454,27 @@ function readTallyWithRetry(
 }
 
 /**
+ * Resolve a space's DAOSpace address (stage-2 prerequisite) with the same per-attempt
+ * timeout + InfraError retry as the other membership RPC reads. The timeout guards
+ * against a hung lookup that never rejects — without it a single stuck call would block
+ * the fiber until the global 270s run timeout, stalling every other space.
+ */
+function resolveDaoSpaceAddressWithRetry(
+	wallet: SmartWallet,
+	spaceRegistryAddress: Address,
+	daoSpaceId: Hex,
+): Effect.Effect<Address, InfraError> {
+	return resolveDaoSpaceAddress(wallet, spaceRegistryAddress, daoSpaceId).pipe(
+		Effect.timeoutFail({
+			duration: Duration.seconds(30),
+			onTimeout: () =>
+				new InfraError({message: "DAO space address resolution timed out after 30s", durationMs: 30_000}),
+		}),
+		Effect.retry({schedule: infraRetryPolicy, while: (e) => e._tag === "InfraError"}),
+	)
+}
+
+/**
  * Process one membership request: stage-2 on-chain read → eligibility gate → vote.
  * A RevertError is caught and turned into a `reverted` outcome (logged, not fatal) so
  * it never aborts the rest of the space. An InfraError propagates to abort this space
@@ -528,8 +549,7 @@ export function processSpaceMembership(
 	spaceRegistryAddress: Address,
 	nowSeconds: bigint,
 ): Effect.Effect<MembershipOutcome[], InfraError> {
-	return resolveDaoSpaceAddress(wallet, spaceRegistryAddress, uuidToBytes16(spaceId)).pipe(
-		Effect.retry({schedule: infraRetryPolicy, while: (e) => e._tag === "InfraError"}),
+	return resolveDaoSpaceAddressWithRetry(wallet, spaceRegistryAddress, uuidToBytes16(spaceId)).pipe(
 		Effect.flatMap((daoSpaceAddress) =>
 			Effect.forEach(
 				requests,

--- a/proposal-executor/src/membership.ts
+++ b/proposal-executor/src/membership.ts
@@ -1,0 +1,240 @@
+/**
+ * Membership-accept path: stage-2 on-chain eligibility read + PROPOSAL_VOTED (Yes)
+ * vote cast, both performed by the dedicated bot wallet.
+ *
+ * Stage 1 (the indexer side) lives in detect.ts (findMembershipRequests). This module
+ * is the authoritative stage-2 half of the "untouched" check: it reads the live on-chain
+ * tally from the per-space DAOSpace contract and casts a single YES vote on a still-
+ * untouched request. Because allowlisted spaces run with fastPathFlatThreshold = 1, that
+ * one YES vote meets the threshold and the contract executes the AddMember action in the
+ * same transaction — admitting the joiner with no human in the loop.
+ *
+ * Reuses the executor's smart-wallet, enter() calldata pattern, encoding helpers, and
+ * error classification (classifyAsRevert) wholesale — see execute.ts.
+ */
+
+import {Effect} from "effect"
+import {type Address, encodeAbiParameters, encodeFunctionData, type Hex} from "viem"
+import {
+	DAOSpaceAbi,
+	EMPTY_SIGNATURE,
+	InfraError,
+	PROPOSAL_VOTED_ACTION,
+	RevertError,
+	SpaceRegistryAbi,
+	VOTE_YES,
+} from "./contracts.js"
+import type {MembershipRequest} from "./detect.js"
+import {classifyAsRevert, padBytes16ToBytes32, type SmartWallet, uuidToBytes16} from "./execute.js"
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** The on-chain Tally plus the executed flag from getLatestProposalInformation. */
+export interface ProposalTally {
+	executed: boolean
+	yes: bigint
+	no: bigint
+	abstain: bigint
+}
+
+/** SpaceRegistry.spaceIdToAddress returns this for an unregistered space. */
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+
+// ---------------------------------------------------------------------------
+// Sanitization — never leak a bundler URL's API key into an error message.
+// Defense in depth: mirrors the pattern in execute.ts / detect.ts.
+// ---------------------------------------------------------------------------
+
+function sanitizeError(error: unknown): string {
+	return String(error).replace(/apikey=[^\s&"]+/gi, "apikey=<redacted>")
+}
+
+// ---------------------------------------------------------------------------
+// Vote-data encoding
+// ---------------------------------------------------------------------------
+
+/**
+ * ABI-encode the PROPOSAL_VOTED data payload: abi.encode(bytes16 proposalId, uint8 voteOption).
+ * A YES vote passes VOTE_YES (1) — see the IDAOSpace.VoteOption enum (None=0, Yes=1, No=2, Abstain=3).
+ */
+export function encodeVoteData(proposalIdHex: Hex, voteOption: number): Hex {
+	return encodeAbiParameters(
+		[
+			{name: "proposalId", type: "bytes16"},
+			{name: "voteOption", type: "uint8"},
+		],
+		[proposalIdHex, voteOption],
+	)
+}
+
+// ---------------------------------------------------------------------------
+// DAO space address resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a DAO space's on-chain contract address via SpaceRegistry.spaceIdToAddress.
+ * The vote-tally getters live on the per-space DAOSpace contract, not the registry, so
+ * this must be resolved before reading the tally. Resolve once per space (cache per run).
+ *
+ * A zero address means the space is unregistered (misconfiguration) — surfaced as an
+ * InfraError so the space is skipped and retried next cycle.
+ */
+export function resolveDaoSpaceAddress(
+	wallet: SmartWallet,
+	spaceRegistryAddress: Address,
+	daoSpaceId: Hex,
+): Effect.Effect<Address, InfraError> {
+	return Effect.tryPromise({
+		try: async () => {
+			const address = await wallet.publicClient.readContract({
+				address: spaceRegistryAddress,
+				abi: SpaceRegistryAbi,
+				functionName: "spaceIdToAddress",
+				args: [daoSpaceId],
+			})
+			if (address.toLowerCase() === ZERO_ADDRESS) {
+				throw new Error(
+					`DAO space ${daoSpaceId} is not registered (spaceIdToAddress returned the zero address)`,
+				)
+			}
+			return address
+		},
+		catch: (error) =>
+			new InfraError({message: `DAO space address resolution failed: ${sanitizeError(error)}`, durationMs: 0}),
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Stage-2 authoritative untouched read
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the live on-chain tally for a proposal from its DAOSpace contract.
+ *
+ * This is the authoritative stage-2 untouched check. It closes the indexing-lag window
+ * (a vote may already be on-chain before the indexer surfaces it) and, because the bot's
+ * own prior vote shows up here immediately, it makes the job idempotent across cycles.
+ */
+export function readProposalTally(
+	wallet: SmartWallet,
+	daoSpaceAddress: Address,
+	proposalId: string,
+): Effect.Effect<ProposalTally, InfraError> {
+	return Effect.tryPromise({
+		try: async () => {
+			const proposalIdHex = uuidToBytes16(proposalId)
+			const [executed, , , tally] = await wallet.publicClient.readContract({
+				address: daoSpaceAddress,
+				abi: DAOSpaceAbi,
+				functionName: "getLatestProposalInformation",
+				args: [proposalIdHex],
+			})
+			return {executed, yes: tally.yes, no: tally.no, abstain: tally.abstain}
+		},
+		catch: (error) =>
+			new InfraError({
+				proposalId,
+				message: `Proposal tally read failed: ${sanitizeError(error)}`,
+				durationMs: 0,
+			}),
+	})
+}
+
+/**
+ * A request is eligible for an auto-accept YES vote iff it has not executed and no vote of
+ * any kind is recorded on-chain. A non-zero tally covers both a human's vote (indexing lag)
+ * and the bot's own in-flight vote → SKIP (reason: onchain_tally_nonzero), idempotency.
+ */
+export function isEligibleToVote(tally: ProposalTally): boolean {
+	return !tally.executed && tally.yes === 0n && tally.no === 0n && tally.abstain === 0n
+}
+
+// ---------------------------------------------------------------------------
+// Vote cast
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify a vote-cast failure, reusing the executor's revert detection.
+ *
+ * Expected reverts (the request is already resolved by someone else): "already executed",
+ * CanNotExecute, InvalidAction → RevertError(expected=true), logged INFO. A CanNotVote
+ * revert means the bot lacks the EDITOR role — a real misconfiguration → expected=false,
+ * skipped and retried next cycle. Everything else is infrastructure → InfraError.
+ */
+function classifyVoteError(error: unknown, proposalId: string, durationMs: number): RevertError | InfraError {
+	const message = sanitizeError(error)
+	const errorName = error instanceof Error ? error.name : typeof error
+
+	if (classifyAsRevert(error, errorName, message)) {
+		const isExpected =
+			message.includes("already executed") ||
+			message.includes("ProposalAlreadyExecuted") ||
+			message.includes("CanNotExecute") ||
+			message.includes("InvalidAction")
+		return new RevertError({proposalId, message: `[${errorName}] ${message}`, expected: isExpected, durationMs})
+	}
+
+	return new InfraError({proposalId, message: `[${errorName}] ${message}`, durationMs})
+}
+
+/**
+ * Cast a single YES vote on a membership request via the bot wallet.
+ *
+ * Builds the same gas-sponsored enter() UserOperation the executor uses, with the
+ * PROPOSAL_VOTED action and the (proposalId, Yes) vote data:
+ *
+ *   enter(botSpaceId, daoSpaceId, PROPOSAL_VOTED, bytes32(proposalId),
+ *         abi.encode(bytes16 proposalId, uint8 1), "0x")
+ *
+ * Returns the transaction hash on success. Errors are classified as RevertError /
+ * InfraError; retry and timeout are composed externally in index.ts.
+ */
+export function castMembershipVote(
+	wallet: SmartWallet,
+	request: MembershipRequest,
+	botSpaceId: Hex,
+	spaceRegistryAddress: Address,
+): Effect.Effect<string, RevertError | InfraError> {
+	// Effect.suspend captures `start` fresh on each retry attempt so durationMs reflects
+	// only the current attempt's wall time (matches executeProposal).
+	return Effect.suspend(() => {
+		const start = Date.now()
+
+		return Effect.tryPromise({
+			try: async () => {
+				const daoSpaceId = uuidToBytes16(request.spaceId)
+				const proposalIdHex = uuidToBytes16(request.id)
+
+				const calldata = encodeFunctionData({
+					abi: SpaceRegistryAbi,
+					functionName: "enter",
+					args: [
+						botSpaceId, // bytes16: membership bot's personal space ID
+						daoSpaceId, // bytes16: DAO space being joined
+						PROPOSAL_VOTED_ACTION, // bytes32: action hash
+						padBytes16ToBytes32(proposalIdHex), // bytes32: topic = bytes32(proposalId), left-aligned
+						encodeVoteData(proposalIdHex, VOTE_YES), // bytes: abi.encode(bytes16 proposalId, uint8 1)
+						EMPTY_SIGNATURE, // bytes: "0x" (ignored when msg.sender == _fromSpace)
+					],
+				})
+
+				const account = wallet.smartAccountClient.account
+				if (!account) {
+					throw new Error("Smart account client has no account — bot wallet was not initialized correctly")
+				}
+
+				const hash = await wallet.smartAccountClient.sendTransaction({
+					account,
+					chain: wallet.chain,
+					to: spaceRegistryAddress,
+					data: calldata,
+				})
+
+				return hash
+			},
+			catch: (error) => classifyVoteError(error, request.id, Date.now() - start),
+		})
+	})
+}

--- a/proposal-executor/src/membership.ts
+++ b/proposal-executor/src/membership.ts
@@ -111,23 +111,31 @@ export function resolveDaoSpaceAddress(
 	spaceRegistryAddress: Address,
 	daoSpaceId: Hex,
 ): Effect.Effect<Address, InfraError> {
-	return Effect.tryPromise({
-		try: async () => {
-			const address = await wallet.publicClient.readContract({
-				address: spaceRegistryAddress,
-				abi: SpaceRegistryAbi,
-				functionName: "spaceIdToAddress",
-				args: [daoSpaceId],
-			})
-			if (address.toLowerCase() === ZERO_ADDRESS) {
-				throw new Error(
-					`DAO space ${daoSpaceId} is not registered (spaceIdToAddress returned the zero address)`,
-				)
-			}
-			return address
-		},
-		catch: (error) =>
-			new InfraError({message: `DAO space address resolution failed: ${sanitizeError(error)}`, durationMs: 0}),
+	// Effect.suspend captures `start` fresh on each retry attempt, so durationMs
+	// reflects only the current attempt's wall time — mirrors executeProposal().
+	return Effect.suspend(() => {
+		const start = Date.now()
+		return Effect.tryPromise({
+			try: async () => {
+				const address = await wallet.publicClient.readContract({
+					address: spaceRegistryAddress,
+					abi: SpaceRegistryAbi,
+					functionName: "spaceIdToAddress",
+					args: [daoSpaceId],
+				})
+				if (address.toLowerCase() === ZERO_ADDRESS) {
+					throw new Error(
+						`DAO space ${daoSpaceId} is not registered (spaceIdToAddress returned the zero address)`,
+					)
+				}
+				return address
+			},
+			catch: (error) =>
+				new InfraError({
+					message: `DAO space address resolution failed: ${sanitizeError(error)}`,
+					durationMs: Date.now() - start,
+				}),
+		})
 	})
 }
 
@@ -147,30 +155,35 @@ export function readProposalTally(
 	daoSpaceAddress: Address,
 	proposalId: string,
 ): Effect.Effect<ProposalTally, InfraError> {
-	return Effect.tryPromise({
-		try: async () => {
-			const proposalIdHex = uuidToBytes16(proposalId)
-			const [executed, , parameters, tally] = await wallet.publicClient.readContract({
-				address: daoSpaceAddress,
-				abi: DAOSpaceAbi,
-				functionName: "getLatestProposalInformation",
-				args: [proposalIdHex],
-			})
-			return {
-				executed,
-				yes: tally.yes,
-				no: tally.no,
-				abstain: tally.abstain,
-				startDate: parameters.startDate,
-				lastDate: parameters.lastDate,
-			}
-		},
-		catch: (error) =>
-			new InfraError({
-				proposalId,
-				message: `Proposal tally read failed: ${sanitizeError(error)}`,
-				durationMs: 0,
-			}),
+	// Effect.suspend captures `start` fresh on each retry attempt, so durationMs
+	// reflects only the current attempt's wall time — mirrors executeProposal().
+	return Effect.suspend(() => {
+		const start = Date.now()
+		return Effect.tryPromise({
+			try: async () => {
+				const proposalIdHex = uuidToBytes16(proposalId)
+				const [executed, , parameters, tally] = await wallet.publicClient.readContract({
+					address: daoSpaceAddress,
+					abi: DAOSpaceAbi,
+					functionName: "getLatestProposalInformation",
+					args: [proposalIdHex],
+				})
+				return {
+					executed,
+					yes: tally.yes,
+					no: tally.no,
+					abstain: tally.abstain,
+					startDate: parameters.startDate,
+					lastDate: parameters.lastDate,
+				}
+			},
+			catch: (error) =>
+				new InfraError({
+					proposalId,
+					message: `Proposal tally read failed: ${sanitizeError(error)}`,
+					durationMs: Date.now() - start,
+				}),
+		})
 	})
 }
 

--- a/proposal-executor/src/membership.ts
+++ b/proposal-executor/src/membership.ts
@@ -99,6 +99,12 @@ export function encodeVoteData(proposalIdHex: Hex, voteOption: number): Hex {
  *
  * A zero address means the space is unregistered (misconfiguration) — surfaced as an
  * InfraError so the space is skipped and retried next cycle.
+ *
+ * TODO(caching): this helper always performs a readContract() despite the "cache per run"
+ * note above — caching is the caller's responsibility today, which is easy to get wrong once
+ * a future orchestrator reuses this module. Either (a) add a memoizing wrapper here, e.g.
+ * makeDaoSpaceResolver(wallet, registryAddr) returning a fn backed by an internal
+ * Map<Hex, Address>, or (b) reword the docstring to state explicitly that callers must cache.
  */
 export function resolveDaoSpaceAddress(
 	wallet: SmartWallet,

--- a/proposal-executor/src/membership.ts
+++ b/proposal-executor/src/membership.ts
@@ -204,8 +204,11 @@ export function readChainTimeSeconds(wallet: SmartWallet): Effect.Effect<bigint>
 }
 
 /**
- * A proposal's voting window is open iff now is at/after startDate and before
- * lastDate extended by the clock-skew buffer. The close is widened, not narrowed:
+ * A proposal's voting window is open iff now is at/after startDate and at/before
+ * lastDate extended by the clock-skew buffer. The bound is inclusive on both ends,
+ * matching the inclusive upper bound in the stage-1 detection SQL ($2 <= end_time +
+ * skew) so the two stages agree at the skew boundary. The close is widened, not
+ * narrowed:
  * during the final CLOCK_SKEW_BUFFER_SECONDS — and up to that long past lastDate —
  * the bot still votes, accepting a possible late revert over wrongly skipping a
  * still-open request. now should be a chain-sourced timestamp (readChainTimeSeconds).
@@ -216,7 +219,7 @@ export function isVotingOpen(
 	lastDate: bigint,
 	skewSeconds: bigint = CLOCK_SKEW_BUFFER_SECONDS,
 ): boolean {
-	return startDate <= nowSeconds && nowSeconds < lastDate + skewSeconds
+	return startDate <= nowSeconds && nowSeconds <= lastDate + skewSeconds
 }
 
 /**

--- a/proposal-executor/src/membership.ts
+++ b/proposal-executor/src/membership.ts
@@ -31,16 +31,35 @@ import {classifyAsRevert, padBytes16ToBytes32, type SmartWallet, uuidToBytes16} 
 // Types
 // ---------------------------------------------------------------------------
 
-/** The on-chain Tally plus the executed flag from getLatestProposalInformation. */
+/**
+ * The on-chain Tally plus the executed flag and voting-window bounds from
+ * getLatestProposalInformation. startDate/lastDate come from ProposalParameters
+ * and are authoritative: the protocol rejects a vote whose block.timestamp falls
+ * outside [startDate, lastDate], so stage-2 eligibility must honour them.
+ */
 export interface ProposalTally {
 	executed: boolean
 	yes: bigint
 	no: bigint
 	abstain: bigint
+	/** Unix seconds the voting window opens (ProposalParameters.startDate). */
+	startDate: bigint
+	/** Unix seconds the voting window closes (ProposalParameters.lastDate); later votes revert. */
+	lastDate: bigint
 }
 
 /** SpaceRegistry.spaceIdToAddress returns this for an unregistered space. */
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+
+/**
+ * Seconds of slack added past the on-chain voting window's close when deciding
+ * whether to vote. The buffer is applied leniently (it extends the window rather
+ * than shrinking it): missing a genuinely-open request during its final seconds
+ * is worse than casting a vote that the contract rejects. So near the boundary we
+ * prefer to vote and risk an at-most-CLOCK_SKEW_BUFFER_SECONDS-late revert over a
+ * conservative skip. Mirrors the detection query's clock-skew constant.
+ */
+export const CLOCK_SKEW_BUFFER_SECONDS = 60n
 
 // ---------------------------------------------------------------------------
 // Sanitization — never leak a bundler URL's API key into an error message.
@@ -125,13 +144,20 @@ export function readProposalTally(
 	return Effect.tryPromise({
 		try: async () => {
 			const proposalIdHex = uuidToBytes16(proposalId)
-			const [executed, , , tally] = await wallet.publicClient.readContract({
+			const [executed, , parameters, tally] = await wallet.publicClient.readContract({
 				address: daoSpaceAddress,
 				abi: DAOSpaceAbi,
 				functionName: "getLatestProposalInformation",
 				args: [proposalIdHex],
 			})
-			return {executed, yes: tally.yes, no: tally.no, abstain: tally.abstain}
+			return {
+				executed,
+				yes: tally.yes,
+				no: tally.no,
+				abstain: tally.abstain,
+				startDate: parameters.startDate,
+				lastDate: parameters.lastDate,
+			}
 		},
 		catch: (error) =>
 			new InfraError({
@@ -143,12 +169,61 @@ export function readProposalTally(
 }
 
 /**
- * A request is eligible for an auto-accept YES vote iff it has not executed and no vote of
- * any kind is recorded on-chain. A non-zero tally covers both a human's vote (indexing lag)
- * and the bot's own in-flight vote → SKIP (reason: onchain_tally_nonzero), idempotency.
+ * Read the current chain time (latest block's timestamp) as Unix seconds.
+ *
+ * The voting-window check should compare against block.timestamp — the same clock
+ * the protocol enforces — not the pod's wall clock, which can drift. If the block
+ * read fails (transient RPC hiccup), fall back to the pod wall clock rather than
+ * failing the batch; CLOCK_SKEW_BUFFER_SECONDS absorbs the drift. Read once per
+ * run and reuse across requests in the batch.
  */
-export function isEligibleToVote(tally: ProposalTally): boolean {
-	return !tally.executed && tally.yes === 0n && tally.no === 0n && tally.abstain === 0n
+export function readChainTimeSeconds(wallet: SmartWallet): Effect.Effect<bigint> {
+	return Effect.tryPromise({
+		try: async () => (await wallet.publicClient.getBlock()).timestamp,
+		catch: (error) => error,
+	}).pipe(Effect.orElseSucceed(() => BigInt(Math.floor(Date.now() / 1000))))
+}
+
+/**
+ * A proposal's voting window is open iff now is at/after startDate and before
+ * lastDate extended by the clock-skew buffer. The close is widened, not narrowed:
+ * during the final CLOCK_SKEW_BUFFER_SECONDS — and up to that long past lastDate —
+ * the bot still votes, accepting a possible late revert over wrongly skipping a
+ * still-open request. now should be a chain-sourced timestamp (readChainTimeSeconds).
+ */
+export function isVotingOpen(
+	nowSeconds: bigint,
+	startDate: bigint,
+	lastDate: bigint,
+	skewSeconds: bigint = CLOCK_SKEW_BUFFER_SECONDS,
+): boolean {
+	return startDate <= nowSeconds && nowSeconds < lastDate + skewSeconds
+}
+
+/**
+ * A request is eligible for an auto-accept YES vote iff:
+ * - it has not executed,
+ * - no vote of any kind is recorded on-chain — a non-zero tally covers both a human's
+ *   vote (indexing lag) and the bot's own in-flight vote → SKIP (onchain_tally_nonzero),
+ *   which is what makes the job idempotent across cycles, and
+ * - its on-chain voting window is still open (now within [startDate, lastDate], with the
+ *   clock-skew buffer applied to the close). The protocol rejects votes outside the
+ *   window, so this is the authoritative stage-2 guard against voting on a closed request.
+ *
+ * now should be a chain-sourced timestamp (readChainTimeSeconds).
+ */
+export function isEligibleToVote(
+	tally: ProposalTally,
+	nowSeconds: bigint,
+	skewSeconds: bigint = CLOCK_SKEW_BUFFER_SECONDS,
+): boolean {
+	return (
+		!tally.executed &&
+		tally.yes === 0n &&
+		tally.no === 0n &&
+		tally.abstain === 0n &&
+		isVotingOpen(nowSeconds, tally.startDate, tally.lastDate, skewSeconds)
+	)
 }
 
 // ---------------------------------------------------------------------------

--- a/proposal-executor/tests/contracts.test.ts
+++ b/proposal-executor/tests/contracts.test.ts
@@ -8,6 +8,7 @@
  */
 
 import {describe, expect, test} from "bun:test"
+import {decodeFunctionResult} from "viem"
 import {DAOSpaceAbi, PROPOSAL_VOTED_ACTION, SpaceRegistryAbi, VOTE_YES} from "../src/contracts.js"
 
 // ---------------------------------------------------------------------------
@@ -64,6 +65,67 @@ describe("DAOSpaceAbi", () => {
 		expect(tally?.type).toBe("tuple")
 		expect(tally?.components?.map((c) => c.name)).toEqual(["yes", "no", "abstain"])
 		expect(tally?.components?.every((c) => c.type === "uint256")).toBe(true)
+	})
+
+	test("ProposalParameters matches the deployed 5-field struct (votingMode, supportThreshold, quorum, startDate, lastDate)", () => {
+		const params = getInfo?.outputs?.[2]
+		expect(params?.type).toBe("tuple")
+		// Authoritative source: geo-contracts-foundry IDAOSpace.ProposalParameters.
+		// The struct has exactly 5 fields; an over- or under-count silently misaligns
+		// the startDate/lastDate slot reads in readProposalTally (overflow / garbage),
+		// which is what the on-chain decode regression below guards against end-to-end.
+		expect(params?.components?.map((c) => c.name)).toEqual([
+			"votingMode",
+			"supportThreshold",
+			"quorum",
+			"startDate",
+			"lastDate",
+		])
+		expect(params?.components?.map((c) => c.type)).toEqual(["uint8", "uint256", "uint256", "uint256", "uint256"])
+	})
+
+	// Regression for the ABI struct-shape bug: decode REAL on-chain return bytes (captured
+	// from getLatestProposalInformation on the Geo testnet) through DAOSpaceAbi and assert the
+	// fields land correctly. The earlier 8-field ProposalParameters misaligned the parameters
+	// slots, so startDate/lastDate read garbage and viem threw a safe-integer overflow. A
+	// fixture-based decode — not a self-consistent round-trip — is the only thing that catches
+	// an ABI that doesn't match the deployed contract. Words: executed=false, creator (bytes16),
+	// params(votingMode=1, supportThreshold=0, quorum=1, startDate, lastDate), tally(0,0,0), 1 action.
+	test("decodes a real getLatestProposalInformation return with correct startDate/lastDate", () => {
+		const raw = ("0x" +
+			"0000000000000000000000000000000000000000000000000000000000000000" + // executed = false
+			"924ac01ba0a4355f16f40e0dfdc4823000000000000000000000000000000000" + // creator (bytes16)
+			"0000000000000000000000000000000000000000000000000000000000000001" + // votingMode = Fast
+			"0000000000000000000000000000000000000000000000000000000000000000" + // supportThreshold
+			"0000000000000000000000000000000000000000000000000000000000000001" + // quorum
+			"000000000000000000000000000000000000000000000000000000006a2c457c" + // startDate = 1781286268
+			"000000000000000000000000000000000000000000000000000000006a2d96fc" + // lastDate  = 1781372668
+			"0000000000000000000000000000000000000000000000000000000000000000" + // tally.yes
+			"0000000000000000000000000000000000000000000000000000000000000000" + // tally.no
+			"0000000000000000000000000000000000000000000000000000000000000000" + // tally.abstain
+			"0000000000000000000000000000000000000000000000000000000000000160" + // actions offset
+			"0000000000000000000000000000000000000000000000000000000000000001" + // actions.length = 1
+			"0000000000000000000000000000000000000000000000000000000000000020" + // actions[0] offset
+			"0000000000000000000000007fadb2a38e44a34e6256273b149e6f436e911713" + // actions[0].to
+			"0000000000000000000000000000000000000000000000000000000000000000" + // actions[0].value
+			"0000000000000000000000000000000000000000000000000000000000000060" + // actions[0].data offset
+			"0000000000000000000000000000000000000000000000000000000000000024" + // actions[0].data length = 36
+			"2afbe350924ac01ba0a4355f16f40e0dfdc48230000000000000000000000000" + // actions[0].data
+			"0000000000000000000000000000000000000000000000000000000000000000") as `0x${string}` // data tail pad
+
+		const [executed, creator, parameters, tally] = decodeFunctionResult({
+			abi: DAOSpaceAbi,
+			functionName: "getLatestProposalInformation",
+			data: raw,
+		})
+
+		expect(executed).toBe(false)
+		expect(creator).toBe("0x924ac01ba0a4355f16f40e0dfdc48230")
+		expect(parameters.startDate).toBe(1781286268n)
+		expect(parameters.lastDate).toBe(1781372668n)
+		expect(tally.yes).toBe(0n)
+		expect(tally.no).toBe(0n)
+		expect(tally.abstain).toBe(0n)
 	})
 })
 

--- a/proposal-executor/tests/contracts.test.ts
+++ b/proposal-executor/tests/contracts.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for contracts.ts — membership vote constants and the DAOSpace /
+ * SpaceRegistry ABI view subsets used by the membership-accept path.
+ *
+ * These pin the on-chain encoding (VoteOption.Yes = 1) and the action hash
+ * against the authoritative source (geo-contracts-foundry IDAOSpace), and
+ * verify the ABI subsets expose the view names the membership path calls.
+ */
+
+import {describe, expect, test} from "bun:test"
+import {DAOSpaceAbi, PROPOSAL_VOTED_ACTION, SpaceRegistryAbi, VOTE_YES} from "../src/contracts.js"
+
+// ---------------------------------------------------------------------------
+// VOTE_YES — guards the documented enum discrepancy
+// ---------------------------------------------------------------------------
+
+describe("VOTE_YES constant", () => {
+	test("is 1 (IDAOSpace.VoteOption.Yes: None=0, Yes=1, No=2, Abstain=3)", () => {
+		// Source of truth: geo-contracts-foundry/src/interfaces/IDAOSpace.sol
+		expect(VOTE_YES).toBe(1)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// PROPOSAL_VOTED_ACTION — keccak256('GOVERNANCE.PROPOSAL_VOTED')
+// ---------------------------------------------------------------------------
+
+describe("PROPOSAL_VOTED_ACTION constant", () => {
+	test("matches the action hash from hermes-substream", () => {
+		expect(PROPOSAL_VOTED_ACTION).toBe("0x4ebf5f29676cedf7e2e4d346a8433289278f95a9fda73691dc1ce24574d5819e")
+	})
+
+	test("is a 32-byte hex string (0x + 64 hex chars)", () => {
+		expect(PROPOSAL_VOTED_ACTION.length).toBe(66)
+		expect(PROPOSAL_VOTED_ACTION).toMatch(/^0x[0-9a-f]{64}$/)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// DAOSpaceAbi — getLatestProposalInformation view (stage-2 tally read)
+// ---------------------------------------------------------------------------
+
+describe("DAOSpaceAbi", () => {
+	const getInfo = DAOSpaceAbi.find(
+		(entry) => entry.type === "function" && entry.name === "getLatestProposalInformation",
+	)
+
+	test("exposes getLatestProposalInformation", () => {
+		expect(getInfo).toBeDefined()
+	})
+
+	test("takes a single bytes16 proposalId input", () => {
+		expect(getInfo?.inputs).toHaveLength(1)
+		expect(getInfo?.inputs[0]?.type).toBe("bytes16")
+	})
+
+	test("returns the (executed, creator, parameters, tally, actions) tuple", () => {
+		const outputs = getInfo?.outputs ?? []
+		expect(outputs.map((o) => o.type)).toEqual(["bool", "bytes16", "tuple", "tuple", "tuple[]"])
+	})
+
+	test("decodes the Tally tuple as (yes, no, abstain) uint256 components", () => {
+		const tally = getInfo?.outputs?.[3]
+		expect(tally?.type).toBe("tuple")
+		expect(tally?.components?.map((c) => c.name)).toEqual(["yes", "no", "abstain"])
+		expect(tally?.components?.every((c) => c.type === "uint256")).toBe(true)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// SpaceRegistryAbi — spaceIdToAddress view (DAOSpace address resolution)
+// ---------------------------------------------------------------------------
+
+describe("SpaceRegistryAbi", () => {
+	test("exposes spaceIdToAddress(bytes16) → address", () => {
+		const fn = SpaceRegistryAbi.find((entry) => entry.type === "function" && entry.name === "spaceIdToAddress")
+		expect(fn).toBeDefined()
+		expect(fn?.inputs[0]?.type).toBe("bytes16")
+		expect(fn?.outputs[0]?.type).toBe("address")
+	})
+
+	test("still exposes the pre-existing enter and addressToSpaceId views", () => {
+		const names = SpaceRegistryAbi.map((entry) => entry.name)
+		expect(names).toContain("enter")
+		expect(names).toContain("addressToSpaceId")
+	})
+})

--- a/proposal-executor/tests/detect.test.ts
+++ b/proposal-executor/tests/detect.test.ts
@@ -132,9 +132,14 @@ describe("membership detection SQL", () => {
 
 	test("guards against corrupt future timestamps but applies no age cutoff", () => {
 		expect(membershipSql).toContain("p.created_at::bigint <= $2::bigint")
-		// Backlog is admitted: no maximum-age bound and no voting-period gate.
+		// Backlog is admitted: no maximum-age bound (unlike the executor query).
 		expect(membershipSql).not.toContain("MAX_PROPOSAL_AGE")
-		expect(membershipSql).not.toContain("end_time")
+	})
+
+	test("excludes proposals whose voting period has ended", () => {
+		// Votes cast after end_time are rejected by the protocol, and an untouched
+		// Fast proposal past its period is already classified REJECTED.
+		expect(membershipSql).toContain("$2::bigint <= p.end_time")
 	})
 })
 

--- a/proposal-executor/tests/detect.test.ts
+++ b/proposal-executor/tests/detect.test.ts
@@ -7,7 +7,9 @@
  */
 
 import {describe, expect, test} from "bun:test"
+import {Effect} from "effect"
 import {RATIO_BASE} from "../src/contracts.js"
+import {findMembershipRequests, MEMBERSHIP_DETECTION_SQL} from "../src/detect.js"
 
 // ---------------------------------------------------------------------------
 // RATIO_BASE cross-validation
@@ -72,5 +74,103 @@ describe("Proposal type", () => {
 		}
 		expect(proposal.id).toContain("-") // UUID with dashes
 		expect(proposal.spaceId).toContain("-") // UUID with dashes
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Membership-request detection SQL (stage 1)
+// ---------------------------------------------------------------------------
+
+// Whitespace-normalized SQL for robust substring assertions.
+const membershipSql = MEMBERSHIP_DETECTION_SQL.replace(/\s+/g, " ").trim()
+
+describe("membership detection SQL", () => {
+	test("scopes to the allowlist via space_id = ANY($1)", () => {
+		expect(membershipSql).toContain("p.space_id = ANY($1)")
+	})
+
+	test("selects only Fast-mode proposals (a single YES vote can execute)", () => {
+		expect(membershipSql).toContain("p.voting_mode = 'Fast'")
+	})
+
+	test("requires the action to be a self-service AddMember (target == proposer)", () => {
+		expect(membershipSql).toContain("a.action_type = 'AddMember'")
+		expect(membershipSql).toContain("a.target_id = p.proposed_by")
+	})
+
+	test("projects the MembershipRequest row shape {id, spaceId, requesterId}", () => {
+		expect(membershipSql).toContain("p.id")
+		expect(membershipSql).toContain('p.space_id AS "spaceId"')
+		expect(membershipSql).toContain('a.target_id AS "requesterId"')
+	})
+
+	test("orders FIFO by numeric created_at", () => {
+		expect(membershipSql).toContain("ORDER BY p.created_at::bigint ASC")
+	})
+
+	test("excludes proposals with any indexed vote", () => {
+		expect(membershipSql).toContain("NOT EXISTS (SELECT 1 FROM proposal_votes pv WHERE pv.proposal_id = p.id)")
+	})
+
+	test("excludes executed proposals", () => {
+		expect(membershipSql).toContain("p.executed_at IS NULL")
+	})
+
+	test("excludes editor-initiated adds by requiring target_id = proposed_by", () => {
+		// An editor-initiated add has proposed_by != target_id, so this predicate filters it out.
+		expect(membershipSql).toContain("a.target_id = p.proposed_by")
+	})
+
+	test("excludes multi-action proposals (exactly one action required)", () => {
+		expect(membershipSql).toContain("(SELECT COUNT(*) FROM proposal_actions a2 WHERE a2.proposal_id = p.id) = 1")
+	})
+
+	test("excludes Slow-mode proposals (Fast-only filter never overlaps the executor query)", () => {
+		expect(membershipSql).toContain("p.voting_mode = 'Fast'")
+		expect(membershipSql).not.toContain("'Slow'")
+	})
+
+	test("guards against corrupt future timestamps but applies no age cutoff", () => {
+		expect(membershipSql).toContain("p.created_at::bigint <= $2::bigint")
+		// Backlog is admitted: no maximum-age bound and no voting-period gate.
+		expect(membershipSql).not.toContain("MAX_PROPOSAL_AGE")
+		expect(membershipSql).not.toContain("end_time")
+	})
+})
+
+// ---------------------------------------------------------------------------
+// findMembershipRequests — kill switch / gating
+// ---------------------------------------------------------------------------
+
+describe("findMembershipRequests", () => {
+	// An empty allowlist is the kill switch: stop all activity, do not query.
+	test("short-circuits to [] without issuing a query when the allowlist is empty", async () => {
+		let queried = false
+		const fakeClient = {
+			query: async () => {
+				queried = true
+				return {rows: []}
+			},
+		} as never
+
+		const result = await Effect.runPromise(findMembershipRequests(fakeClient, []))
+		expect(result).toEqual([])
+		expect(queried).toBe(false)
+	})
+
+	// Gating: only allowlisted spaces reach the query, bound as ANY($1).
+	test("passes the allowlist as the first bind parameter", async () => {
+		const allowlist = ["660e8400-e29b-41d4-a716-446655440000"]
+		let boundParams: unknown[] = []
+		const fakeClient = {
+			query: async (_sql: string, params: unknown[]) => {
+				boundParams = params
+				return {rows: []}
+			},
+		} as never
+
+		await Effect.runPromise(findMembershipRequests(fakeClient, allowlist))
+		expect(boundParams[0]).toEqual(allowlist)
+		expect(typeof boundParams[1]).toBe("number") // nowSeconds guard
 	})
 })

--- a/proposal-executor/tests/detect.test.ts
+++ b/proposal-executor/tests/detect.test.ts
@@ -136,10 +136,12 @@ describe("membership detection SQL", () => {
 		expect(membershipSql).not.toContain("MAX_PROPOSAL_AGE")
 	})
 
-	test("excludes proposals whose voting period has ended", () => {
+	test("excludes proposals whose voting period has ended, with the stage-2 skew buffer", () => {
 		// Votes cast after end_time are rejected by the protocol, and an untouched
-		// Fast proposal past its period is already classified REJECTED.
-		expect(membershipSql).toContain("$2::bigint <= p.end_time")
+		// Fast proposal past its period is already classified REJECTED. The +60s buffer
+		// mirrors stage-2's isVotingOpen so detection never excludes a request the
+		// on-chain eligibility check would still vote on.
+		expect(membershipSql).toContain("$2::bigint <= p.end_time + 60")
 	})
 })
 
@@ -158,7 +160,7 @@ describe("findMembershipRequests", () => {
 			},
 		} as never
 
-		const result = await Effect.runPromise(findMembershipRequests(fakeClient, []))
+		const result = await Effect.runPromise(findMembershipRequests(fakeClient, [], 1_700_000_000))
 		expect(result).toEqual([])
 		expect(queried).toBe(false)
 	})
@@ -174,8 +176,9 @@ describe("findMembershipRequests", () => {
 			},
 		} as never
 
-		await Effect.runPromise(findMembershipRequests(fakeClient, allowlist))
+		await Effect.runPromise(findMembershipRequests(fakeClient, allowlist, 1_700_000_000))
 		expect(boundParams[0]).toEqual(allowlist)
-		expect(typeof boundParams[1]).toBe("number") // nowSeconds guard
+		// nowSeconds is the caller-supplied (chain-sourced) timestamp, bound verbatim.
+		expect(boundParams[1]).toBe(1_700_000_000)
 	})
 })

--- a/proposal-executor/tests/index.test.ts
+++ b/proposal-executor/tests/index.test.ts
@@ -562,7 +562,7 @@ describe("kill switch", () => {
 			},
 			// biome-ignore lint/suspicious/noExplicitAny: minimal pg.Client stub
 		} as any
-		const rows = await Effect.runPromise(findMembershipRequests(fakeClient, []))
+		const rows = await Effect.runPromise(findMembershipRequests(fakeClient, [], 1_700_000_000))
 		expect(rows).toEqual([])
 		expect(queried).toBe(false)
 	})

--- a/proposal-executor/tests/index.test.ts
+++ b/proposal-executor/tests/index.test.ts
@@ -6,7 +6,9 @@
  */
 
 import {describe, expect, test} from "bun:test"
+import {Cause, ConfigProvider, Effect, Exit, Option} from "effect"
 import {InfraError, RevertError} from "../src/contracts.js"
+import {type ExecutorEnv, parseConfig} from "../src/index.js"
 
 // ---------------------------------------------------------------------------
 // Tagged error construction
@@ -213,5 +215,113 @@ describe("concurrency model contracts", () => {
 		expect(succeeded).toBe(3)
 		expect(failed).toBe(1)
 		expect(skipped).toBe(1)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// parseConfig — dual-wallet + allowlist parsing (membership-accept path)
+// ---------------------------------------------------------------------------
+
+describe("parseConfig: membership-bot config & allowlist", () => {
+	const EXECUTOR_KEY: `0x${string}` = `0x${"1".repeat(64)}`
+	const BOT_KEY: `0x${string}` = `0x${"2".repeat(64)}`
+	const EXECUTOR_SPACE: `0x${string}` = `0x${"a".repeat(32)}`
+	const BOT_SPACE: `0x${string}` = `0x${"b".repeat(32)}`
+	const ALLOW_A: `0x${string}` = `0x${"c".repeat(32)}`
+	const ALLOW_B: `0x${string}` = `0x${"d".repeat(32)}`
+
+	const VALID_ENV: Record<string, string> = {
+		DATABASE_URL: "postgres://user:pass@localhost:5432/indexer",
+		EXECUTOR_PRIVATE_KEY: EXECUTOR_KEY,
+		PIMLICO_API_KEY: "pimlico-test-key",
+		RPC_URL: "https://rpc.example.com",
+		EXECUTOR_SPACE_ID: EXECUTOR_SPACE,
+		SPACE_REGISTRY_ADDRESS: "0x1111111111111111111111111111111111111111",
+		CHAIN_ID: "80451",
+		MEMBERSHIP_BOT_PRIVATE_KEY: BOT_KEY,
+		MEMBERSHIP_BOT_SPACE_ID: BOT_SPACE,
+		MEMBERSHIP_AUTOACCEPT_SPACE_IDS: `${ALLOW_A},${ALLOW_B}`,
+	}
+
+	/** Run parseConfig against an in-memory env (overrides merged, omitted keys removed). */
+	function runParse(
+		overrides: Record<string, string> = {},
+		omit: string[] = [],
+	): Promise<Exit.Exit<ExecutorEnv, InfraError>> {
+		const merged: Record<string, string> = {...VALID_ENV, ...overrides}
+		for (const key of omit) delete merged[key]
+		const provider = ConfigProvider.fromMap(new Map(Object.entries(merged)))
+		return Effect.runPromiseExit(parseConfig.pipe(Effect.withConfigProvider(provider)))
+	}
+
+	function expectSuccess(exit: Exit.Exit<ExecutorEnv, InfraError>): ExecutorEnv {
+		if (!Exit.isSuccess(exit)) {
+			throw new Error(`expected success, got failure: ${JSON.stringify(exit)}`)
+		}
+		return exit.value
+	}
+
+	function expectInfraError(exit: Exit.Exit<ExecutorEnv, InfraError>): InfraError {
+		expect(Exit.isFailure(exit)).toBe(true)
+		const failure = exit as Exit.Failure<ExecutorEnv, InfraError>
+		const err = Option.getOrThrow(Cause.failureOption(failure.cause))
+		expect(err._tag).toBe("InfraError")
+		return err
+	}
+
+	test("valid env parses bot identity + allowlist", async () => {
+		const env = expectSuccess(await runParse())
+		expect(env.membershipBotPrivateKey).toBe(BOT_KEY)
+		expect(env.membershipBotSpaceId).toBe(BOT_SPACE)
+		expect(env.membershipAutoacceptSpaceIds).toEqual([ALLOW_A, ALLOW_B])
+	})
+
+	test("auto-prefixes a bot key supplied without 0x", async () => {
+		const env = expectSuccess(await runParse({MEMBERSHIP_BOT_PRIVATE_KEY: "2".repeat(64)}))
+		expect(env.membershipBotPrivateKey).toBe(BOT_KEY)
+	})
+
+	test("rejects a malformed bot private key", async () => {
+		const err = expectInfraError(await runParse({MEMBERSHIP_BOT_PRIVATE_KEY: "0xdeadbeef"}))
+		expect(err.message).toContain("MEMBERSHIP_BOT_PRIVATE_KEY")
+	})
+
+	test("rejects a malformed bot space ID", async () => {
+		const err = expectInfraError(await runParse({MEMBERSHIP_BOT_SPACE_ID: "0xnothex"}))
+		expect(err.message).toContain("MEMBERSHIP_BOT_SPACE_ID")
+	})
+
+	test("rejects a malformed allowlist entry", async () => {
+		const err = expectInfraError(await runParse({MEMBERSHIP_AUTOACCEPT_SPACE_IDS: `${ALLOW_A},0xbogus`}))
+		expect(err.message).toContain("MEMBERSHIP_AUTOACCEPT_SPACE_IDS")
+	})
+
+	test("rejects a bot key identical to the executor key (distinct identity)", async () => {
+		const err = expectInfraError(await runParse({MEMBERSHIP_BOT_PRIVATE_KEY: EXECUTOR_KEY}))
+		expect(err.message).toContain("must differ from EXECUTOR_PRIVATE_KEY")
+	})
+
+	test("rejects a bot space identical to the executor space (distinct identity)", async () => {
+		const err = expectInfraError(await runParse({MEMBERSHIP_BOT_SPACE_ID: EXECUTOR_SPACE}))
+		expect(err.message).toContain("must differ from EXECUTOR_SPACE_ID")
+	})
+
+	test("empty allowlist is accepted — kill switch (explicit empty string)", async () => {
+		const env = expectSuccess(await runParse({MEMBERSHIP_AUTOACCEPT_SPACE_IDS: ""}))
+		expect(env.membershipAutoacceptSpaceIds).toEqual([])
+	})
+
+	test("empty allowlist is accepted — kill switch (unset var)", async () => {
+		const env = expectSuccess(await runParse({}, ["MEMBERSHIP_AUTOACCEPT_SPACE_IDS"]))
+		expect(env.membershipAutoacceptSpaceIds).toEqual([])
+	})
+
+	test("allowlist entries are trimmed and de-duplicated case-insensitively", async () => {
+		// Same space as ALLOW_A but upper-cased hex body (the 0x prefix stays lowercase).
+		const ALLOW_A_UPPER = `0x${"c".repeat(32).toUpperCase()}`
+		const env = expectSuccess(
+			await runParse({MEMBERSHIP_AUTOACCEPT_SPACE_IDS: `  ${ALLOW_A} , ${ALLOW_A_UPPER} ,${ALLOW_B}, `}),
+		)
+		expect(env.membershipAutoacceptSpaceIds).toEqual([ALLOW_A, ALLOW_B])
 	})
 })

--- a/proposal-executor/tests/index.test.ts
+++ b/proposal-executor/tests/index.test.ts
@@ -7,8 +7,20 @@
 
 import {describe, expect, test} from "bun:test"
 import {Cause, ConfigProvider, Effect, Exit, Option} from "effect"
+import type {Address, Hex} from "viem"
 import {InfraError, RevertError} from "../src/contracts.js"
-import {type ExecutorEnv, parseConfig} from "../src/index.js"
+import {findMembershipRequests, type MembershipRequest} from "../src/detect.js"
+import {type SmartWallet, uuidToBytes16} from "../src/execute.js"
+import {
+	aggregateMembership,
+	bytes16ToUuid,
+	classifyMembershipSkip,
+	type ExecutorEnv,
+	parseConfig,
+	processMembershipRequest,
+	processSpaceMembership,
+} from "../src/index.js"
+import type {ProposalTally} from "../src/membership.js"
 
 // ---------------------------------------------------------------------------
 // Tagged error construction
@@ -323,5 +335,241 @@ describe("parseConfig: membership-bot config & allowlist", () => {
 			await runParse({MEMBERSHIP_AUTOACCEPT_SPACE_IDS: `  ${ALLOW_A} , ${ALLOW_A_UPPER} ,${ALLOW_B}, `}),
 		)
 		expect(env.membershipAutoacceptSpaceIds).toEqual([ALLOW_A, ALLOW_B])
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Membership-accept orchestration
+// ---------------------------------------------------------------------------
+
+const DAO_ADDRESS: Address = "0x00000000000000000000000000000000000000aa"
+const REGISTRY_ADDRESS: Address = "0x1111111111111111111111111111111111111111"
+const BOT_SPACE: Hex = `0x${"b".repeat(32)}`
+
+const REQUEST_A: MembershipRequest = {
+	id: "550e8400-e29b-41d4-a716-446655440000",
+	spaceId: "11111111-1111-1111-1111-111111111111",
+	requesterId: "22222222-2222-2222-2222-222222222222",
+}
+const REQUEST_B: MembershipRequest = {
+	id: "660e8400-e29b-41d4-a716-446655440001",
+	spaceId: "11111111-1111-1111-1111-111111111111",
+	requesterId: "33333333-3333-3333-3333-333333333333",
+}
+
+/** A fully-eligible tally: not executed, zero votes, voting window wide open. */
+function makeTally(overrides: Partial<ProposalTally> = {}): ProposalTally {
+	return {executed: false, yes: 0n, no: 0n, abstain: 0n, startDate: 0n, lastDate: 10_000_000_000n, ...overrides}
+}
+
+interface FakeWalletOpts {
+	tally?: ProposalTally
+	daoAddress?: Address
+	/** Receives the 1-based send-transaction call index; throw to simulate a revert/infra error. */
+	sendTransaction?: (callIndex: number) => Promise<string>
+}
+
+interface FakeWallet {
+	wallet: SmartWallet
+	calls: {readContract: string[]; sendTransaction: number}
+}
+
+/**
+ * A minimal SmartWallet stub that lets the real orchestration run without infra:
+ * `readContract` dispatches on functionName (spaceIdToAddress / getLatestProposalInformation)
+ * and `sendTransaction` is scriptable per call. Records call counts for assertions.
+ */
+function makeFakeWallet(opts: FakeWalletOpts = {}): FakeWallet {
+	const tally = opts.tally ?? makeTally()
+	const calls = {readContract: [] as string[], sendTransaction: 0}
+	const wallet = {
+		chain: {id: 80451},
+		safeAddress: "0x0000000000000000000000000000000000000001",
+		publicClient: {
+			// biome-ignore lint/suspicious/noExplicitAny: minimal stub
+			readContract: async ({functionName}: any) => {
+				calls.readContract.push(functionName)
+				if (functionName === "spaceIdToAddress") return opts.daoAddress ?? DAO_ADDRESS
+				if (functionName === "getLatestProposalInformation") {
+					return [
+						tally.executed,
+						`0x${"0".repeat(32)}`,
+						{startDate: tally.startDate, lastDate: tally.lastDate},
+						{yes: tally.yes, no: tally.no, abstain: tally.abstain},
+						[],
+					]
+				}
+				throw new Error(`unexpected readContract: ${functionName}`)
+			},
+			getBlock: async () => ({timestamp: 1000n}),
+		},
+		smartAccountClient: {
+			account: {address: "0x0000000000000000000000000000000000000002"},
+			sendTransaction: async () => {
+				calls.sendTransaction += 1
+				if (opts.sendTransaction) return opts.sendTransaction(calls.sendTransaction)
+				return "0xtxhash"
+			},
+		},
+	}
+	return {wallet: wallet as unknown as SmartWallet, calls}
+}
+
+/** Build a revert-classified error (viem-style name → classifyAsRevert true). */
+function makeRevert(reason: string): Error {
+	const err = new Error(`execution reverted: ${reason}`)
+	err.name = "ContractFunctionRevertedError"
+	return err
+}
+
+describe("bytes16ToUuid (allowlist conversion)", () => {
+	test("converts a bytes16 space ID to a dashed lower-cased UUID", () => {
+		expect(bytes16ToUuid("0x550e8400e29b41d4a716446655440000")).toBe("550e8400-e29b-41d4-a716-446655440000")
+	})
+
+	test("normalizes upper-cased hex to lower case (matches indexer storage)", () => {
+		expect(bytes16ToUuid("0x550E8400E29B41D4A716446655440000")).toBe("550e8400-e29b-41d4-a716-446655440000")
+	})
+
+	test("round-trips with uuidToBytes16", () => {
+		const uuid = "550e8400-e29b-41d4-a716-446655440000"
+		expect(bytes16ToUuid(uuidToBytes16(uuid))).toBe(uuid)
+	})
+
+	test("rejects a malformed bytes16", () => {
+		expect(() => bytes16ToUuid("0xdeadbeef" as Hex)).toThrow()
+	})
+
+	test("an empty allowlist maps to no UUIDs (kill switch)", () => {
+		const empty: Hex[] = []
+		expect(empty.map(bytes16ToUuid)).toEqual([])
+	})
+})
+
+describe("classifyMembershipSkip — stage-2 skip reasons", () => {
+	test("an eligible (untouched, open) tally yields null — the bot should vote", () => {
+		expect(classifyMembershipSkip(makeTally(), 1000n)).toBeNull()
+	})
+
+	test("a non-zero tally is skipped as onchain_tally_nonzero", () => {
+		expect(classifyMembershipSkip(makeTally({yes: 1n}), 1000n)).toBe("onchain_tally_nonzero")
+		expect(classifyMembershipSkip(makeTally({no: 1n}), 1000n)).toBe("onchain_tally_nonzero")
+		expect(classifyMembershipSkip(makeTally({abstain: 1n}), 1000n)).toBe("onchain_tally_nonzero")
+	})
+
+	test("an already-executed proposal is skipped as already_executed", () => {
+		expect(classifyMembershipSkip(makeTally({executed: true}), 1000n)).toBe("already_executed")
+	})
+
+	test("a closed voting window with a zero tally is skipped as voting_window_closed", () => {
+		// now=1000, lastDate=100 (+60s skew) → window closed, yet the tally is zero:
+		// the cause is expiry, not a recorded vote.
+		expect(classifyMembershipSkip(makeTally({lastDate: 100n}), 1000n)).toBe("voting_window_closed")
+	})
+})
+
+describe("processMembershipRequest", () => {
+	test("a fresh eligible request casts exactly one YES vote", async () => {
+		const {wallet, calls} = makeFakeWallet({tally: makeTally()})
+		const outcome = await Effect.runPromise(
+			processMembershipRequest(wallet, REQUEST_A, DAO_ADDRESS, BOT_SPACE, REGISTRY_ADDRESS, 1000n),
+		)
+		expect(outcome.status).toBe("voted")
+		expect(calls.sendTransaction).toBe(1)
+	})
+
+	test("a touched request is skipped without voting", async () => {
+		const {wallet, calls} = makeFakeWallet({tally: makeTally({yes: 1n})})
+		const outcome = await Effect.runPromise(
+			processMembershipRequest(wallet, REQUEST_A, DAO_ADDRESS, BOT_SPACE, REGISTRY_ADDRESS, 1000n),
+		)
+		expect(outcome.status).toBe("skipped")
+		if (outcome.status === "skipped") expect(outcome.reason).toBe("onchain_tally_nonzero")
+		expect(calls.sendTransaction).toBe(0)
+	})
+
+	test("a revert is absorbed into a 'reverted' outcome (not a failure)", async () => {
+		const {wallet} = makeFakeWallet({
+			tally: makeTally(),
+			sendTransaction: () => Promise.reject(makeRevert("CanNotVote")),
+		})
+		const outcome = await Effect.runPromise(
+			processMembershipRequest(wallet, REQUEST_A, DAO_ADDRESS, BOT_SPACE, REGISTRY_ADDRESS, 1000n),
+		)
+		expect(outcome.status).toBe("reverted")
+	})
+})
+
+describe("processSpaceMembership — revert isolation", () => {
+	test("a RevertError on one request does not abort processing of others", async () => {
+		// First request reverts (CanNotVote), second votes successfully.
+		const {wallet, calls} = makeFakeWallet({
+			tally: makeTally(),
+			sendTransaction: (callIndex) =>
+				callIndex === 1 ? Promise.reject(makeRevert("CanNotVote")) : Promise.resolve("0xok"),
+		})
+		const outcomes = await Effect.runPromise(
+			processSpaceMembership(
+				wallet,
+				REQUEST_A.spaceId,
+				[REQUEST_A, REQUEST_B],
+				BOT_SPACE,
+				REGISTRY_ADDRESS,
+				1000n,
+			),
+		)
+		expect(outcomes.length).toBe(2)
+		expect(outcomes[0]?.status).toBe("reverted")
+		expect(outcomes[1]?.status).toBe("voted")
+		// Two vote attempts; the DAO address was resolved once for the space.
+		expect(calls.sendTransaction).toBe(2)
+		expect(calls.readContract.filter((fn) => fn === "spaceIdToAddress").length).toBe(1)
+	})
+})
+
+describe("aggregateMembership — run_end counts", () => {
+	test("counts votes as admitted, skips/reverts as skipped, infra spaces as failed", () => {
+		const results = [
+			{
+				status: "ok" as const,
+				spaceId: "s1",
+				outcomes: [
+					{status: "voted" as const, txHash: "0x1"},
+					{status: "skipped" as const, reason: "onchain_tally_nonzero" as const},
+				],
+			},
+			{status: "ok" as const, spaceId: "s2", outcomes: [{status: "reverted" as const, expected: true}]},
+			{status: "infraError" as const, spaceId: "s3", outcomes: []},
+		]
+		expect(aggregateMembership(results)).toEqual({admitted: 1, skipped: 2, failed: 1})
+	})
+
+	test("an empty run aggregates to all-zero", () => {
+		expect(aggregateMembership([])).toEqual({admitted: 0, skipped: 0, failed: 0})
+	})
+})
+
+describe("kill switch", () => {
+	// Mirrors the exit-code formula: process.exit(failed > 0 && succeeded === 0 ? 1 : 0)
+	const computeExitCode = (succeeded: number, failed: number) => (failed > 0 && succeeded === 0 ? 1 : 0)
+
+	test("an empty allowlist issues no detection query", async () => {
+		let queried = false
+		const fakeClient = {
+			query: async () => {
+				queried = true
+				return {rows: []}
+			},
+			// biome-ignore lint/suspicious/noExplicitAny: minimal pg.Client stub
+		} as any
+		const rows = await Effect.runPromise(findMembershipRequests(fakeClient, []))
+		expect(rows).toEqual([])
+		expect(queried).toBe(false)
+	})
+
+	test("with nothing admitted, membership contributes exit 0", () => {
+		const agg = aggregateMembership([])
+		expect(agg.admitted).toBe(0)
+		expect(computeExitCode(agg.admitted, agg.failed)).toBe(0)
 	})
 })

--- a/proposal-executor/tests/index.test.ts
+++ b/proposal-executor/tests/index.test.ts
@@ -6,7 +6,7 @@
  */
 
 import {describe, expect, test} from "bun:test"
-import {Cause, ConfigProvider, Effect, Exit, Option} from "effect"
+import {Cause, ConfigProvider, Effect, Exit, Option, Redacted} from "effect"
 import type {Address, Hex} from "viem"
 import {InfraError, RevertError} from "../src/contracts.js"
 import {findMembershipRequests, type MembershipRequest} from "../src/detect.js"
@@ -283,14 +283,14 @@ describe("parseConfig: membership-bot config & allowlist", () => {
 
 	test("valid env parses bot identity + allowlist", async () => {
 		const env = expectSuccess(await runParse())
-		expect(env.membershipBotPrivateKey).toBe(BOT_KEY)
+		expect(Redacted.value(env.membershipBotPrivateKey)).toBe(BOT_KEY)
 		expect(env.membershipBotSpaceId).toBe(BOT_SPACE)
 		expect(env.membershipAutoacceptSpaceIds).toEqual([ALLOW_A, ALLOW_B])
 	})
 
 	test("auto-prefixes a bot key supplied without 0x", async () => {
 		const env = expectSuccess(await runParse({MEMBERSHIP_BOT_PRIVATE_KEY: "2".repeat(64)}))
-		expect(env.membershipBotPrivateKey).toBe(BOT_KEY)
+		expect(Redacted.value(env.membershipBotPrivateKey)).toBe(BOT_KEY)
 	})
 
 	test("rejects a malformed bot private key", async () => {

--- a/proposal-executor/tests/membership.test.ts
+++ b/proposal-executor/tests/membership.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Tests for membership.ts — vote-data encoding, the enter() vote calldata, the
+ * stage-2 on-chain tally read, two-stage eligibility, and error classification.
+ *
+ * Encoding is pinned against the authoritative IDAOSpace.VoteOption enum (Yes = 1).
+ * On-chain calls are exercised against a fake SmartWallet that captures calldata /
+ * returns canned reads, so no live RPC or paymaster is needed.
+ */
+
+import {describe, expect, test} from "bun:test"
+import {Effect} from "effect"
+import {type Address, decodeAbiParameters, decodeFunctionData, type Hex} from "viem"
+import {PROPOSAL_VOTED_ACTION, SpaceRegistryAbi, VOTE_YES} from "../src/contracts.js"
+import type {MembershipRequest} from "../src/detect.js"
+import type {SmartWallet} from "../src/execute.js"
+import {
+	castMembershipVote,
+	encodeVoteData,
+	isEligibleToVote,
+	type ProposalTally,
+	readProposalTally,
+	resolveDaoSpaceAddress,
+} from "../src/membership.js"
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const PROPOSAL_UUID = "550e8400-e29b-41d4-a716-446655440000"
+const PROPOSAL_BYTES16 = "0x550e8400e29b41d4a716446655440000"
+const SPACE_UUID = "660e8400-e29b-41d4-a716-446655440000"
+const SPACE_BYTES16 = "0x660e8400e29b41d4a716446655440000"
+const BOT_SPACE_ID = "0x770e8400e29b41d4a716446655440000" as Hex
+const REGISTRY = "0x1111111111111111111111111111111111111111" as Address
+const DAO_SPACE_ADDR = "0x2222222222222222222222222222222222222222" as Address
+
+const REQUEST: MembershipRequest = {
+	id: PROPOSAL_UUID,
+	spaceId: SPACE_UUID,
+	requesterId: "880e8400-e29b-41d4-a716-446655440000",
+}
+
+/**
+ * Minimal SmartWallet stub. sendTransaction / readContract are injected per-test;
+ * the account is present by default so the "no account" guard does not trip.
+ */
+function fakeWallet(overrides: {
+	sendTransaction?: (args: {data: Hex; to: Address}) => Promise<string>
+	readContract?: (args: {functionName: string; args: readonly unknown[]}) => Promise<unknown>
+}): SmartWallet {
+	return {
+		smartAccountClient: {
+			account: {address: "0xbot"},
+			sendTransaction: overrides.sendTransaction ?? (async () => "0xhash"),
+		},
+		publicClient: {
+			readContract: overrides.readContract ?? (async () => undefined),
+		},
+		chain: {id: 19411},
+		safeAddress: "0xsafe",
+	} as unknown as SmartWallet
+}
+
+// ---------------------------------------------------------------------------
+// encodeVoteData
+// ---------------------------------------------------------------------------
+
+describe("encodeVoteData", () => {
+	test("encodes abi.encode(bytes16 proposalId, uint8 voteOption)", () => {
+		const data = encodeVoteData(PROPOSAL_BYTES16 as Hex, VOTE_YES)
+		const [proposalId, voteOption] = decodeAbiParameters(
+			[
+				{name: "proposalId", type: "bytes16"},
+				{name: "voteOption", type: "uint8"},
+			],
+			data,
+		)
+		// bytes16 is left-aligned in its 32-byte word; viem returns it padded to bytes32.
+		expect((proposalId as string).slice(0, 34)).toBe(PROPOSAL_BYTES16)
+		expect(voteOption).toBe(VOTE_YES)
+	})
+
+	test("uses VOTE_YES === 1 for a YES vote", () => {
+		// Guards the documented enum discrepancy: a YES vote must encode uint8 1, not 2.
+		expect(VOTE_YES).toBe(1)
+		const data = encodeVoteData(PROPOSAL_BYTES16 as Hex, VOTE_YES)
+		const [, voteOption] = decodeAbiParameters([{type: "bytes16"}, {type: "uint8"}], data)
+		expect(voteOption).toBe(1)
+	})
+
+	test("two words: bytes16 proposalId then uint8 voteOption (0x + 128 hex chars)", () => {
+		const data = encodeVoteData(PROPOSAL_BYTES16 as Hex, VOTE_YES)
+		expect(data.length).toBe(2 + 128)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// castMembershipVote — enter() calldata
+// ---------------------------------------------------------------------------
+
+describe("castMembershipVote calldata", () => {
+	test("builds enter() with the PROPOSAL_VOTED action, bytes32(proposalId) topic, and YES vote data", async () => {
+		let captured: {data: Hex; to: Address} | undefined
+		const wallet = fakeWallet({
+			sendTransaction: async (args) => {
+				captured = args
+				return "0xtxhash"
+			},
+		})
+
+		const hash = await Effect.runPromise(castMembershipVote(wallet, REQUEST, BOT_SPACE_ID, REGISTRY))
+		expect(hash).toBe("0xtxhash")
+		if (!captured) throw new Error("sendTransaction was never called")
+		expect(captured.to).toBe(REGISTRY)
+
+		const decoded = decodeFunctionData({abi: SpaceRegistryAbi, data: captured.data})
+		expect(decoded.functionName).toBe("enter")
+
+		const [fromSpace, toSpace, action, topic, voteData, signature] = decoded.args as readonly [
+			Hex,
+			Hex,
+			Hex,
+			Hex,
+			Hex,
+			Hex,
+		]
+		expect(fromSpace.toLowerCase()).toBe(BOT_SPACE_ID.toLowerCase())
+		expect(toSpace.toLowerCase()).toBe(SPACE_BYTES16)
+		expect(action.toLowerCase()).toBe(PROPOSAL_VOTED_ACTION)
+		// Topic = bytes32(proposalId), left-aligned (proposalId in the high 16 bytes).
+		expect(topic.toLowerCase()).toBe(`${PROPOSAL_BYTES16}${"0".repeat(32)}`)
+		expect(signature).toBe("0x")
+
+		// Vote data decodes to (proposalId, Yes=1).
+		const [encodedId, encodedVote] = decodeAbiParameters([{type: "bytes16"}, {type: "uint8"}], voteData)
+		expect((encodedId as string).slice(0, 34)).toBe(PROPOSAL_BYTES16)
+		expect(encodedVote).toBe(1)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// castMembershipVote — error classification
+// ---------------------------------------------------------------------------
+
+describe("castMembershipVote error classification", () => {
+	test("classifies an on-chain revert as RevertError (CanNotVote ⇒ not expected)", async () => {
+		const revert = new Error("execution reverted: CanNotVote")
+		revert.name = "ContractFunctionRevertedError"
+		const wallet = fakeWallet({
+			sendTransaction: async () => {
+				throw revert
+			},
+		})
+
+		const failure = await Effect.runPromise(
+			Effect.flip(castMembershipVote(wallet, REQUEST, BOT_SPACE_ID, REGISTRY)),
+		)
+		expect(failure._tag).toBe("RevertError")
+		expect((failure as {proposalId: string}).proposalId).toBe(REQUEST.id)
+		// CanNotVote (bot lacks EDITOR) is a real misconfiguration, not an expected race.
+		expect((failure as {expected: boolean}).expected).toBe(false)
+	})
+
+	test("marks an already-executed revert as expected (request resolved elsewhere)", async () => {
+		const revert = new Error("execution reverted: proposal already executed")
+		revert.name = "ContractFunctionRevertedError"
+		const wallet = fakeWallet({
+			sendTransaction: async () => {
+				throw revert
+			},
+		})
+
+		const failure = await Effect.runPromise(
+			Effect.flip(castMembershipVote(wallet, REQUEST, BOT_SPACE_ID, REGISTRY)),
+		)
+		expect(failure._tag).toBe("RevertError")
+		expect((failure as {expected: boolean}).expected).toBe(true)
+	})
+
+	test("classifies a bundler/RPC failure as InfraError", async () => {
+		const wallet = fakeWallet({
+			sendTransaction: async () => {
+				throw new Error("connect ECONNREFUSED api.pimlico.io")
+			},
+		})
+
+		const failure = await Effect.runPromise(
+			Effect.flip(castMembershipVote(wallet, REQUEST, BOT_SPACE_ID, REGISTRY)),
+		)
+		expect(failure._tag).toBe("InfraError")
+		expect((failure as {proposalId?: string}).proposalId).toBe(REQUEST.id)
+	})
+
+	test("redacts a Pimlico API key leaked into an error message", async () => {
+		const wallet = fakeWallet({
+			sendTransaction: async () => {
+				throw new Error("request to https://api.pimlico.io/rpc?apikey=secret123 failed")
+			},
+		})
+
+		const failure = await Effect.runPromise(
+			Effect.flip(castMembershipVote(wallet, REQUEST, BOT_SPACE_ID, REGISTRY)),
+		)
+		expect((failure as {message: string}).message).toContain("apikey=<redacted>")
+		expect((failure as {message: string}).message).not.toContain("secret123")
+	})
+})
+
+// ---------------------------------------------------------------------------
+// readProposalTally
+// ---------------------------------------------------------------------------
+
+describe("readProposalTally", () => {
+	test("decodes the (executed, creator, parameters, Tally, actions) tuple into the tally", async () => {
+		const wallet = fakeWallet({
+			readContract: async (args) => {
+				expect(args.functionName).toBe("getLatestProposalInformation")
+				// proposalId passed as bytes16
+				expect(args.args[0]).toBe(PROPOSAL_BYTES16)
+				return [
+					false, // executed
+					"0xcreator", // creator
+					{}, // parameters (unused by the read)
+					{yes: 3n, no: 1n, abstain: 2n}, // tally
+					[], // actions
+				]
+			},
+		})
+
+		const tally = await Effect.runPromise(readProposalTally(wallet, DAO_SPACE_ADDR, PROPOSAL_UUID))
+		expect(tally).toEqual({executed: false, yes: 3n, no: 1n, abstain: 2n})
+	})
+
+	test("surfaces a read failure as an InfraError carrying the proposalId", async () => {
+		const wallet = fakeWallet({
+			readContract: async () => {
+				throw new Error("RPC timeout")
+			},
+		})
+
+		const failure = await Effect.runPromise(Effect.flip(readProposalTally(wallet, DAO_SPACE_ADDR, PROPOSAL_UUID)))
+		expect(failure._tag).toBe("InfraError")
+		expect((failure as {proposalId?: string}).proposalId).toBe(PROPOSAL_UUID)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// isEligibleToVote — two-stage eligibility (stage 2)
+// ---------------------------------------------------------------------------
+
+describe("isEligibleToVote", () => {
+	test("eligible iff !executed && yes + no + abstain == 0", () => {
+		const fresh: ProposalTally = {executed: false, yes: 0n, no: 0n, abstain: 0n}
+		expect(isEligibleToVote(fresh)).toBe(true)
+	})
+
+	test("ineligible when already executed", () => {
+		expect(isEligibleToVote({executed: true, yes: 0n, no: 0n, abstain: 0n})).toBe(false)
+	})
+
+	test("ineligible when any vote is recorded (yes / no / abstain)", () => {
+		expect(isEligibleToVote({executed: false, yes: 1n, no: 0n, abstain: 0n})).toBe(false)
+		expect(isEligibleToVote({executed: false, yes: 0n, no: 1n, abstain: 0n})).toBe(false)
+		expect(isEligibleToVote({executed: false, yes: 0n, no: 0n, abstain: 1n})).toBe(false)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Idempotency (US2) — a non-zero on-chain tally ⇒ ineligible ⇒ no vote cast
+// ---------------------------------------------------------------------------
+
+describe("idempotency: the bot never double-votes", () => {
+	test("the bot's own prior YES vote makes the request ineligible (stage-2 tally non-zero)", async () => {
+		// After the bot votes once, yes >= 1 is visible on-chain immediately — even before
+		// the indexer surfaces it — so the next cycle reads it and must skip.
+		const wallet = fakeWallet({
+			readContract: async () => [false, "0xcreator", {}, {yes: 1n, no: 0n, abstain: 0n}, []],
+		})
+
+		const tally = await Effect.runPromise(readProposalTally(wallet, DAO_SPACE_ADDR, PROPOSAL_UUID))
+		expect(isEligibleToVote(tally)).toBe(false)
+	})
+
+	test("a human's pre-existing vote (indexing-lag window) also blocks the cast", async () => {
+		const wallet = fakeWallet({
+			readContract: async () => [false, "0xcreator", {}, {yes: 0n, no: 2n, abstain: 0n}, []],
+		})
+
+		const tally = await Effect.runPromise(readProposalTally(wallet, DAO_SPACE_ADDR, PROPOSAL_UUID))
+		expect(isEligibleToVote(tally)).toBe(false)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// resolveDaoSpaceAddress
+// ---------------------------------------------------------------------------
+
+describe("resolveDaoSpaceAddress", () => {
+	test("returns the DAOSpace address from spaceIdToAddress", async () => {
+		const wallet = fakeWallet({
+			readContract: async (args) => {
+				expect(args.functionName).toBe("spaceIdToAddress")
+				return DAO_SPACE_ADDR
+			},
+		})
+
+		const addr = await Effect.runPromise(resolveDaoSpaceAddress(wallet, REGISTRY, SPACE_BYTES16 as Hex))
+		expect(addr).toBe(DAO_SPACE_ADDR)
+	})
+
+	test("rejects an unregistered space (zero address) as an InfraError", async () => {
+		const wallet = fakeWallet({
+			readContract: async () => "0x0000000000000000000000000000000000000000",
+		})
+
+		const failure = await Effect.runPromise(
+			Effect.flip(resolveDaoSpaceAddress(wallet, REGISTRY, SPACE_BYTES16 as Hex)),
+		)
+		expect(failure._tag).toBe("InfraError")
+		expect((failure as {message: string}).message).toContain("not registered")
+	})
+})

--- a/proposal-executor/tests/membership.test.ts
+++ b/proposal-executor/tests/membership.test.ts
@@ -17,7 +17,9 @@ import {
 	castMembershipVote,
 	encodeVoteData,
 	isEligibleToVote,
+	isVotingOpen,
 	type ProposalTally,
+	readChainTimeSeconds,
 	readProposalTally,
 	resolveDaoSpaceAddress,
 } from "../src/membership.js"
@@ -40,13 +42,21 @@ const REQUEST: MembershipRequest = {
 	requesterId: "880e8400-e29b-41d4-a716-446655440000",
 }
 
+// Voting-window fixtures: NOW sits comfortably inside an open window.
+const NOW = 1_700_000_000n
+const START_DATE = NOW - 3_600n // opened an hour ago
+const LAST_DATE = NOW + 3_600n // closes in an hour
+/** A ProposalParameters tuple whose only fields the read uses are startDate/lastDate. */
+const OPEN_PARAMS = {startDate: START_DATE, lastDate: LAST_DATE}
+
 /**
- * Minimal SmartWallet stub. sendTransaction / readContract are injected per-test;
- * the account is present by default so the "no account" guard does not trip.
+ * Minimal SmartWallet stub. sendTransaction / readContract / getBlock are injected
+ * per-test; the account is present by default so the "no account" guard does not trip.
  */
 function fakeWallet(overrides: {
 	sendTransaction?: (args: {data: Hex; to: Address}) => Promise<string>
 	readContract?: (args: {functionName: string; args: readonly unknown[]}) => Promise<unknown>
+	getBlock?: () => Promise<{timestamp: bigint}>
 }): SmartWallet {
 	return {
 		smartAccountClient: {
@@ -55,6 +65,7 @@ function fakeWallet(overrides: {
 		},
 		publicClient: {
 			readContract: overrides.readContract ?? (async () => undefined),
+			getBlock: overrides.getBlock ?? (async () => ({timestamp: NOW})),
 		},
 		chain: {id: 19411},
 		safeAddress: "0xsafe",
@@ -220,7 +231,7 @@ describe("readProposalTally", () => {
 				return [
 					false, // executed
 					"0xcreator", // creator
-					{}, // parameters (unused by the read)
+					OPEN_PARAMS, // parameters → startDate/lastDate
 					{yes: 3n, no: 1n, abstain: 2n}, // tally
 					[], // actions
 				]
@@ -228,7 +239,14 @@ describe("readProposalTally", () => {
 		})
 
 		const tally = await Effect.runPromise(readProposalTally(wallet, DAO_SPACE_ADDR, PROPOSAL_UUID))
-		expect(tally).toEqual({executed: false, yes: 3n, no: 1n, abstain: 2n})
+		expect(tally).toEqual({
+			executed: false,
+			yes: 3n,
+			no: 1n,
+			abstain: 2n,
+			startDate: START_DATE,
+			lastDate: LAST_DATE,
+		})
 	})
 
 	test("surfaces a read failure as an InfraError carrying the proposalId", async () => {
@@ -249,19 +267,87 @@ describe("readProposalTally", () => {
 // ---------------------------------------------------------------------------
 
 describe("isEligibleToVote", () => {
-	test("eligible iff !executed && yes + no + abstain == 0", () => {
-		const fresh: ProposalTally = {executed: false, yes: 0n, no: 0n, abstain: 0n}
-		expect(isEligibleToVote(fresh)).toBe(true)
+	const fresh: ProposalTally = {
+		executed: false,
+		yes: 0n,
+		no: 0n,
+		abstain: 0n,
+		startDate: START_DATE,
+		lastDate: LAST_DATE,
+	}
+
+	test("eligible iff !executed && zero tally && voting window open", () => {
+		expect(isEligibleToVote(fresh, NOW)).toBe(true)
 	})
 
 	test("ineligible when already executed", () => {
-		expect(isEligibleToVote({executed: true, yes: 0n, no: 0n, abstain: 0n})).toBe(false)
+		expect(isEligibleToVote({...fresh, executed: true}, NOW)).toBe(false)
 	})
 
 	test("ineligible when any vote is recorded (yes / no / abstain)", () => {
-		expect(isEligibleToVote({executed: false, yes: 1n, no: 0n, abstain: 0n})).toBe(false)
-		expect(isEligibleToVote({executed: false, yes: 0n, no: 1n, abstain: 0n})).toBe(false)
-		expect(isEligibleToVote({executed: false, yes: 0n, no: 0n, abstain: 1n})).toBe(false)
+		expect(isEligibleToVote({...fresh, yes: 1n}, NOW)).toBe(false)
+		expect(isEligibleToVote({...fresh, no: 1n}, NOW)).toBe(false)
+		expect(isEligibleToVote({...fresh, abstain: 1n}, NOW)).toBe(false)
+	})
+
+	test("ineligible once the voting window has closed (beyond the skew buffer)", () => {
+		// 61s past lastDate: outside the 60s lenient buffer ⇒ no vote.
+		expect(isEligibleToVote(fresh, LAST_DATE + 61n)).toBe(false)
+	})
+
+	test("still eligible within the lenient skew buffer past lastDate", () => {
+		// 30s past close but inside the 60s buffer: prefer voting (may revert) over skipping.
+		expect(isEligibleToVote(fresh, LAST_DATE + 30n)).toBe(true)
+	})
+
+	test("ineligible before the voting window opens", () => {
+		expect(isEligibleToVote(fresh, START_DATE - 1n)).toBe(false)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// isVotingOpen — voting-window predicate
+// ---------------------------------------------------------------------------
+
+describe("isVotingOpen", () => {
+	test("open in the middle of the window", () => {
+		expect(isVotingOpen(NOW, START_DATE, LAST_DATE)).toBe(true)
+	})
+
+	test("open at exactly startDate, closed just before it", () => {
+		expect(isVotingOpen(START_DATE, START_DATE, LAST_DATE)).toBe(true)
+		expect(isVotingOpen(START_DATE - 1n, START_DATE, LAST_DATE)).toBe(false)
+	})
+
+	test("the buffer extends the close, never shrinks it", () => {
+		// Last second of the real window is always open.
+		expect(isVotingOpen(LAST_DATE - 1n, START_DATE, LAST_DATE)).toBe(true)
+		// And the window stays open for skewSeconds past lastDate.
+		expect(isVotingOpen(LAST_DATE + 59n, START_DATE, LAST_DATE, 60n)).toBe(true)
+		expect(isVotingOpen(LAST_DATE + 60n, START_DATE, LAST_DATE, 60n)).toBe(false)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// readChainTimeSeconds — chain clock with wall-clock fallback
+// ---------------------------------------------------------------------------
+
+describe("readChainTimeSeconds", () => {
+	test("returns the latest block timestamp", async () => {
+		const wallet = fakeWallet({getBlock: async () => ({timestamp: 1_234_567n})})
+		const now = await Effect.runPromise(readChainTimeSeconds(wallet))
+		expect(now).toBe(1_234_567n)
+	})
+
+	test("falls back to the pod wall clock when the block read fails", async () => {
+		const wallet = fakeWallet({
+			getBlock: async () => {
+				throw new Error("RPC down")
+			},
+		})
+		const before = BigInt(Math.floor(Date.now() / 1000))
+		const now = await Effect.runPromise(readChainTimeSeconds(wallet))
+		expect(now).toBeGreaterThanOrEqual(before)
 	})
 })
 
@@ -274,20 +360,20 @@ describe("idempotency: the bot never double-votes", () => {
 		// After the bot votes once, yes >= 1 is visible on-chain immediately — even before
 		// the indexer surfaces it — so the next cycle reads it and must skip.
 		const wallet = fakeWallet({
-			readContract: async () => [false, "0xcreator", {}, {yes: 1n, no: 0n, abstain: 0n}, []],
+			readContract: async () => [false, "0xcreator", OPEN_PARAMS, {yes: 1n, no: 0n, abstain: 0n}, []],
 		})
 
 		const tally = await Effect.runPromise(readProposalTally(wallet, DAO_SPACE_ADDR, PROPOSAL_UUID))
-		expect(isEligibleToVote(tally)).toBe(false)
+		expect(isEligibleToVote(tally, NOW)).toBe(false)
 	})
 
 	test("a human's pre-existing vote (indexing-lag window) also blocks the cast", async () => {
 		const wallet = fakeWallet({
-			readContract: async () => [false, "0xcreator", {}, {yes: 0n, no: 2n, abstain: 0n}, []],
+			readContract: async () => [false, "0xcreator", OPEN_PARAMS, {yes: 0n, no: 2n, abstain: 0n}, []],
 		})
 
 		const tally = await Effect.runPromise(readProposalTally(wallet, DAO_SPACE_ADDR, PROPOSAL_UUID))
-		expect(isEligibleToVote(tally)).toBe(false)
+		expect(isEligibleToVote(tally, NOW)).toBe(false)
 	})
 })
 

--- a/proposal-executor/tests/membership.test.ts
+++ b/proposal-executor/tests/membership.test.ts
@@ -322,9 +322,12 @@ describe("isVotingOpen", () => {
 	test("the buffer extends the close, never shrinks it", () => {
 		// Last second of the real window is always open.
 		expect(isVotingOpen(LAST_DATE - 1n, START_DATE, LAST_DATE)).toBe(true)
-		// And the window stays open for skewSeconds past lastDate.
+		// And the window stays open through skewSeconds past lastDate. The upper
+		// bound is inclusive, matching the inclusive stage-1 detection SQL, so the
+		// two stages agree exactly at the skew boundary (lastDate + skew).
 		expect(isVotingOpen(LAST_DATE + 59n, START_DATE, LAST_DATE, 60n)).toBe(true)
-		expect(isVotingOpen(LAST_DATE + 60n, START_DATE, LAST_DATE, 60n)).toBe(false)
+		expect(isVotingOpen(LAST_DATE + 60n, START_DATE, LAST_DATE, 60n)).toBe(true)
+		expect(isVotingOpen(LAST_DATE + 61n, START_DATE, LAST_DATE, 60n)).toBe(false)
 	})
 })
 


### PR DESCRIPTION
## Summary

Extends the existing `proposal-executor` CronJob with a second action path that automatically admits joiners to an explicit allowlist of spaces — no human voting required.

Each cycle (~5 min) the job detects open **request-to-join** proposals in allowlisted spaces and casts a single **YES vote** on each untouched one. Because allowlisted spaces are configured with a fast-path threshold of 1, that YES vote executes the add immediately, admitting the requester.

The membership path runs under a **dedicated bot identity whose wallet is distinct from the existing slow-path executor wallet** (separate private key + separate registered space, its own kill switch and blast radius). The bot holds the EDITOR role in each allowlisted space — the authority a YES vote requires.

This is an *extension* of the existing recurring job (its gas-sponsored Safe signing pipeline, indexer data source, and 5-minute cadence), not a new service.

## How it works

**Two-stage "untouched" eligibility check** (closes the indexing-lag window and makes the job idempotent across cycles):

1. **Indexer first** — skip the request if any vote is already indexed (`proposal_votes`).
2. **On-chain fallback** — only when the indexer shows zero votes, read the authoritative tally from the per-space DAOSpace contract via RPC (`getLatestProposalInformation`) and cast only if `yes + no + abstain == 0`.

Because the bot's own prior vote shows up in the on-chain tally, a request it has already acted on becomes ineligible on later cycles — even while the vote is still in flight and not yet indexed.

**Detection signature** — a membership request is a `Fast` proposal whose single action is `AddMember` targeting the proposer itself (`proposals.proposed_by = proposal_actions.target_id`), from the `MEMBERSHIP_REQUESTED` flow. No creation-time cutoff: pre-existing backlog is admitted on the first cycle after a space is allowlisted.

**Vote cast** — reuses the executor's `enter()` calldata pattern: `enter(botSpaceId, daoSpaceId, PROPOSAL_VOTED, bytes32(proposalId), abi.encode(bytes16 proposalId, uint8 1), "0x")`.

**Isolation & safety** — each request is processed independently (one failure never aborts the cycle); admit failures (missing authority, revert, sponsorship down) are logged and retried unbounded next cycle. Non-allowlisted spaces are completely unaffected.

## Configuration (new env)

| Var | Purpose |
| --- | --- |
| `MEMBERSHIP_BOT_PRIVATE_KEY` | Dedicated bot signing key (redacted). MUST differ from `EXECUTOR_PRIVATE_KEY`. |
| `MEMBERSHIP_BOT_SPACE_ID` | Bot's registered space (bytes16). MUST differ from `EXECUTOR_SPACE_ID`. |
| `MEMBERSHIP_AUTOACCEPT_SPACE_IDS` | Comma-separated bytes16 allowlist. Empty/unset = **kill switch** (no admits anywhere). |

Config is read once at startup and validated fail-fast; distinct-identity is enforced (bot key/space must differ from the executor's). The allowlist is read once at startup, so add/remove/kill-switch changes take effect only after a redeploy/restart.

## Changes

- **`src/contracts.ts`** — `PROPOSAL_VOTED_ACTION`, `VOTE_YES = 1`, vote-data encoder, `DAOSpaceAbi` subset (`getLatestProposalInformation`), `SpaceRegistryAbi += spaceIdToAddress`.
- **`src/detect.ts`** — `findMembershipRequests()` detection query (AddMember self-request, Fast mode, stage-1 untouched, allowlisted, within voting window).
- **`src/membership.ts`** *(new)* — stage-2 on-chain tally read + DAO address resolution + `castMembershipVote()`.
- **`src/index.ts`** — parse allowlist + bot config, build the second (bot) wallet, distinct-identity validation, orchestrate the membership path alongside the existing execute path with independent failure isolation.
- **`deployment/{staging,production}`** — new env vars + secrets examples.
- **`ARCHITECTURE.md` / `RUNBOOK.md`** — membership path, dual-wallet isolation, two-stage eligibility, bot onboarding (threshold=1 + editor role), kill switch.

## Tests

`bun test` — added/extended:

- `tests/contracts.test.ts` — `VOTE_YES === 1`, `PROPOSAL_VOTED_ACTION` hash, new ABI views.
- `tests/detect.test.ts` — membership detection SQL shape + proposal shape.
- `tests/membership.test.ts` — vote calldata/encoding, tally decoding, two-stage eligibility logic, error classification.
- `tests/index.test.ts` — dual-wallet + allowlist parsing, distinct-identity rejection, empty-allowlist (kill switch), exit code.

## Out of scope (v1)

- Durable failure tracking / smarter retry-backoff (retries are unbounded each cycle).
- Any per-cycle or per-space cap on admits (every eligible request is processed).
- Self-serve UI toggle or on-chain per-space setting for enabling auto-accept.
- Auto-rejecting or any per-requester screening / anti-sybil policy.
- Any smart-contract changes.

## Operational notes

- Each allowlisted space must already be configured with single-vote acceptance (threshold = 1) and must have granted the bot the EDITOR role — enforced by the onboarding runbook, not by code.
- Kill-switch response (e.g. compromised bot key): remove the bot from the editor role in listed spaces and clear `MEMBERSHIP_AUTOACCEPT_SPACE_IDS`, then redeploy.
- ⚠️ `docs/protocol/dao-space.md` documents `VoteOption` incorrectly (`Abstain=1, Yes=2`); the deployed `IDAOSpace` is `None=0, Yes=1, No=2, Abstain=3` and should be corrected separately.
