### PR TITLE
feat(api): v2 enriched proposal diff endpoints (folded + media-filtered)

### DIFF
--- a/api/drizzle/0064_blocks_to_entity_idx.sql
+++ b/api/drizzle/0064_blocks_to_entity_idx.sql
@@ -1,0 +1,4 @@
+-- Large envs: build CONCURRENTLY first (then the IF NOT EXISTS below no-ops):
+--   SET lock_timeout=0; SET statement_timeout=0;
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS "relation_versions_blocks_to_entity_idx" ON "relation_versions" USING btree ("to_entity_id","space_id","valid_from_key") WHERE "type_id" = 'beaba5cb-a677-41a8-b353-77030613fc70'::uuid;
+CREATE INDEX IF NOT EXISTS "relation_versions_blocks_to_entity_idx" ON "relation_versions" USING btree ("to_entity_id","space_id","valid_from_key") WHERE "relation_versions"."type_id" = 'beaba5cb-a677-41a8-b353-77030613fc70'::uuid;

--- a/api/drizzle/meta/0064_snapshot.json
+++ b/api/drizzle/meta/0064_snapshot.json
@@ -1,0 +1,3904 @@
+{
+  "id": "e7ef5434-73dd-4eac-af59-3b328c28a2cb",
+  "prevId": "2873933b-353c-4050-9cb9-0c3bb542f723",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.app_webhooks": {
+      "name": "app_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "app_name": {
+          "name": "app_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_webhooks_app_name_unique": {
+          "name": "app_webhooks_app_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "app_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.atlas_checkpoints": {
+      "name": "atlas_checkpoints",
+      "schema": "",
+      "columns": {
+        "indexer_id": {
+          "name": "indexer_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph_state_version": {
+          "name": "graph_state_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_compatibility_marker": {
+          "name": "runtime_compatibility_marker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_space_id": {
+          "name": "root_space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph_state_blob": {
+          "name": "graph_state_blob",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emission_baseline_blob": {
+          "name": "emission_baseline_blob",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.edit_versions": {
+      "name": "edit_versions",
+      "schema": "",
+      "columns": {
+        "edit_id": {
+          "name": "edit_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_key": {
+          "name": "version_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "edit_versions_version_key_idx": {
+          "name": "edit_versions_version_key_idx",
+          "columns": [
+            {
+              "expression": "version_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "edit_versions_block_sequence_unique": {
+          "name": "edit_versions_block_sequence_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "block_number",
+            "sequence"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.editors": {
+      "name": "editors",
+      "schema": "",
+      "columns": {
+        "member_space_id": {
+          "name": "member_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "editors_space_id_idx": {
+          "name": "editors_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "editors_member_space_id_space_id_pk": {
+          "name": "editors_member_space_id_space_id_pk",
+          "columns": [
+            "member_space_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_block": {
+          "name": "created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at_block": {
+          "name": "updated_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "entities_updated_at_idx": {
+          "name": "entities_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entities_updated_at_id_idx": {
+          "name": "entities_updated_at_id_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entities_created_at_id_idx": {
+          "name": "entities_created_at_id_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.global_scores": {
+      "name": "global_scores",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ipfs_cache": {
+      "name": "ipfs_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_errored": {
+          "name": "is_errored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "block": {
+          "name": "block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space": {
+          "name": "space",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ipfs_cache_uri_unique": {
+          "name": "ipfs_cache_uri_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uri"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.local_scores": {
+      "name": "local_scores",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_local_scores_space_id": {
+          "name": "idx_local_scores_space_id",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_local_scores_entity_id": {
+          "name": "idx_local_scores_entity_id",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_local_scores_space_score": {
+          "name": "idx_local_scores_space_score",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "local_scores_entity_id_space_id_pk": {
+          "name": "local_scores_entity_id_space_id_pk",
+          "columns": [
+            "entity_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "member_space_id": {
+          "name": "member_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "members_space_id_idx": {
+          "name": "members_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "members_member_space_id_space_id_pk": {
+          "name": "members_member_space_id_space_id_pk",
+          "columns": [
+            "member_space_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta": {
+      "name": "meta",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_deliveries": {
+      "name": "notification_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "outbox_id": {
+          "name": "outbox_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_deliveries_pending": {
+          "name": "idx_deliveries_pending",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_deliveries_outbox_id_notification_outbox_id_fk": {
+          "name": "notification_deliveries_outbox_id_notification_outbox_id_fk",
+          "tableFrom": "notification_deliveries",
+          "tableTo": "notification_outbox",
+          "columnsFrom": [
+            "outbox_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_deliveries_webhook_id_app_webhooks_id_fk": {
+          "name": "notification_deliveries_webhook_id_app_webhooks_id_fk",
+          "tableFrom": "notification_deliveries",
+          "tableTo": "app_webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_deliveries_outbox_id_webhook_id_unique": {
+          "name": "notification_deliveries_outbox_id_webhook_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "outbox_id",
+            "webhook_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_outbox": {
+      "name": "notification_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_outbox_idempotency_key_unique": {
+          "name": "notification_outbox_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_poll_cursors": {
+      "name": "notification_poll_cursors",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor_updated_at": {
+          "name": "cursor_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cursor_id": {
+          "name": "cursor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_actions": {
+      "name": "proposal_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "proposalActionType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_uri": {
+          "name": "content_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quorum": {
+          "name": "quorum",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fast_threshold": {
+          "name": "fast_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slow_threshold": {
+          "name": "slow_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "proposal_actions_proposal_id_idx": {
+          "name": "proposal_actions_proposal_id_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_actions_action_type_idx": {
+          "name": "proposal_actions_action_type_idx",
+          "columns": [
+            {
+              "expression": "action_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_actions_proposal_action_target_idx": {
+          "name": "proposal_actions_proposal_action_target_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_actions_proposal_id_proposals_id_fk": {
+          "name": "proposal_actions_proposal_id_proposals_id_fk",
+          "tableFrom": "proposal_actions",
+          "tableTo": "proposals",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_tally_queue": {
+      "name": "proposal_tally_queue",
+      "schema": "",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "proposal_tally_queue_proposal_id_proposals_id_fk": {
+          "name": "proposal_tally_queue_proposal_id_proposals_id_fk",
+          "tableFrom": "proposal_tally_queue",
+          "tableTo": "proposals",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_votes": {
+      "name": "proposal_votes",
+      "schema": "",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "voteOption",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_block": {
+          "name": "created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "proposal_votes_space_id_idx": {
+          "name": "proposal_votes_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_votes_voter_id_idx": {
+          "name": "proposal_votes_voter_id_idx",
+          "columns": [
+            {
+              "expression": "voter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_votes_vote_idx": {
+          "name": "proposal_votes_vote_idx",
+          "columns": [
+            {
+              "expression": "vote",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_votes_proposal_id_proposals_id_fk": {
+          "name": "proposal_votes_proposal_id_proposals_id_fk",
+          "tableFrom": "proposal_votes",
+          "tableTo": "proposals",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "proposal_votes_space_id_spaces_id_fk": {
+          "name": "proposal_votes_space_id_spaces_id_fk",
+          "tableFrom": "proposal_votes",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "proposal_votes_proposal_id_voter_id_pk": {
+          "name": "proposal_votes_proposal_id_voter_id_pk",
+          "columns": [
+            "proposal_id",
+            "voter_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposals": {
+      "name": "proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_by": {
+          "name": "proposed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voting_mode": {
+          "name": "voting_mode",
+          "type": "votingMode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quorum": {
+          "name": "quorum",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_block": {
+          "name": "created_at_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yes_count": {
+          "name": "yes_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "no_count": {
+          "name": "no_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "abstain_count": {
+          "name": "abstain_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "proposals_space_id_idx": {
+          "name": "proposals_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_proposed_by_idx": {
+          "name": "proposals_proposed_by_idx",
+          "columns": [
+            {
+              "expression": "proposed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_created_at_idx": {
+          "name": "proposals_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_space_created_at_idx": {
+          "name": "proposals_space_created_at_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_space_end_time_idx": {
+          "name": "proposals_space_end_time_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposals_space_start_time_idx": {
+          "name": "proposals_space_start_time_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposals_space_id_spaces_id_fk": {
+          "name": "proposals_space_id_spaces_id_fk",
+          "tableFrom": "proposals",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ranks.ranking_blocks": {
+      "name": "ranking_blocks",
+      "schema": "ranks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filter": {
+          "name": "filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restriction_id": {
+          "name": "restriction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ranking_blocks_id_space_id_pk": {
+          "name": "ranking_blocks_id_space_id_pk",
+          "columns": [
+            "id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ranks.ranking_items": {
+      "name": "ranking_items",
+      "schema": "ranks",
+      "columns": {
+        "ranking_id": {
+          "name": "ranking_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ranking_items_ranking_id_entity_id_space_id_pk": {
+          "name": "ranking_items_ranking_id_entity_id_space_id_pk",
+          "columns": [
+            "ranking_id",
+            "entity_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ranks.ranking_scores": {
+      "name": "ranking_scores",
+      "schema": "ranks",
+      "columns": {
+        "block_id": {
+          "name": "block_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ranking_scores_block_position_idx": {
+          "name": "ranking_scores_block_position_idx",
+          "columns": [
+            {
+              "expression": "block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ranking_scores_block_id_entity_id_space_id_pk": {
+          "name": "ranking_scores_block_id_entity_id_space_id_pk",
+          "columns": [
+            "block_id",
+            "entity_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ranks.rankings": {
+      "name": "rankings",
+      "schema": "ranks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_address": {
+          "name": "author_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank_type": {
+          "name": "rank_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at_block": {
+          "name": "updated_at_block",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "update_index": {
+          "name": "update_index",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rankings_block_id_idx": {
+          "name": "rankings_block_id_idx",
+          "columns": [
+            {
+              "expression": "block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rankings_block_space_idx": {
+          "name": "rankings_block_space_idx",
+          "columns": [
+            {
+              "expression": "block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rankings_space_id_idx": {
+          "name": "rankings_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rankings_id_space_id_pk": {
+          "name": "rankings_id_space_id_pk",
+          "columns": [
+            "id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ranks.editors": {
+      "name": "editors",
+      "schema": "ranks",
+      "columns": {
+        "member_space_id": {
+          "name": "member_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ranks_editors_space_id_idx": {
+          "name": "ranks_editors_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "editors_member_space_id_space_id_pk": {
+          "name": "editors_member_space_id_space_id_pk",
+          "columns": [
+            "member_space_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ranks.members": {
+      "name": "members",
+      "schema": "ranks",
+      "columns": {
+        "member_space_id": {
+          "name": "member_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ranks_members_space_id_idx": {
+          "name": "ranks_members_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "members_member_space_id_space_id_pk": {
+          "name": "members_member_space_id_space_id_pk",
+          "columns": [
+            "member_space_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relation_versions": {
+      "name": "relation_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "relation_id": {
+          "name": "relation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_space_id": {
+          "name": "from_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_entity_id": {
+          "name": "to_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_space_id": {
+          "name": "to_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_from_key": {
+          "name": "valid_from_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_to_key": {
+          "name": "valid_to_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_root_id": {
+          "name": "context_root_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_edge_type_id": {
+          "name": "context_edge_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_last_to_entity_id": {
+          "name": "context_last_to_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "relation_versions_relation_idx": {
+          "name": "relation_versions_relation_idx",
+          "columns": [
+            {
+              "expression": "relation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_entity_idx": {
+          "name": "relation_versions_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_open_idx": {
+          "name": "relation_versions_open_idx",
+          "columns": [
+            {
+              "expression": "relation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"relation_versions\".\"valid_to_key\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_range_idx": {
+          "name": "relation_versions_range_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_from_entity_type_idx": {
+          "name": "relation_versions_from_entity_type_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_blocks_to_entity_idx": {
+          "name": "relation_versions_blocks_to_entity_idx",
+          "columns": [
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"relation_versions\".\"type_id\" = 'beaba5cb-a677-41a8-b353-77030613fc70'::uuid",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_from_entity_valid_to_idx": {
+          "name": "relation_versions_from_entity_valid_to_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_to_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"relation_versions\".\"valid_to_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relation_versions_context_root_idx": {
+          "name": "relation_versions_context_root_idx",
+          "columns": [
+            {
+              "expression": "context_root_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"relation_versions\".\"context_root_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relations": {
+      "name": "relations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_space_id": {
+          "name": "from_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_version_id": {
+          "name": "from_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_entity_id": {
+          "name": "to_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_space_id": {
+          "name": "to_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_version_id": {
+          "name": "to_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "relations_entity_id_idx": {
+          "name": "relations_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_type_id_idx": {
+          "name": "relations_type_id_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_from_entity_id_idx": {
+          "name": "relations_from_entity_id_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_to_entity_id_idx": {
+          "name": "relations_to_entity_id_idx",
+          "columns": [
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_space_id_idx": {
+          "name": "relations_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_space_from_to_idx": {
+          "name": "relations_space_from_to_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_space_type_idx": {
+          "name": "relations_space_type_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_to_entity_space_idx": {
+          "name": "relations_to_entity_space_idx",
+          "columns": [
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_from_entity_space_idx": {
+          "name": "relations_from_entity_space_idx",
+          "columns": [
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_entity_type_space_idx": {
+          "name": "relations_entity_type_space_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relations_type_from_to_idx": {
+          "name": "relations_type_from_to_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.space_scores": {
+      "name": "space_scores",
+      "schema": "",
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.spaces": {
+      "name": "spaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "spaceTypes",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "spaces_topic_id_idx": {
+          "name": "spaces_topic_id_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "spaces_topic_id_entities_id_fk": {
+          "name": "spaces_topic_id_entities_id_fk",
+          "tableFrom": "spaces",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subspace_topics": {
+      "name": "subspace_topics",
+      "schema": "",
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "subspace_topics_space_id_idx": {
+          "name": "subspace_topics_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subspace_topics_topic_id_idx": {
+          "name": "subspace_topics_topic_id_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subspace_topics_space_id_spaces_id_fk": {
+          "name": "subspace_topics_space_id_spaces_id_fk",
+          "tableFrom": "subspace_topics",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "subspace_topics_topic_id_entities_id_fk": {
+          "name": "subspace_topics_topic_id_entities_id_fk",
+          "tableFrom": "subspace_topics",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "subspace_topics_space_id_topic_id_pk": {
+          "name": "subspace_topics_space_id_topic_id_pk",
+          "columns": [
+            "space_id",
+            "topic_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subspaces": {
+      "name": "subspaces",
+      "schema": "",
+      "columns": {
+        "parent_space_id": {
+          "name": "parent_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_space_id": {
+          "name": "child_space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "subspaceType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'verified'"
+        }
+      },
+      "indexes": {
+        "subspaces_parent_space_id_idx": {
+          "name": "subspaces_parent_space_id_idx",
+          "columns": [
+            {
+              "expression": "parent_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subspaces_child_space_id_idx": {
+          "name": "subspaces_child_space_id_idx",
+          "columns": [
+            {
+              "expression": "child_space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subspaces_parent_space_id_spaces_id_fk": {
+          "name": "subspaces_parent_space_id_spaces_id_fk",
+          "tableFrom": "subspaces",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "parent_space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "subspaces_child_space_id_spaces_id_fk": {
+          "name": "subspaces_child_space_id_spaces_id_fk",
+          "tableFrom": "subspaces",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "child_space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "subspaces_parent_space_id_child_space_id_type_pk": {
+          "name": "subspaces_parent_space_id_child_space_id_type_pk",
+          "columns": [
+            "parent_space_id",
+            "child_space_id",
+            "type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_votes": {
+      "name": "user_votes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voted_at": {
+          "name": "voted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_user_votes_object": {
+          "name": "idx_user_votes_object",
+          "columns": [
+            {
+              "expression": "object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_votes_user_id_object_id_object_type_space_id_unique": {
+          "name": "user_votes_user_id_object_id_object_type_space_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "object_id",
+            "object_type",
+            "space_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.value_versions": {
+      "name": "value_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from_key": {
+          "name": "valid_from_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_to_key": {
+          "name": "valid_to_key",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boolean": {
+          "name": "boolean",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integer": {
+          "name": "integer",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "float": {
+          "name": "float",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decimal": {
+          "name": "decimal",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime": {
+          "name": "datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "point": {
+          "name": "point",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rect": {
+          "name": "rect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_utc": {
+          "name": "time_utc",
+          "type": "time with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime_utc": {
+          "name": "datetime_utc",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_root_id": {
+          "name": "context_root_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_edge_type_id": {
+          "name": "context_edge_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_last_to_entity_id": {
+          "name": "context_last_to_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "value_versions_entity_idx": {
+          "name": "value_versions_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_lookup_idx": {
+          "name": "value_versions_lookup_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_open_idx": {
+          "name": "value_versions_open_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"value_versions\".\"valid_to_key\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_range_idx": {
+          "name": "value_versions_range_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_entity_space_valid_to_idx": {
+          "name": "value_versions_entity_space_valid_to_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_to_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"value_versions\".\"valid_to_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "value_versions_context_root_idx": {
+          "name": "value_versions_context_root_idx",
+          "columns": [
+            {
+              "expression": "context_root_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"value_versions\".\"context_root_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.values": {
+      "name": "values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boolean": {
+          "name": "boolean",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integer": {
+          "name": "integer",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "float": {
+          "name": "float",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decimal": {
+          "name": "decimal",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime": {
+          "name": "datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "point": {
+          "name": "point",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rect": {
+          "name": "rect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_utc": {
+          "name": "time_utc",
+          "type": "time with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime_utc": {
+          "name": "datetime_utc",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "values_property_id_idx": {
+          "name": "values_property_id_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_entity_id_idx": {
+          "name": "values_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_space_id_idx": {
+          "name": "values_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_boolean_idx": {
+          "name": "values_boolean_idx",
+          "columns": [
+            {
+              "expression": "boolean",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_integer_idx": {
+          "name": "values_integer_idx",
+          "columns": [
+            {
+              "expression": "integer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_float_idx": {
+          "name": "values_float_idx",
+          "columns": [
+            {
+              "expression": "float",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_decimal_idx": {
+          "name": "values_decimal_idx",
+          "columns": [
+            {
+              "expression": "decimal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_text_idx": {
+          "name": "values_text_idx",
+          "columns": [
+            {
+              "expression": "text",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "length(\"values\".\"text\") <= 2000",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_date_idx": {
+          "name": "values_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_time_idx": {
+          "name": "values_time_idx",
+          "columns": [
+            {
+              "expression": "time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_datetime_idx": {
+          "name": "values_datetime_idx",
+          "columns": [
+            {
+              "expression": "datetime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_point_idx": {
+          "name": "values_point_idx",
+          "columns": [
+            {
+              "expression": "point",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_rect_idx": {
+          "name": "values_rect_idx",
+          "columns": [
+            {
+              "expression": "rect",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_entity_property_idx": {
+          "name": "values_entity_property_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_entity_space_idx": {
+          "name": "values_entity_space_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_property_space_idx": {
+          "name": "values_property_space_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_entity_property_space_idx": {
+          "name": "values_entity_property_space_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_language_idx": {
+          "name": "values_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_unit_idx": {
+          "name": "values_unit_idx",
+          "columns": [
+            {
+              "expression": "unit",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_time_utc_idx": {
+          "name": "values_time_utc_idx",
+          "columns": [
+            {
+              "expression": "time_utc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "values_datetime_utc_idx": {
+          "name": "values_datetime_utc_idx",
+          "columns": [
+            {
+              "expression": "datetime_utc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_timestamp": {
+          "name": "block_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_votes_voter_id": {
+          "name": "idx_votes_voter_id",
+          "columns": [
+            {
+              "expression": "voter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_votes_object_type_object_id_space_id": {
+          "name": "idx_votes_object_type_object_id_space_id",
+          "columns": [
+            {
+              "expression": "object_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes_count": {
+      "name": "votes_count",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upvotes": {
+          "name": "upvotes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "downvotes": {
+          "name": "downvotes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_votes_count_updated_at": {
+          "name": "idx_votes_count_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "object_type = 0",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "votes_count_object_id_object_type_space_id_unique": {
+          "name": "votes_count_object_id_object_type_space_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "object_id",
+            "object_type",
+            "space_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.proposalActionType": {
+      "name": "proposalActionType",
+      "schema": "public",
+      "values": [
+        "AddMember",
+        "RemoveMember",
+        "AddEditor",
+        "RemoveEditor",
+        "UnflagEditor",
+        "Publish",
+        "Flag",
+        "Unflag",
+        "UpdateVotingSettings",
+        "Unknown",
+        "SubspaceVerified",
+        "SubspaceUnverified",
+        "SubspaceRelated",
+        "SubspaceUnrelated",
+        "SubspaceTopicDeclared",
+        "SubspaceTopicRemoved",
+        "SetTopic",
+        "UnsetTopic"
+      ]
+    },
+    "public.spaceTypes": {
+      "name": "spaceTypes",
+      "schema": "public",
+      "values": [
+        "DAO",
+        "Personal"
+      ]
+    },
+    "public.subspaceType": {
+      "name": "subspaceType",
+      "schema": "public",
+      "values": [
+        "verified",
+        "related"
+      ]
+    },
+    "public.voteOption": {
+      "name": "voteOption",
+      "schema": "public",
+      "values": [
+        "Yes",
+        "No",
+        "Abstain"
+      ]
+    },
+    "public.votingMode": {
+      "name": "votingMode",
+      "schema": "public",
+      "values": [
+        "Fast",
+        "Slow"
+      ]
+    }
+  },
+  "schemas": {
+    "ranks": "ranks"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -449,6 +449,13 @@
       "when": 1781536970769,
       "tag": "0063_context_aware_diff_columns",
       "breakpoints": true
+    },
+    {
+      "idx": 64,
+      "version": "7",
+      "when": 1781897486376,
+      "tag": "0064_blocks_to_entity_idx",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/services/storage/schema.ts
+++ b/api/src/services/storage/schema.ts
@@ -927,6 +927,12 @@ export const relationVersions = pgTable(
 		// Composite index for batch block relation discovery queries that filter on
 		// from_entity_id + type_id with temporal range predicates
 		index("relation_versions_from_entity_type_idx").on(table.fromEntityId, table.typeId, table.validFromKey),
+		// Partial index for the reverse (block child -> parent) BLOCKS lookup used by
+		// proposal-diff block folding (batchGetBlockParentsAtVersion: WHERE to_entity_id
+		// = ANY AND type_id = BLOCKS AND space_id ...). Partial on BLOCKS keeps it small.
+		index("relation_versions_blocks_to_entity_idx")
+			.on(table.toEntityId, table.spaceId, table.validFromKey)
+			.where(sql`${table.typeId} = 'beaba5cb-a677-41a8-b353-77030613fc70'::uuid`),
 		// Partial index for version discovery queries that scan valid_to_key
 		// to find edits that deleted/superseded relations on an entity
 		index("relation_versions_from_entity_valid_to_idx")

--- a/api/src/versioned/__tests__/proposal-diff-edit-flow.test.ts
+++ b/api/src/versioned/__tests__/proposal-diff-edit-flow.test.ts
@@ -628,6 +628,10 @@ describe.skipIf(SKIP_INTEGRATION)("Proposal Diff - Full GRC-20 Edit Flow", () =>
 			relViewM2: "21000000-0006-4000-8000-000000000012",
 			propMultiConfig: "21000000-0008-4000-8000-000000000007",
 			actMultiConfig: "21000000-000a-4000-8000-000000000007",
+			// Scenario X: proposal UNSETS an existing image's IMAGE_URL (reuses pageU/imgU).
+			relCoverX: "21000000-0006-4000-8000-000000000013",
+			propUnsetMedia: "21000000-0008-4000-8000-000000000008",
+			actUnsetMedia: "21000000-000a-4000-8000-000000000008",
 		}
 		const RANKING_BLOCK_TYPE = "150db6defe2344f0805afa57502e2c32"
 
@@ -848,6 +852,27 @@ describe.skipIf(SKIP_INTEGRATION)("Proposal Diff - Full GRC-20 Edit Flow", () =>
 							.build(),
 					contentUri: generateTestUri("fold-multi-config"),
 				})
+				// Proposal X: unset the existing image's IMAGE_URL while pointing a Cover relation at it.
+				await createProposalWithEdit(client2, {
+					proposalId: f.propUnsetMedia,
+					actionId: f.actUnsetMedia,
+					spaceId: f.space,
+					startTime: now - 1000,
+					endTime: now + 86400,
+					editBuilder: (editId) =>
+						new EditBuilder(editId)
+							.setName("Remove cover image url")
+							.setCreatedNow()
+							.updateEntity(uuidToId(f.imgU), (u) => u.unsetAll(uuidToId(SystemIds.IMAGE_URL_PROPERTY)))
+							.createRelationSimple(
+								uuidToId(f.relCoverX),
+								uuidToId(f.pageU),
+								uuidToId(f.imgU),
+								uuidToId(f.relTypeAvatar),
+							)
+							.build(),
+					contentUri: generateTestUri("fold-unset-media"),
+				})
 			} finally {
 				client2.release()
 			}
@@ -986,6 +1011,19 @@ describe.skipIf(SKIP_INTEGRATION)("Proposal Diff - Full GRC-20 Edit Flow", () =>
 			// Each parent's fold must carry its OWN config — not a single block-keyed collision.
 			expect(viewOf(f.pageM1)).toBe(n(SystemIds.GALLERY_VIEW))
 			expect(viewOf(f.pageM2)).toBe(n(SystemIds.LIST_VIEW))
+		})
+
+		it("removes a relation's inlined media URL when the proposal unsets it", async () => {
+			const res = await v2App.request(`/v2/versioned/proposals/${f.propUnsetMedia}/diff?spaceId=${f.space}`)
+			expect(res.status).toBe(200)
+			const body = await res.json()
+			const page = body.entities.find((e: {entityId: string}) => e.entityId === n(f.pageU))
+			expect(page).toBeDefined()
+			const rel = page.relations.find((r: {after?: {toEntityId: string}}) => r.after?.toEntityId === n(f.imgU))
+			expect(rel).toBeDefined()
+			// The proposal unset IMAGE_URL → no stale base-version URL should remain inlined.
+			expect(rel.after.imageUrl ?? null).toBeNull()
+			expect(rel.after.videoUrl ?? null).toBeNull()
 		})
 	})
 })

--- a/api/src/versioned/__tests__/proposal-diff-edit-flow.test.ts
+++ b/api/src/versioned/__tests__/proposal-diff-edit-flow.test.ts
@@ -610,6 +610,13 @@ describe.skipIf(SKIP_INTEGRATION)("Proposal Diff - Full GRC-20 Edit Flow", () =>
 			relTypesR: "21000000-0006-4000-8000-00000000000b",
 			propEditRank: "21000000-0008-4000-8000-000000000005",
 			actEditRank: "21000000-000a-4000-8000-000000000005",
+			// Scenario U: existing (DB-typed) image whose IMAGE_URL is updated in the proposal.
+			pageU: "21000000-0002-4000-8000-00000000000b",
+			imgU: "21000000-0002-4000-8000-00000000000c",
+			relImgUTypes: "21000000-0006-4000-8000-00000000000c",
+			relCoverU: "21000000-0006-4000-8000-00000000000d",
+			propUpdateMedia: "21000000-0008-4000-8000-000000000006",
+			actUpdateMedia: "21000000-000a-4000-8000-000000000006",
 		}
 		const RANKING_BLOCK_TYPE = "150db6defe2344f0805afa57502e2c32"
 
@@ -660,6 +667,10 @@ describe.skipIf(SKIP_INTEGRATION)("Proposal Diff - Full GRC-20 Edit Flow", () =>
 				await val(`${f.rankR}-name`, f.rankR, SystemIds.NAME_PROPERTY, "Old Rank")
 				await rel(f.relBlocksR, f.pageR, f.rankR, SystemIds.BLOCKS)
 				await rel(f.relTypesR, f.rankR, RANKING_BLOCK_TYPE, SystemIds.TYPES_PROPERTY)
+				// Scenario U: page U + an EXISTING image entity (DB-typed, url "ipfs://oldcover").
+				await val(`${f.pageU}-name`, f.pageU, SystemIds.NAME_PROPERTY, "Page U")
+				await val(`${f.imgU}-url`, f.imgU, SystemIds.IMAGE_URL_PROPERTY, "ipfs://oldcover")
+				await rel(f.relImgUTypes, f.imgU, SystemIds.IMAGE_TYPE, SystemIds.TYPES_PROPERTY)
 				await client.query("COMMIT")
 			} catch (e) {
 				await client.query("ROLLBACK")
@@ -770,6 +781,29 @@ describe.skipIf(SKIP_INTEGRATION)("Proposal Diff - Full GRC-20 Edit Flow", () =>
 							.build(),
 					contentUri: generateTestUri("fold-edit-rank"),
 				})
+				// Proposal U: update an existing image's url AND point a Cover relation at it.
+				await createProposalWithEdit(client2, {
+					proposalId: f.propUpdateMedia,
+					actionId: f.actUpdateMedia,
+					spaceId: f.space,
+					startTime: now - 1000,
+					endTime: now + 86400,
+					editBuilder: (editId) =>
+						new EditBuilder(editId)
+							.setName("Update cover image url")
+							.setCreatedNow()
+							.updateEntity(uuidToId(f.imgU), (u) =>
+								u.setText(uuidToId(SystemIds.IMAGE_URL_PROPERTY), "ipfs://newcover"),
+							)
+							.createRelationSimple(
+								uuidToId(f.relCoverU),
+								uuidToId(f.pageU),
+								uuidToId(f.imgU),
+								uuidToId(f.relTypeAvatar),
+							)
+							.build(),
+					contentUri: generateTestUri("fold-update-media"),
+				})
 			} finally {
 				client2.release()
 			}
@@ -877,6 +911,20 @@ describe.skipIf(SKIP_INTEGRATION)("Proposal Diff - Full GRC-20 Edit Flow", () =>
 			// The two pages cover distinct roots.
 			const all = new Set([...b1.entities, ...b2.entities].map((e: {entityId: string}) => e.entityId))
 			expect(all.size).toBe(2)
+		})
+
+		it("inlines the proposed (updated) URL for an existing DB-typed media entity, not the stale base URL", async () => {
+			const res = await v2App.request(`/v2/versioned/proposals/${f.propUpdateMedia}/diff?spaceId=${f.space}`)
+			expect(res.status).toBe(200)
+			const body = await res.json()
+			const ids = body.entities.map((e: {entityId: string}) => e.entityId)
+			expect(ids).toContain(n(f.pageU))
+			expect(ids).not.toContain(n(f.imgU))
+			const page = body.entities.find((e: {entityId: string}) => e.entityId === n(f.pageU))
+			const rel = page.relations.find((r: {after?: {toEntityId: string}}) => r.after?.toEntityId === n(f.imgU))
+			expect(rel).toBeDefined()
+			// The edit updated the image's IMAGE_URL; the proposed URL must win over the base-version URL.
+			expect(rel.after.imageUrl).toBe("ipfs://newcover")
 		})
 	})
 })

--- a/api/src/versioned/__tests__/proposal-diff-edit-flow.test.ts
+++ b/api/src/versioned/__tests__/proposal-diff-edit-flow.test.ts
@@ -632,6 +632,13 @@ describe.skipIf(SKIP_INTEGRATION)("Proposal Diff - Full GRC-20 Edit Flow", () =>
 			relCoverX: "21000000-0006-4000-8000-000000000013",
 			propUnsetMedia: "21000000-0008-4000-8000-000000000008",
 			actUnsetMedia: "21000000-000a-4000-8000-000000000008",
+			// Scenario Y: one edit SETS then UNSETS a new image's IMAGE_URL (last write wins → no url).
+			pageY: "21000000-0002-4000-8000-000000000010",
+			imgY: "21000000-0002-4000-8000-000000000011",
+			relImgYTypes: "21000000-0006-4000-8000-000000000014",
+			relCoverY: "21000000-0006-4000-8000-000000000015",
+			propSetUnsetMedia: "21000000-0008-4000-8000-000000000009",
+			actSetUnsetMedia: "21000000-000a-4000-8000-000000000009",
 		}
 		const RANKING_BLOCK_TYPE = "150db6defe2344f0805afa57502e2c32"
 
@@ -873,6 +880,37 @@ describe.skipIf(SKIP_INTEGRATION)("Proposal Diff - Full GRC-20 Edit Flow", () =>
 							.build(),
 					contentUri: generateTestUri("fold-unset-media"),
 				})
+				// Proposal Y: within ONE edit, set then unset a new image's IMAGE_URL.
+				// Last write wins → the proposed url must NOT be inlined onto the Cover relation.
+				await createProposalWithEdit(client2, {
+					proposalId: f.propSetUnsetMedia,
+					actionId: f.actSetUnsetMedia,
+					spaceId: f.space,
+					startTime: now - 1000,
+					endTime: now + 86400,
+					editBuilder: (editId) =>
+						new EditBuilder(editId)
+							.setName("Add then remove cover url")
+							.setCreatedNow()
+							.createEntity(uuidToId(f.imgY), (e) =>
+								e.text(uuidToId(SystemIds.IMAGE_URL_PROPERTY), "ipfs://shouldberemoved"),
+							)
+							.createRelationSimple(
+								uuidToId(f.relImgYTypes),
+								uuidToId(f.imgY),
+								uuidToId(SystemIds.IMAGE_TYPE),
+								uuidToId(SystemIds.TYPES_PROPERTY),
+							)
+							.updateEntity(uuidToId(f.imgY), (u) => u.unsetAll(uuidToId(SystemIds.IMAGE_URL_PROPERTY)))
+							.createRelationSimple(
+								uuidToId(f.relCoverY),
+								uuidToId(f.pageY),
+								uuidToId(f.imgY),
+								uuidToId(f.relTypeAvatar),
+							)
+							.build(),
+					contentUri: generateTestUri("fold-set-unset-media"),
+				})
 			} finally {
 				client2.release()
 			}
@@ -1022,6 +1060,19 @@ describe.skipIf(SKIP_INTEGRATION)("Proposal Diff - Full GRC-20 Edit Flow", () =>
 			const rel = page.relations.find((r: {after?: {toEntityId: string}}) => r.after?.toEntityId === n(f.imgU))
 			expect(rel).toBeDefined()
 			// The proposal unset IMAGE_URL → no stale base-version URL should remain inlined.
+			expect(rel.after.imageUrl ?? null).toBeNull()
+			expect(rel.after.videoUrl ?? null).toBeNull()
+		})
+
+		it("does not inline a proposed media URL that the same edit later unsets (last write wins)", async () => {
+			const res = await v2App.request(`/v2/versioned/proposals/${f.propSetUnsetMedia}/diff?spaceId=${f.space}`)
+			expect(res.status).toBe(200)
+			const body = await res.json()
+			const page = body.entities.find((e: {entityId: string}) => e.entityId === n(f.pageY))
+			expect(page).toBeDefined()
+			const rel = page.relations.find((r: {after?: {toEntityId: string}}) => r.after?.toEntityId === n(f.imgY))
+			expect(rel).toBeDefined()
+			// The edit set IMAGE_URL then unset it; the proposed url must not be inlined.
 			expect(rel.after.imageUrl ?? null).toBeNull()
 			expect(rel.after.videoUrl ?? null).toBeNull()
 		})

--- a/api/src/versioned/__tests__/proposal-diff-edit-flow.test.ts
+++ b/api/src/versioned/__tests__/proposal-diff-edit-flow.test.ts
@@ -617,6 +617,17 @@ describe.skipIf(SKIP_INTEGRATION)("Proposal Diff - Full GRC-20 Edit Flow", () =>
 			relCoverU: "21000000-0006-4000-8000-00000000000d",
 			propUpdateMedia: "21000000-0008-4000-8000-000000000006",
 			actUpdateMedia: "21000000-000a-4000-8000-000000000006",
+			// Scenario M: one data block shared under TWO parents, each with its own config.
+			pageM1: "21000000-0002-4000-8000-00000000000d",
+			pageM2: "21000000-0002-4000-8000-00000000000e",
+			sharedBlock: "21000000-0002-4000-8000-00000000000f",
+			relBlocksM1: "21000000-0006-4000-8000-00000000000e",
+			relBlocksM2: "21000000-0006-4000-8000-00000000000f",
+			relTypesShared: "21000000-0006-4000-8000-000000000010",
+			relViewM1: "21000000-0006-4000-8000-000000000011",
+			relViewM2: "21000000-0006-4000-8000-000000000012",
+			propMultiConfig: "21000000-0008-4000-8000-000000000007",
+			actMultiConfig: "21000000-000a-4000-8000-000000000007",
 		}
 		const RANKING_BLOCK_TYPE = "150db6defe2344f0805afa57502e2c32"
 
@@ -671,6 +682,13 @@ describe.skipIf(SKIP_INTEGRATION)("Proposal Diff - Full GRC-20 Edit Flow", () =>
 				await val(`${f.pageU}-name`, f.pageU, SystemIds.NAME_PROPERTY, "Page U")
 				await val(`${f.imgU}-url`, f.imgU, SystemIds.IMAGE_URL_PROPERTY, "ipfs://oldcover")
 				await rel(f.relImgUTypes, f.imgU, SystemIds.IMAGE_TYPE, SystemIds.TYPES_PROPERTY)
+				// Scenario M: a single data block embedded under two parents (distinct config carriers).
+				await val(`${f.pageM1}-name`, f.pageM1, SystemIds.NAME_PROPERTY, "Parent 1")
+				await val(`${f.pageM2}-name`, f.pageM2, SystemIds.NAME_PROPERTY, "Parent 2")
+				await val(`${f.sharedBlock}-name`, f.sharedBlock, SystemIds.NAME_PROPERTY, "Shared Block")
+				await rel(f.relBlocksM1, f.pageM1, f.sharedBlock, SystemIds.BLOCKS)
+				await rel(f.relBlocksM2, f.pageM2, f.sharedBlock, SystemIds.BLOCKS)
+				await rel(f.relTypesShared, f.sharedBlock, SystemIds.DATA_BLOCK, SystemIds.TYPES_PROPERTY)
 				await client.query("COMMIT")
 			} catch (e) {
 				await client.query("ROLLBACK")
@@ -804,6 +822,32 @@ describe.skipIf(SKIP_INTEGRATION)("Proposal Diff - Full GRC-20 Edit Flow", () =>
 							.build(),
 					contentUri: generateTestUri("fold-update-media"),
 				})
+				// Proposal M: set DIFFERENT views on the shared block's two parent configs.
+				await createProposalWithEdit(client2, {
+					proposalId: f.propMultiConfig,
+					actionId: f.actMultiConfig,
+					spaceId: f.space,
+					startTime: now - 1000,
+					endTime: now + 86400,
+					editBuilder: (editId) =>
+						new EditBuilder(editId)
+							.setName("Set per-parent views")
+							.setCreatedNow()
+							.createRelationSimple(
+								uuidToId(f.relViewM1),
+								uuidToId(f.relBlocksM1),
+								uuidToId(SystemIds.GALLERY_VIEW),
+								uuidToId(SystemIds.VIEW_PROPERTY),
+							)
+							.createRelationSimple(
+								uuidToId(f.relViewM2),
+								uuidToId(f.relBlocksM2),
+								uuidToId(SystemIds.LIST_VIEW),
+								uuidToId(SystemIds.VIEW_PROPERTY),
+							)
+							.build(),
+					contentUri: generateTestUri("fold-multi-config"),
+				})
 			} finally {
 				client2.release()
 			}
@@ -925,6 +969,23 @@ describe.skipIf(SKIP_INTEGRATION)("Proposal Diff - Full GRC-20 Edit Flow", () =>
 			expect(rel).toBeDefined()
 			// The edit updated the image's IMAGE_URL; the proposed URL must win over the base-version URL.
 			expect(rel.after.imageUrl).toBe("ipfs://newcover")
+		})
+
+		it("keeps per-parent config when one data block is shared under two parents", async () => {
+			const res = await v2App.request(`/v2/versioned/proposals/${f.propMultiConfig}/diff?spaceId=${f.space}`)
+			expect(res.status).toBe(200)
+			const body = await res.json()
+			const viewOf = (parentId: string) => {
+				const page = body.entities.find((e: {entityId: string}) => e.entityId === n(parentId))
+				const block = page?.blocks.find((b: {id: string}) => b.id === n(f.sharedBlock))
+				const viewRel = (block?.relations ?? []).find(
+					(r: {typeId: string}) => r.typeId === n(SystemIds.VIEW_PROPERTY),
+				)
+				return viewRel?.after?.toEntityId
+			}
+			// Each parent's fold must carry its OWN config — not a single block-keyed collision.
+			expect(viewOf(f.pageM1)).toBe(n(SystemIds.GALLERY_VIEW))
+			expect(viewOf(f.pageM2)).toBe(n(SystemIds.LIST_VIEW))
 		})
 	})
 })

--- a/api/src/versioned/__tests__/proposal-diff-edit-flow.test.ts
+++ b/api/src/versioned/__tests__/proposal-diff-edit-flow.test.ts
@@ -1531,16 +1531,17 @@ async function cleanupTestData(pool: Pool): Promise<void> {
 	try {
 		await client.query("BEGIN")
 
-		// Delete in reverse order of foreign key dependencies
-		await client.query(`DELETE FROM proposal_actions WHERE proposal_id::text LIKE '20000000-%'`)
-		await client.query(`DELETE FROM proposals WHERE id::text LIKE '20000000-%'`)
-		await client.query(`DELETE FROM relations WHERE from_entity_id::text LIKE '20000000-%'`)
-		await client.query(`DELETE FROM relation_versions WHERE from_entity_id::text LIKE '20000000-%'`)
-		await client.query(`DELETE FROM "values" WHERE entity_id::text LIKE '20000000-%'`)
-		await client.query(`DELETE FROM value_versions WHERE entity_id::text LIKE '20000000-%'`)
-		await client.query(`DELETE FROM edit_versions WHERE edit_id::text LIKE '20000000-%'`)
-		await client.query(`DELETE FROM entities WHERE id::text LIKE '20000000-%'`)
-		await client.query(`DELETE FROM spaces WHERE id::text LIKE '20000000-%'`)
+		// Delete in reverse order of foreign key dependencies.
+		// Covers both fixture prefixes used in this file: 20000000-* and 21000000-*.
+		await client.query(`DELETE FROM proposal_actions WHERE proposal_id::text ~ '^2[01]000000-'`)
+		await client.query(`DELETE FROM proposals WHERE id::text ~ '^2[01]000000-'`)
+		await client.query(`DELETE FROM relations WHERE from_entity_id::text ~ '^2[01]000000-'`)
+		await client.query(`DELETE FROM relation_versions WHERE from_entity_id::text ~ '^2[01]000000-'`)
+		await client.query(`DELETE FROM "values" WHERE entity_id::text ~ '^2[01]000000-'`)
+		await client.query(`DELETE FROM value_versions WHERE entity_id::text ~ '^2[01]000000-'`)
+		await client.query(`DELETE FROM edit_versions WHERE edit_id::text ~ '^2[01]000000-'`)
+		await client.query(`DELETE FROM entities WHERE id::text ~ '^2[01]000000-'`)
+		await client.query(`DELETE FROM spaces WHERE id::text ~ '^2[01]000000-'`)
 		await client.query(`DELETE FROM ipfs_cache WHERE uri LIKE 'ipfs://bafkreitest%'`)
 
 		await client.query("COMMIT")

--- a/api/src/versioned/__tests__/proposal-diff-edit-flow.test.ts
+++ b/api/src/versioned/__tests__/proposal-diff-edit-flow.test.ts
@@ -588,7 +588,30 @@ describe.skipIf(SKIP_INTEGRATION)("Proposal Diff - Full GRC-20 Edit Flow", () =>
 			relAvatar: "21000000-0006-4000-8000-000000000004",
 			propAddAvatar: "21000000-0008-4000-8000-000000000002",
 			actAddAvatar: "21000000-000a-4000-8000-000000000002",
+			// Scenario C: data block whose config (View) is set on the reified BLOCKS relation entity.
+			pageC: "21000000-0002-4000-8000-000000000005",
+			dataBlockC: "21000000-0002-4000-8000-000000000006",
+			relBlocksC: "21000000-0006-4000-8000-000000000005",
+			relTypesC: "21000000-0006-4000-8000-000000000006",
+			relViewConfig: "21000000-0006-4000-8000-000000000007",
+			propSetConfig: "21000000-0008-4000-8000-000000000003",
+			actSetConfig: "21000000-000a-4000-8000-000000000003",
+			// Scenario V: video block whose url is edited.
+			pageV: "21000000-0002-4000-8000-000000000007",
+			videoV: "21000000-0002-4000-8000-000000000008",
+			relBlocksV: "21000000-0006-4000-8000-000000000008",
+			relTypesV: "21000000-0006-4000-8000-000000000009",
+			propEditVideo: "21000000-0008-4000-8000-000000000004",
+			actEditVideo: "21000000-000a-4000-8000-000000000004",
+			// Scenario R: ranking block (a data-block subtype) whose name is edited.
+			pageR: "21000000-0002-4000-8000-000000000009",
+			rankR: "21000000-0002-4000-8000-00000000000a",
+			relBlocksR: "21000000-0006-4000-8000-00000000000a",
+			relTypesR: "21000000-0006-4000-8000-00000000000b",
+			propEditRank: "21000000-0008-4000-8000-000000000005",
+			actEditRank: "21000000-000a-4000-8000-000000000005",
 		}
+		const RANKING_BLOCK_TYPE = "150db6defe2344f0805afa57502e2c32"
 
 		beforeAll(async () => {
 			const db = drizzle(pool)
@@ -621,6 +644,22 @@ describe.skipIf(SKIP_INTEGRATION)("Proposal Diff - Full GRC-20 Edit Flow", () =>
 				await rel(f.relTypesA, f.blockA, SystemIds.TEXT_BLOCK, SystemIds.TYPES_PROPERTY)
 				// Scenario B: page B (name only); proposal will add an image + avatar relation.
 				await val(`${f.pageB}-name`, f.pageB, SystemIds.NAME_PROPERTY, "Page B")
+				// Scenario C: page C owns a data block; config lives on the reified BLOCKS relation.
+				await val(`${f.pageC}-name`, f.pageC, SystemIds.NAME_PROPERTY, "Page C")
+				await val(`${f.dataBlockC}-name`, f.dataBlockC, SystemIds.NAME_PROPERTY, "My Data Block")
+				// The BLOCKS relation's reified entity id (entity_id) == relBlocksC → config carrier.
+				await rel(f.relBlocksC, f.pageC, f.dataBlockC, SystemIds.BLOCKS)
+				await rel(f.relTypesC, f.dataBlockC, SystemIds.DATA_BLOCK, SystemIds.TYPES_PROPERTY)
+				// Scenario V: page V owns a video block (url "ipfs://oldvid").
+				await val(`${f.pageV}-name`, f.pageV, SystemIds.NAME_PROPERTY, "Page V")
+				await val(`${f.videoV}-url`, f.videoV, SystemIds.IMAGE_URL_PROPERTY, "ipfs://oldvid")
+				await rel(f.relBlocksV, f.pageV, f.videoV, SystemIds.BLOCKS)
+				await rel(f.relTypesV, f.videoV, SystemIds.VIDEO_BLOCK, SystemIds.TYPES_PROPERTY)
+				// Scenario R: page R owns a ranking block (name "Old Rank").
+				await val(`${f.pageR}-name`, f.pageR, SystemIds.NAME_PROPERTY, "Page R")
+				await val(`${f.rankR}-name`, f.rankR, SystemIds.NAME_PROPERTY, "Old Rank")
+				await rel(f.relBlocksR, f.pageR, f.rankR, SystemIds.BLOCKS)
+				await rel(f.relTypesR, f.rankR, RANKING_BLOCK_TYPE, SystemIds.TYPES_PROPERTY)
 				await client.query("COMMIT")
 			} catch (e) {
 				await client.query("ROLLBACK")
@@ -677,6 +716,60 @@ describe.skipIf(SKIP_INTEGRATION)("Proposal Diff - Full GRC-20 Edit Flow", () =>
 							.build(),
 					contentUri: generateTestUri("fold-add-avatar"),
 				})
+				// Proposal C: set a View config on the data block's reified BLOCKS relation entity.
+				await createProposalWithEdit(client2, {
+					proposalId: f.propSetConfig,
+					actionId: f.actSetConfig,
+					spaceId: f.space,
+					startTime: now - 1000,
+					endTime: now + 86400,
+					editBuilder: (editId) =>
+						new EditBuilder(editId)
+							.setName("Set data block view")
+							.setCreatedNow()
+							.createRelationSimple(
+								uuidToId(f.relViewConfig),
+								uuidToId(f.relBlocksC), // from = reified BLOCKS relation entity
+								uuidToId(SystemIds.GALLERY_VIEW),
+								uuidToId(SystemIds.VIEW_PROPERTY),
+							)
+							.build(),
+					contentUri: generateTestUri("fold-set-config"),
+				})
+				// Proposal V: edit the video block's url.
+				await createProposalWithEdit(client2, {
+					proposalId: f.propEditVideo,
+					actionId: f.actEditVideo,
+					spaceId: f.space,
+					startTime: now - 1000,
+					endTime: now + 86400,
+					editBuilder: (editId) =>
+						new EditBuilder(editId)
+							.setName("Edit video url")
+							.setCreatedNow()
+							.updateEntity(uuidToId(f.videoV), (u) =>
+								u.setText(uuidToId(SystemIds.IMAGE_URL_PROPERTY), "ipfs://newvid"),
+							)
+							.build(),
+					contentUri: generateTestUri("fold-edit-video"),
+				})
+				// Proposal R: rename the ranking block.
+				await createProposalWithEdit(client2, {
+					proposalId: f.propEditRank,
+					actionId: f.actEditRank,
+					spaceId: f.space,
+					startTime: now - 1000,
+					endTime: now + 86400,
+					editBuilder: (editId) =>
+						new EditBuilder(editId)
+							.setName("Rename ranking block")
+							.setCreatedNow()
+							.updateEntity(uuidToId(f.rankR), (u) =>
+								u.setText(uuidToId(SystemIds.NAME_PROPERTY), "New Rank"),
+							)
+							.build(),
+					contentUri: generateTestUri("fold-edit-rank"),
+				})
 			} finally {
 				client2.release()
 			}
@@ -711,6 +804,79 @@ describe.skipIf(SKIP_INTEGRATION)("Proposal Diff - Full GRC-20 Edit Flow", () =>
 			const rel = page.relations.find((r: {after?: {toEntityId: string}}) => r.after?.toEntityId === n(f.imgB))
 			expect(rel).toBeDefined()
 			expect(rel.after.imageUrl).toBe("ipfs://foldtestimg")
+		})
+
+		it("folds data-block config (from the reified BLOCKS relation entity) into the block", async () => {
+			const res = await v2App.request(`/v2/versioned/proposals/${f.propSetConfig}/diff?spaceId=${f.space}`)
+			expect(res.status).toBe(200)
+			const body = await res.json()
+			const ids = body.entities.map((e: {entityId: string}) => e.entityId)
+			// Only the page is a root; the reified config entity is folded, not top-level.
+			expect(ids).toContain(n(f.pageC))
+			expect(ids).not.toContain(n(f.relBlocksC))
+			const page = body.entities.find((e: {entityId: string}) => e.entityId === n(f.pageC))
+			const block = page.blocks.find((b: {id: string}) => b.id === n(f.dataBlockC))
+			expect(block).toBeDefined()
+			expect(block.type).toBe("dataBlock")
+			// The View config relation (authored on the reified entity) is folded onto the block.
+			const viewRel = (block.relations ?? []).find(
+				(r: {typeId: string; after?: {toEntityId: string}}) =>
+					r.typeId === n(SystemIds.VIEW_PROPERTY) && r.after?.toEntityId === n(SystemIds.GALLERY_VIEW),
+			)
+			expect(viewRel).toBeDefined()
+			expect(viewRel.changeType).toBe("ADD")
+		})
+
+		it("folds a video block (videoBlock type) under its parent", async () => {
+			const res = await v2App.request(`/v2/versioned/proposals/${f.propEditVideo}/diff?spaceId=${f.space}`)
+			expect(res.status).toBe(200)
+			const body = await res.json()
+			const ids = body.entities.map((e: {entityId: string}) => e.entityId)
+			expect(ids).toContain(n(f.pageV))
+			expect(ids).not.toContain(n(f.videoV))
+			const page = body.entities.find((e: {entityId: string}) => e.entityId === n(f.pageV))
+			const block = page.blocks.find((b: {id: string}) => b.id === n(f.videoV))
+			expect(block).toBeDefined()
+			expect(block.type).toBe("videoBlock")
+			expect(block.before).toBe("ipfs://oldvid")
+			expect(block.after).toBe("ipfs://newvid")
+		})
+
+		it("folds a ranking block as a dataBlock", async () => {
+			const res = await v2App.request(`/v2/versioned/proposals/${f.propEditRank}/diff?spaceId=${f.space}`)
+			expect(res.status).toBe(200)
+			const body = await res.json()
+			const page = body.entities.find((e: {entityId: string}) => e.entityId === n(f.pageR))
+			expect(page).toBeDefined()
+			const block = page.blocks.find((b: {id: string}) => b.id === n(f.rankR))
+			expect(block).toBeDefined()
+			expect(block.type).toBe("dataBlock")
+			expect(block.before).toBe("Old Rank")
+			expect(block.after).toBe("New Rank")
+		})
+
+		it("paginates over root entities (cursor crosses a page boundary)", async () => {
+			// proposalMultipleOps changes 2 root entities; limit=1 forces two pages.
+			const r1 = await v2App.request(
+				`/v2/versioned/proposals/${uuid.proposalMultipleOps}/diff?spaceId=${uuid.space1}&limit=1`,
+			)
+			expect(r1.status).toBe(200)
+			const b1 = await r1.json()
+			expect(b1.entities.length).toBe(1)
+			expect(b1.pagination.totalEntities).toBe(2)
+			expect(b1.pagination.hasMore).toBe(true)
+			expect(b1.pagination.cursor).toBeTruthy()
+
+			const r2 = await v2App.request(
+				`/v2/versioned/proposals/${uuid.proposalMultipleOps}/diff?spaceId=${uuid.space1}&limit=1&cursor=${encodeURIComponent(b1.pagination.cursor)}`,
+			)
+			expect(r2.status).toBe(200)
+			const b2 = await r2.json()
+			expect(b2.entities.length).toBe(1)
+			expect(b2.pagination.hasMore).toBe(false)
+			// The two pages cover distinct roots.
+			const all = new Set([...b1.entities, ...b2.entities].map((e: {entityId: string}) => e.entityId))
+			expect(all.size).toBe(2)
 		})
 	})
 })

--- a/api/src/versioned/__tests__/proposal-diff-edit-flow.test.ts
+++ b/api/src/versioned/__tests__/proposal-diff-edit-flow.test.ts
@@ -225,7 +225,7 @@ describe.skipIf(SKIP_INTEGRATION)("Proposal Diff - Full GRC-20 Edit Flow", () =>
 			const floatDiff = entityDiff.values.find((v: any) => v.propertyId === n(uuid.propFloat))
 			expect(floatDiff?.type).toBe("FLOAT64")
 			expect(floatDiff?.before).toBeNull()
-			expect(Number(floatDiff?.after)).toBeCloseTo(3.14159, 4)
+			expect(Number(floatDiff?.after)).toBeCloseTo(Math.PI, 4)
 		})
 	})
 
@@ -566,6 +566,153 @@ describe.skipIf(SKIP_INTEGRATION)("Proposal Diff - Full GRC-20 Edit Flow", () =>
 			expect(res.status).toBe(400)
 		})
 	})
+
+	// ==========================================================================
+	// 11. v2 folding — cross-parent block folding + media-property filtering
+	// ==========================================================================
+
+	describe("v2 folding (blocks + media)", () => {
+		let v2App: Hono
+		const f = {
+			space: "21000000-0001-4000-8000-000000000001",
+			pageA: "21000000-0002-4000-8000-000000000001",
+			blockA: "21000000-0002-4000-8000-000000000002",
+			relBlocksA: "21000000-0006-4000-8000-000000000001",
+			relTypesA: "21000000-0006-4000-8000-000000000002",
+			propEditBlock: "21000000-0008-4000-8000-000000000001",
+			actEditBlock: "21000000-000a-4000-8000-000000000001",
+			pageB: "21000000-0002-4000-8000-000000000003",
+			imgB: "21000000-0002-4000-8000-000000000004",
+			relTypeAvatar: "21000000-0005-4000-8000-000000000001",
+			relImgTypes: "21000000-0006-4000-8000-000000000003",
+			relAvatar: "21000000-0006-4000-8000-000000000004",
+			propAddAvatar: "21000000-0008-4000-8000-000000000002",
+			actAddAvatar: "21000000-000a-4000-8000-000000000002",
+		}
+
+		beforeAll(async () => {
+			const db = drizzle(pool)
+			v2App = new Hono()
+			v2App.route("/v2/versioned", createVersionedV2Router(db as any, runtime))
+
+			const now = Math.floor(Date.now() / 1000)
+			const client = await pool.connect()
+			try {
+				await client.query("BEGIN")
+				await client.query(
+					`INSERT INTO spaces (id, type, address) VALUES ($1, 'DAO', '0xFoldTestSpace') ON CONFLICT DO NOTHING`,
+					[f.space],
+				)
+				const val = (id: string, entity: string, prop: string, text: string) =>
+					client.query(
+						`INSERT INTO "values" (id, entity_id, property_id, space_id, text) VALUES ($1, $2, $3, $4, $5) ON CONFLICT DO NOTHING`,
+						[id, entity, prop, f.space, text],
+					)
+				const rel = (id: string, from: string, to: string, type: string) =>
+					client.query(
+						`INSERT INTO relations (id, entity_id, from_entity_id, to_entity_id, type_id, space_id) VALUES ($1, $1, $2, $3, $4, $5) ON CONFLICT DO NOTHING`,
+						[id, from, to, type, f.space],
+					)
+				// Scenario A: page A owns a text block B (markdown "old text").
+				await val(`${f.pageA}-name`, f.pageA, SystemIds.NAME_PROPERTY, "Page A")
+				await val(`${f.blockA}-name`, f.blockA, SystemIds.NAME_PROPERTY, "Block A")
+				await val(`${f.blockA}-md`, f.blockA, SystemIds.MARKDOWN_CONTENT, "old text")
+				await rel(f.relBlocksA, f.pageA, f.blockA, SystemIds.BLOCKS)
+				await rel(f.relTypesA, f.blockA, SystemIds.TEXT_BLOCK, SystemIds.TYPES_PROPERTY)
+				// Scenario B: page B (name only); proposal will add an image + avatar relation.
+				await val(`${f.pageB}-name`, f.pageB, SystemIds.NAME_PROPERTY, "Page B")
+				await client.query("COMMIT")
+			} catch (e) {
+				await client.query("ROLLBACK")
+				throw e
+			} finally {
+				client.release()
+			}
+
+			const client2 = await pool.connect()
+			try {
+				// Proposal A: edit block A's markdown. Page A is NOT in the edit → orphan parent.
+				await createProposalWithEdit(client2, {
+					proposalId: f.propEditBlock,
+					actionId: f.actEditBlock,
+					spaceId: f.space,
+					startTime: now - 1000,
+					endTime: now + 86400,
+					editBuilder: (editId) =>
+						new EditBuilder(editId)
+							.setName("Edit block text")
+							.setCreatedNow()
+							.updateEntity(uuidToId(f.blockA), (u) =>
+								u.setText(uuidToId(SystemIds.MARKDOWN_CONTENT), "new text"),
+							)
+							.build(),
+					contentUri: generateTestUri("fold-edit-block"),
+				})
+				// Proposal B: add an avatar image to page B (new IMAGE entity + relation).
+				await createProposalWithEdit(client2, {
+					proposalId: f.propAddAvatar,
+					actionId: f.actAddAvatar,
+					spaceId: f.space,
+					startTime: now - 1000,
+					endTime: now + 86400,
+					editBuilder: (editId) =>
+						new EditBuilder(editId)
+							.setName("Add avatar")
+							.setCreatedNow()
+							.createEntity(uuidToId(f.imgB), (e) =>
+								e.text(uuidToId(SystemIds.IMAGE_URL_PROPERTY), "ipfs://foldtestimg"),
+							)
+							.createRelationSimple(
+								uuidToId(f.relImgTypes),
+								uuidToId(f.imgB),
+								uuidToId(SystemIds.IMAGE_TYPE),
+								uuidToId(SystemIds.TYPES_PROPERTY),
+							)
+							.createRelationSimple(
+								uuidToId(f.relAvatar),
+								uuidToId(f.pageB),
+								uuidToId(f.imgB),
+								uuidToId(f.relTypeAvatar),
+							)
+							.build(),
+					contentUri: generateTestUri("fold-add-avatar"),
+				})
+			} finally {
+				client2.release()
+			}
+		})
+
+		it("folds an edited block under its (unchanged) parent page; block is not top-level", async () => {
+			const res = await v2App.request(`/v2/versioned/proposals/${f.propEditBlock}/diff?spaceId=${f.space}`)
+			expect(res.status).toBe(200)
+			const body = await res.json()
+			const ids = body.entities.map((e: {entityId: string}) => e.entityId)
+			// Page A is the only root (resolved via BLOCKS backlink); block B is folded, not top-level.
+			expect(ids).toContain(n(f.pageA))
+			expect(ids).not.toContain(n(f.blockA))
+			expect(body.pagination.totalEntities).toBe(1)
+			const page = body.entities.find((e: {entityId: string}) => e.entityId === n(f.pageA))
+			const block = page.blocks.find((b: {id: string}) => b.id === n(f.blockA))
+			expect(block).toBeDefined()
+			expect(block.type).toBe("textBlock")
+			expect(block.before).toBe("old text")
+			expect(block.after).toBe("new text")
+		})
+
+		it("drops a media-property entity and inlines its URL onto the parent relation", async () => {
+			const res = await v2App.request(`/v2/versioned/proposals/${f.propAddAvatar}/diff?spaceId=${f.space}`)
+			expect(res.status).toBe(200)
+			const body = await res.json()
+			const ids = body.entities.map((e: {entityId: string}) => e.entityId)
+			expect(ids).toContain(n(f.pageB))
+			// The IMAGE entity is dropped from the top level; its URL is inlined instead.
+			expect(ids).not.toContain(n(f.imgB))
+			const page = body.entities.find((e: {entityId: string}) => e.entityId === n(f.pageB))
+			const rel = page.relations.find((r: {after?: {toEntityId: string}}) => r.after?.toEntityId === n(f.imgB))
+			expect(rel).toBeDefined()
+			expect(rel.after.imageUrl).toBe("ipfs://foldtestimg")
+		})
+	})
 })
 
 // ============================================================================
@@ -847,9 +994,7 @@ async function setupTestData(pool: Pool): Promise<void> {
 					.updateEntity(uuidToId(uuid.entityExisting1), (u) =>
 						u.setInt64(uuidToId(uuid.propInt), BigInt(100)),
 					)
-					.updateEntity(uuidToId(uuid.entityExisting2), (u) =>
-						u.setFloat64(uuidToId(uuid.propFloat), 2.71828),
-					)
+					.updateEntity(uuidToId(uuid.entityExisting2), (u) => u.setFloat64(uuidToId(uuid.propFloat), Math.E))
 				return builder.build()
 			},
 			contentUri: generateTestUri("multiple-ops"),
@@ -871,7 +1016,7 @@ async function setupTestData(pool: Pool): Promise<void> {
 							.text(uuidToId(uuid.propText), "Entity with all types")
 							.bool(uuidToId(uuid.propBool), true)
 							.int64(uuidToId(uuid.propInt), BigInt(42))
-							.float64(uuidToId(uuid.propFloat), 3.14159),
+							.float64(uuidToId(uuid.propFloat), Math.PI),
 					)
 				return builder.build()
 			},

--- a/api/src/versioned/__tests__/proposal-diff-edit-flow.test.ts
+++ b/api/src/versioned/__tests__/proposal-diff-edit-flow.test.ts
@@ -31,6 +31,7 @@ import {afterAll, beforeAll, describe, expect, it} from "vitest"
 import {runtime} from "../../services/runtime"
 import {normalizeUuid} from "../../utils/uuid"
 import {createVersionedRouter} from "../router"
+import {createVersionedV2Router} from "../v2"
 
 /** Shorthand to normalize a UUID for response-body assertions. */
 const n = normalizeUuid
@@ -476,6 +477,93 @@ describe.skipIf(SKIP_INTEGRATION)("Proposal Diff - Full GRC-20 Edit Flow", () =>
 			const nonExistentId = "20000000-0008-4000-8000-000000000999"
 			const res = await app.request(`/versioned/proposals/${nonExistentId}/diff?spaceId=${uuid.space1}`)
 			expect(res.status).toBe(404)
+		})
+	})
+
+	// ==========================================================================
+	// 10. v2 enriched / context-aware proposal diff (/v2/versioned/...)
+	// ==========================================================================
+
+	describe("v2 enriched endpoints", () => {
+		let v2App: Hono
+
+		beforeAll(async () => {
+			const db = drizzle(pool)
+			v2App = new Hono()
+			v2App.route("/v2/versioned", createVersionedV2Router(db as any, runtime))
+			// Seed a NAME for propText so name resolution (enrichNames) is assertable.
+			await pool.query(
+				`INSERT INTO "values" (id, entity_id, property_id, space_id, text) VALUES ($1, $2, $3, $4, 'Text Property') ON CONFLICT DO NOTHING`,
+				[uuid.val(900), n(uuid.propText), n(SystemIds.NAME_PROPERTY), n(uuid.space1)],
+			)
+		})
+
+		it("returns the same set of changed entities as v1 (enrichment preserves the diff)", async () => {
+			const [v1Res, v2Res] = await Promise.all([
+				app.request(`/versioned/proposals/${uuid.proposalMultipleOps}/diff?spaceId=${uuid.space1}`),
+				v2App.request(`/v2/versioned/proposals/${uuid.proposalMultipleOps}/diff?spaceId=${uuid.space1}`),
+			])
+			expect(v1Res.status).toBe(200)
+			expect(v2Res.status).toBe(200)
+			const v1 = await v1Res.json()
+			const v2 = await v2Res.json()
+			const ids = (b: {entities: {entityId: string}[]}) => b.entities.map((e) => e.entityId).sort()
+			expect(ids(v2)).toEqual(ids(v1))
+			expect(v2.pagination.totalEntities).toBe(v1.pagination.totalEntities)
+		})
+
+		it("returns the grouped/enriched shape with propertyName resolved", async () => {
+			const res = await v2App.request(
+				`/v2/versioned/proposals/${uuid.proposalCreateEntity}/diff?spaceId=${uuid.space1}`,
+			)
+			expect(res.status).toBe(200)
+			const body = await res.json()
+			const entity = body.entities.find((e: {entityId: string}) => e.entityId === n(uuid.entityNew1))
+			expect(entity).toBeDefined()
+			expect(Array.isArray(entity.groupKeys)).toBe(true)
+			expect(Array.isArray(entity.blocks)).toBe(true)
+			const textChange = entity.values.find((v: {propertyId: string}) => v.propertyId === n(uuid.propText))
+			expect(textChange).toBeDefined()
+			expect(textChange).toHaveProperty("propertyName")
+			expect(textChange.propertyName).toBe("Text Property")
+		})
+
+		it("relation changes carry typeName + toEntityName fields", async () => {
+			const res = await v2App.request(
+				`/v2/versioned/proposals/${uuid.proposalCreateRelation}/diff?spaceId=${uuid.space1}`,
+			)
+			expect(res.status).toBe(200)
+			const body = await res.json()
+			const withRel = body.entities.find((e: {relations: unknown[]}) => e.relations.length > 0)
+			expect(withRel).toBeDefined()
+			const rel = withRel.relations[0]
+			expect(rel).toHaveProperty("typeName")
+			expect(rel.after ?? rel.before).toHaveProperty("toEntityName")
+		})
+
+		it("grouped (multi-proposal) v2 endpoint returns enriched entities", async () => {
+			const res = await v2App.request(
+				`/v2/versioned/proposal-groups/diff?spaceId=${uuid.space1}&proposalIds=${uuid.proposalCreateEntity},${uuid.proposalCreateRelation}`,
+			)
+			expect(res.status).toBe(200)
+			const body = await res.json()
+			expect(body.mode).toBe("active")
+			expect(Array.isArray(body.entities)).toBe(true)
+			expect(body.entities.length).toBeGreaterThan(0)
+		})
+
+		it("returns 404 for a non-existent proposal", async () => {
+			const res = await v2App.request(
+				`/v2/versioned/proposals/20000000-0008-4000-8000-000000000999/diff?spaceId=${uuid.space1}`,
+			)
+			expect(res.status).toBe(404)
+		})
+
+		it("returns 400 for an invalid spaceId", async () => {
+			const res = await v2App.request(
+				`/v2/versioned/proposals/${uuid.proposalCreateEntity}/diff?spaceId=not-a-uuid`,
+			)
+			expect(res.status).toBe(400)
 		})
 	})
 })

--- a/api/src/versioned/diff.ts
+++ b/api/src/versioned/diff.ts
@@ -29,7 +29,12 @@ const TYPES_PROPERTY = normalizeUuid(SystemIds.TYPES_PROPERTY)
 const TEXT_BLOCK = normalizeUuid(SystemIds.TEXT_BLOCK)
 const IMAGE_BLOCK = normalizeUuid(SystemIds.IMAGE_BLOCK)
 const IMAGE = normalizeUuid(SystemIds.IMAGE)
+const IMAGE_TYPE = normalizeUuid(SystemIds.IMAGE_TYPE)
+const VIDEO_BLOCK = normalizeUuid(SystemIds.VIDEO_BLOCK)
+const VIDEO_TYPE = normalizeUuid(SystemIds.VIDEO_TYPE)
 const DATA_BLOCK = normalizeUuid(SystemIds.DATA_BLOCK)
+// Ranking blocks are a Geo-specific data-block subtype; no SystemIds entry.
+const RANKING_BLOCK_TYPE = normalizeUuid("150db6defe2344f0805afa57502e2c32")
 const MARKDOWN_CONTENT = normalizeUuid(SystemIds.MARKDOWN_CONTENT)
 const IMAGE_URL_PROPERTY = normalizeUuid(SystemIds.IMAGE_URL_PROPERTY)
 const NAME_PROPERTY = normalizeUuid(SystemIds.NAME_PROPERTY)
@@ -325,16 +330,29 @@ export function diffRelations(
 /**
  * Determine block type from its relations.
  */
-export function getBlockType(block: BlockSnapshot): "textBlock" | "imageBlock" | "dataBlock" | null {
+export function getBlockType(block: BlockSnapshot): "textBlock" | "imageBlock" | "videoBlock" | "dataBlock" | null {
 	// Check relations for type indicators
 	for (const rel of block.relations) {
 		if (rel.typeId === TYPES_PROPERTY) {
 			if (rel.toEntityId === TEXT_BLOCK) return "textBlock"
-			if (rel.toEntityId === IMAGE_BLOCK || rel.toEntityId === IMAGE) return "imageBlock"
-			if (rel.toEntityId === DATA_BLOCK) return "dataBlock"
+			if (rel.toEntityId === IMAGE_BLOCK || rel.toEntityId === IMAGE || rel.toEntityId === IMAGE_TYPE)
+				return "imageBlock"
+			if (rel.toEntityId === VIDEO_BLOCK || rel.toEntityId === VIDEO_TYPE) return "videoBlock"
+			if (rel.toEntityId === DATA_BLOCK || rel.toEntityId === RANKING_BLOCK_TYPE) return "dataBlock"
 		}
 	}
 	return null
+}
+
+/** Media (image/video) block change with the url on before/after. Both kinds
+ *  store their url under IMAGE_URL_PROPERTY in the current data model. */
+function mediaBlockChange(
+	id: NormalizedUuid,
+	type: "imageBlock" | "videoBlock",
+	before: string | null,
+	after: string | null,
+): BlockChange {
+	return {id, type, before, after} as BlockChange
 }
 
 /**
@@ -395,12 +413,8 @@ export function diffBlocks(
 						break
 					}
 					case "imageBlock":
-						changes.push({
-							id,
-							type: "imageBlock",
-							before: null,
-							after: getImageUrl(afterBlock),
-						})
+					case "videoBlock":
+						changes.push(mediaBlockChange(id, blockType, null, getImageUrl(afterBlock)))
 						break
 					case "dataBlock":
 						changes.push({
@@ -428,16 +442,12 @@ export function diffBlocks(
 						}
 						break
 					}
-					case "imageBlock": {
+					case "imageBlock":
+					case "videoBlock": {
 						const beforeUrl = getImageUrl(beforeBlock)
 						const afterUrl = getImageUrl(afterBlock)
 						if (beforeUrl !== afterUrl) {
-							changes.push({
-								id,
-								type: "imageBlock",
-								before: beforeUrl,
-								after: afterUrl,
-							})
+							changes.push(mediaBlockChange(id, blockType, beforeUrl, afterUrl))
 						}
 						break
 					}
@@ -477,12 +487,8 @@ export function diffBlocks(
 						break
 					}
 					case "imageBlock":
-						changes.push({
-							id,
-							type: "imageBlock",
-							before: getImageUrl(beforeBlock),
-							after: null,
-						})
+					case "videoBlock":
+						changes.push(mediaBlockChange(id, blockType, getImageUrl(beforeBlock), null))
 						break
 					case "dataBlock":
 						changes.push({
@@ -589,12 +595,8 @@ export function diffDynamicGroup(
 							break
 						}
 						case "imageBlock":
-							changes.push({
-								id,
-								type: "imageBlock",
-								before: null,
-								after: getImageUrl(afterEntity),
-							})
+						case "videoBlock":
+							changes.push(mediaBlockChange(id, blockType, null, getImageUrl(afterEntity)))
 							break
 						case "dataBlock":
 							changes.push({
@@ -621,16 +623,12 @@ export function diffDynamicGroup(
 							}
 							break
 						}
-						case "imageBlock": {
+						case "imageBlock":
+						case "videoBlock": {
 							const beforeUrl = getImageUrl(beforeEntity)
 							const afterUrl = getImageUrl(afterEntity)
 							if (beforeUrl !== afterUrl) {
-								changes.push({
-									id,
-									type: "imageBlock",
-									before: beforeUrl,
-									after: afterUrl,
-								})
+								changes.push(mediaBlockChange(id, blockType, beforeUrl, afterUrl))
 							}
 							break
 						}
@@ -680,12 +678,8 @@ export function diffDynamicGroup(
 							break
 						}
 						case "imageBlock":
-							changes.push({
-								id,
-								type: "imageBlock",
-								before: getImageUrl(beforeEntity),
-								after: null,
-							})
+						case "videoBlock":
+							changes.push(mediaBlockChange(id, blockType, getImageUrl(beforeEntity), null))
 							break
 						case "dataBlock":
 							changes.push({

--- a/api/src/versioned/proposal-diff.ts
+++ b/api/src/versioned/proposal-diff.ts
@@ -154,7 +154,7 @@ interface ProposalWithAction {
 /**
  * Get proposal with its Publish action (if any) in a single query.
  */
-function getProposalWithPublishAction(
+export function getProposalWithPublishAction(
 	db: Database,
 	proposalId: string,
 ): Effect.Effect<ProposalWithAction | null, QueryError> {
@@ -209,7 +209,7 @@ function getProposalWithPublishAction(
  * Batch-load multiple proposals with their Publish actions in a single query.
  * Returns a Map keyed by proposal ID for O(1) lookup.
  */
-function batchGetProposalsWithPublishActions(
+export function batchGetProposalsWithPublishActions(
 	db: Database,
 	proposalIds: NormalizedUuid[],
 ): Effect.Effect<Map<NormalizedUuid, ProposalWithAction>, QueryError> {
@@ -266,7 +266,7 @@ function batchGetProposalsWithPublishActions(
  * "not cached" (no row), "cached but decode failed" (row with is_errored=true),
  * and "cached successfully" (row with data).
  */
-function getIpfsCacheData(
+export function getIpfsCacheData(
 	db: Database,
 	uri: string,
 ): Effect.Effect<{data: Buffer | null; isErrored: boolean} | null, QueryError> {
@@ -291,7 +291,7 @@ function getIpfsCacheData(
 /**
  * Determine proposal status.
  */
-function getProposalStatus(proposal: ProposalWithAction["proposal"]): ProposalStatus {
+export function getProposalStatus(proposal: ProposalWithAction["proposal"]): ProposalStatus {
 	if (proposal.executedAt !== null) {
 		return "executed"
 	}
@@ -309,7 +309,10 @@ function getProposalStatus(proposal: ProposalWithAction["proposal"]): ProposalSt
  * so the diff shows what the proposal changed. Using `<` (not `<=`) ensures
  * edits at the exact execution timestamp are excluded from the base.
  */
-function resolveVersionKeyBeforeTimestamp(db: Database, timestamp: bigint): Effect.Effect<bigint | null, QueryError> {
+export function resolveVersionKeyBeforeTimestamp(
+	db: Database,
+	timestamp: bigint,
+): Effect.Effect<bigint | null, QueryError> {
 	return Effect.tryPromise({
 		try: async () => {
 			const result = await db.execute<{version_key: string}>(sql`
@@ -395,7 +398,7 @@ function batchLookupRelationEntities(
  * Batch fetch live snapshots for multiple entities.
  * Uses 2 queries total (values + relations), not 2N.
  */
-function batchGetLiveSnapshots(
+export function batchGetLiveSnapshots(
 	db: Database,
 	entityIds: NormalizedUuid[],
 	spaceId: NormalizedUuid,
@@ -445,7 +448,7 @@ function batchGetLiveSnapshots(
 /**
  * Batch fetch versioned snapshots for multiple entities at a specific version.
  */
-function batchGetVersionedSnapshots(
+export function batchGetVersionedSnapshots(
 	db: Database,
 	entityIds: NormalizedUuid[],
 	spaceId: NormalizedUuid,
@@ -592,7 +595,7 @@ function extractAffectedEntitiesAndRelations(ops: Op[]): {
 /**
  * Extract all affected entity IDs from ops, including those requiring relation lookups.
  */
-function extractAffectedEntities(db: Database, ops: Op[]): Effect.Effect<NormalizedUuid[], QueryError> {
+export function extractAffectedEntities(db: Database, ops: Op[]): Effect.Effect<NormalizedUuid[], QueryError> {
 	return Effect.gen(function* () {
 		const {entityIds, relationIdsNeedingLookup} = extractAffectedEntitiesAndRelations(ops)
 
@@ -718,7 +721,7 @@ export function propertyValueToVersionedValue(
  *   which are stored in `blocks` rather than `relations` on the snapshot.
  *   **Mutated** by createRelation ops that add new BLOCKS relations.
  */
-function applyOpsToSnapshot(
+export function applyOpsToSnapshot(
 	base: EntitySnapshot,
 	ops: Op[],
 	entityId: NormalizedUuid,
@@ -892,14 +895,14 @@ function applyOpsToSnapshot(
 /**
  * Check if an entity diff is empty (no changes).
  */
-function isDiffEmpty(diff: EntityDiff): boolean {
+export function isDiffEmpty(diff: EntityDiff): boolean {
 	return diff.values.length === 0 && diff.relations.length === 0 && diff.blocks.length === 0
 }
 
 /**
  * Create an empty snapshot for a new entity.
  */
-function emptySnapshot(entityId: NormalizedUuid): EntitySnapshot {
+export function emptySnapshot(entityId: NormalizedUuid): EntitySnapshot {
 	return {id: entityId, values: [], relations: [], blocks: []}
 }
 
@@ -907,11 +910,11 @@ function emptySnapshot(entityId: NormalizedUuid): EntitySnapshot {
 // Cursor Encoding
 // ============================================================================
 
-function encodeCursor(cursor: ProposalDiffCursor): string {
+export function encodeCursor(cursor: ProposalDiffCursor): string {
 	return Buffer.from(JSON.stringify(cursor)).toString("base64")
 }
 
-function decodeCursor(encoded: string): ProposalDiffCursor | null {
+export function decodeCursor(encoded: string): ProposalDiffCursor | null {
 	try {
 		const json = Buffer.from(encoded, "base64").toString("utf-8")
 		return JSON.parse(json) as ProposalDiffCursor
@@ -933,7 +936,7 @@ function decodeCursor(encoded: string): ProposalDiffCursor | null {
  * - Non-active with no resolved version → use empty fallback
  * - Non-active with resolved version → fetch from versioned tables
  */
-function fetchBaseData<T>(
+export function fetchBaseData<T>(
 	status: ProposalStatus,
 	baseVersionKey: bigint | null,
 	fetchLive: () => Effect.Effect<T, QueryError>,

--- a/api/src/versioned/proposal-diff.ts
+++ b/api/src/versioned/proposal-diff.ts
@@ -548,7 +548,7 @@ function groupByEntityId(
  * Convert Id (Uint8Array) to NormalizedUuid.
  * Returns lowercase hex without dashes for consistent comparison with normalized DB output.
  */
-function idToUuid(id: Id): NormalizedUuid {
+export function idToUuid(id: Id): NormalizedUuid {
 	return Array.from(id)
 		.map((b) => b.toString(16).padStart(2, "0"))
 		.join("") as NormalizedUuid

--- a/api/src/versioned/types.ts
+++ b/api/src/versioned/types.ts
@@ -197,6 +197,19 @@ export interface ImageBlockChange {
 }
 
 /**
+ * A video block change with before/after URLs.
+ */
+export interface VideoBlockChange {
+	id: NormalizedUuid
+	type: "videoBlock"
+	before: string | null
+	after: string | null
+	blockName?: string | null
+	values?: ValueChange[]
+	relations?: RelationChange[]
+}
+
+/**
  * A data block change with before/after names.
  */
 export interface DataBlockChange {
@@ -209,7 +222,7 @@ export interface DataBlockChange {
 	relations?: RelationChange[]
 }
 
-export type BlockChange = TextBlockChange | ImageBlockChange | DataBlockChange
+export type BlockChange = TextBlockChange | ImageBlockChange | VideoBlockChange | DataBlockChange
 
 // ============================================================================
 // Entity Snapshots and Diffs

--- a/api/src/versioned/v2/context.md
+++ b/api/src/versioned/v2/context.md
@@ -138,7 +138,29 @@ Validated against the DB in `__tests__/proposal-diff-edit-flow.test.ts`: block f
 *unchanged* parent (orphan-parent backlink), media entity dropped + URL inlined, plus the phase-0
 parity/enrichment/error tests.
 
-**Still missing:** `/v2/versioned/entities/:id` (snapshot) v2 variant.
+**`postProcessDiffs` parity (gaps closed):** to let the UI delete `postProcessDiffs` for the
+proposal path, the remaining client-only steps were ported:
+- **Data-block config merge for proposals.** The config (View/Shown columns/sort) lives on the
+  *reified BLOCKS-relation entity*, modified in the edit — `enrichBlockConfig` only reads committed
+  DB config, so it was a no-op for proposals and the reified entity leaked as a top-level row.
+  `resolveRoots` now classifies reified BLOCKS-relation entities (`batchGetBlocksRelationsByReifiedId`
+  over DB + edit ops), folds the data block under its parent, and `buildFoldedPage` merges the
+  config entity's base+proposed values/relations into the block before/after (so `enrichBlocks`
+  folds the config diff). The reified entity no longer appears top-level.
+- **Video blocks (shared `diff.ts`, benefits both endpoints).** `BlockChange` gained `videoBlock`;
+  `getBlockType`/`diffBlocks`/`diffDynamicGroup`/`enrichBlocks` handle `VIDEO_BLOCK`/`VIDEO_TYPE`
+  (url via `IMAGE_URL_PROPERTY`, matching the frontend).
+- **Ranking blocks.** `getBlockType` maps `RANKING_BLOCK_TYPE` → `dataBlock` (matches frontend).
+- **imageBlock detection** now also accepts `IMAGE_TYPE` (frontend parity), not just `IMAGE`/`IMAGE_BLOCK`.
+
+The v2 **entity-diff** endpoint inherits video/ranking/image-type from the shared `diff.ts` changes;
+data-block config was already covered there (committed-vs-committed via `enrichBlockConfig`).
+
+**Still missing:** `/v2/versioned/entities/:id` (snapshot) v2 variant — the only remaining endpoint;
+`postProcessDiffs` doesn't apply to it. **Accepted divergence:** the orphan new-block *fallback
+heuristic* (frontend L360–394, guessing a parent when a brand-new block has no backlink and no
+in-edit BLOCKS relation) is not ported — v2 resolves new blocks from the edit's BLOCKS ops, which
+covers the real case.
 
 ---
 

--- a/api/src/versioned/v2/context.md
+++ b/api/src/versioned/v2/context.md
@@ -119,21 +119,26 @@ through the **same enrichment chain** as the entity-diff endpoint (grouped diff 
 Validated against the DB in `__tests__/proposal-diff-edit-flow.test.ts` (v1↔v2 entity-set parity,
 `propertyName`/`typeName`/`toEntityName` resolution, grouped mode, error parity).
 
-This slice keeps v1's pagination unit (the flat affected-entity list), so block/media child
-entities still appear as separate top-level entries.
+**Phases 2–3 (done):** the proposal endpoints now **paginate over root entities** and fold/drop
+children (`v2/proposal-diff.ts` — `resolveRoots` + `buildFoldedPage`):
+- **#1 cross-parent block folding.** `resolveRoots` classifies each affected entity as a block
+  child via a BLOCKS backlink (`batchGetBlockParents*` over the DB at base **+** the edit's new
+  BLOCKS ops) and promotes parents to roots — *including* parents that weren't otherwise changed
+  (e.g. editing a block's text). The page unit is now the root set, not the flat affected list.
+  Each block is folded under its parent's `blocks[]` with its **own** proposed values/relations
+  (computed by applying ops with the block as the entity, since the parent's `applyOps` only tracks
+  block membership), and the block entity is no longer a top-level entry.
+- **#2 media-property filtering.** IMAGE/VIDEO-typed affected entities (classified via
+  `batchGetMediaUrls*` for existing media + the edit's `TYPES → IMAGE/VIDEO` ops for new media) are
+  dropped from the top level; their URL is inlined on the parent's relation — DB-side via
+  `enrichWithMediaUrls`, and **proposed-side** (a media entity created in the edit, not yet in the
+  DB) via `inlineProposedMedia` reading the IMAGE_URL set by the ops.
 
-**Phases 2–3 (remaining):** **#1 cross-parent block folding** + **#2 media-property filtering** —
-both require paginating over *root* entities instead of the flat affected list:
-- Resolve each affected block's parent via a BLOCKS backlink (DB at base + the edit's new BLOCKS
-  ops); treat parents (incl. parents not otherwise changed) as the roots and paginate over them.
-- Fold each block under its parent's `blocks[]` (the per-entity `enrichBlocks` already folds a
-  parent's *own* blocks; the remaining work is the cross-parent case) and drop the block entity
-  from the top level.
-- Media-property filtering is mostly reuse: `batchGetMediaUrls*` already classifies IMAGE/VIDEO
-  entities and `enrichWithMediaUrls` inlines the URL — the new bit is dropping the now-redundant
-  top-level media entity. Plus proposed-side media URLs (a media entity *created in the edit* isn't
-  in the DB; its AFTER url must come from the applied proposed snapshot).
-- **Also missing:** `/v2/versioned/entities/:id` (snapshot).
+Validated against the DB in `__tests__/proposal-diff-edit-flow.test.ts`: block folded under an
+*unchanged* parent (orphan-parent backlink), media entity dropped + URL inlined, plus the phase-0
+parity/enrichment/error tests.
+
+**Still missing:** `/v2/versioned/entities/:id` (snapshot) v2 variant.
 
 ---
 

--- a/api/src/versioned/v2/context.md
+++ b/api/src/versioned/v2/context.md
@@ -109,11 +109,31 @@ and snapshot mode. Run in CI by `.github/workflows/api-integration-tests.yml` (n
 
 ## Remaining (proposal-centric → Track B)
 
-- **#2 media-property filtering** + **#1 cross-parent block folding** — only bite with multiple
-  top-level entities.
-- **Missing v2 endpoints:** `/v2/versioned/entities/:id` (snapshot), `/proposals/:id/diff`,
-  `/proposal-groups/diff`. The enrichers above are reusable; proposal folding additionally needs
-  to fold each block under the *right* parent (or expose a `parentId` per top-level diff).
+**Phase 0 (done):** `/v2/versioned/proposals/:id/diff` and `/v2/versioned/proposal-groups/diff`
+now exist (`v2/proposal-diff.ts`, routed in `v2/router.ts`). They reuse v1's proposal
+state-construction wholesale (proposal load, edit decode, base-state fetch, op application,
+pagination, mode logic, errors — exported from `proposal-diff.ts`) and run each affected entity
+through the **same enrichment chain** as the entity-diff endpoint (grouped diff → `enrichBlocks` →
+`enrichBlockConfig` → `enrichNames` → `enrichWithMediaUrls`). Each entity comes back as the grouped
+`EntityDiffV2` shape with resolved names, media URLs on relations, and folded block values/config.
+Validated against the DB in `__tests__/proposal-diff-edit-flow.test.ts` (v1↔v2 entity-set parity,
+`propertyName`/`typeName`/`toEntityName` resolution, grouped mode, error parity).
+
+This slice keeps v1's pagination unit (the flat affected-entity list), so block/media child
+entities still appear as separate top-level entries.
+
+**Phases 2–3 (remaining):** **#1 cross-parent block folding** + **#2 media-property filtering** —
+both require paginating over *root* entities instead of the flat affected list:
+- Resolve each affected block's parent via a BLOCKS backlink (DB at base + the edit's new BLOCKS
+  ops); treat parents (incl. parents not otherwise changed) as the roots and paginate over them.
+- Fold each block under its parent's `blocks[]` (the per-entity `enrichBlocks` already folds a
+  parent's *own* blocks; the remaining work is the cross-parent case) and drop the block entity
+  from the top level.
+- Media-property filtering is mostly reuse: `batchGetMediaUrls*` already classifies IMAGE/VIDEO
+  entities and `enrichWithMediaUrls` inlines the URL — the new bit is dropping the now-redundant
+  top-level media entity. Plus proposed-side media URLs (a media entity *created in the edit* isn't
+  in the DB; its AFTER url must come from the applied proposed snapshot).
+- **Also missing:** `/v2/versioned/entities/:id` (snapshot).
 
 ---
 

--- a/api/src/versioned/v2/enrich-blocks.ts
+++ b/api/src/versioned/v2/enrich-blocks.ts
@@ -92,7 +92,8 @@ function synthesizeUnchangedBlock(
 			const content = getMarkdownContent(a)
 			return {id, type, before: content, after: content, diff: [], ...rich}
 		}
-		case "imageBlock": {
+		case "imageBlock":
+		case "videoBlock": {
 			const url = getImageUrl(a)
 			return {id, type, before: url, after: url, ...rich}
 		}

--- a/api/src/versioned/v2/proposal-diff.ts
+++ b/api/src/versioned/v2/proposal-diff.ts
@@ -109,6 +109,8 @@ interface OpsIndex {
 	mediaTyped: Map<NormalizedUuid, "image" | "video">
 	/** entity id → IMAGE_URL set by the edit (proposed-side media url). */
 	proposedImageUrls: Map<NormalizedUuid, string>
+	/** entities whose IMAGE_URL the edit *unset* (so the media url is removed). */
+	unsetImageUrls: Set<NormalizedUuid>
 	/** reified BLOCKS-relation id (from the edit) → its parent + data block. */
 	blocksReified: Map<NormalizedUuid, BlocksReifiedEntry>
 }
@@ -117,6 +119,7 @@ function indexOps(ops: Op[]): OpsIndex {
 	const blockParents = new Map<NormalizedUuid, Set<NormalizedUuid>>()
 	const mediaTyped = new Map<NormalizedUuid, "image" | "video">()
 	const proposedImageUrls = new Map<NormalizedUuid, string>()
+	const unsetImageUrls = new Set<NormalizedUuid>()
 	const blocksReified = new Map<NormalizedUuid, BlocksReifiedEntry>()
 
 	const noteImageUrl = (entityId: NormalizedUuid, values: {property: unknown; value: unknown}[]) => {
@@ -148,9 +151,14 @@ function indexOps(ops: Op[]): OpsIndex {
 			noteImageUrl(normalizeUuid(idToUuid(op.id)), op.values)
 		} else if (op.type === "updateEntity") {
 			noteImageUrl(normalizeUuid(idToUuid(op.id)), op.set)
+			for (const u of op.unset) {
+				if (normalizeUuid(idToUuid(u.property as never)) === IMAGE_URL_PROPERTY_ID) {
+					unsetImageUrls.add(normalizeUuid(idToUuid(op.id)))
+				}
+			}
 		}
 	}
-	return {blockParents, mediaTyped, proposedImageUrls, blocksReified}
+	return {blockParents, mediaTyped, proposedImageUrls, unsetImageUrls, blocksReified}
 }
 
 /** Composite key for per-(parent, block) config lookup. */
@@ -301,15 +309,22 @@ function inlineProposedMedia(
 	diff: GroupedEntityDiff & {relations: RelationChangeV2[]},
 	ctx: RootContext,
 ): GroupedEntityDiff & {relations: RelationChangeV2[]} {
-	const {mediaTyped, proposedImageUrls} = ctx.opsIndex
-	if (proposedImageUrls.size === 0) return diff
+	const {mediaTyped, proposedImageUrls, unsetImageUrls} = ctx.opsIndex
+	if (proposedImageUrls.size === 0 && unsetImageUrls.size === 0) return diff
 	const apply = (r: RelationChange): RelationChangeV2 => {
 		if (!r.after) return r
-		const url = proposedImageUrls.get(r.after.toEntityId)
-		if (!url) return r
-		const mt = mediaTyped.get(r.after.toEntityId) ?? ctx.mediaTypeById.get(r.after.toEntityId)
+		const target = r.after.toEntityId
+		const mt = mediaTyped.get(target) ?? ctx.mediaTypeById.get(target)
 		if (!mt) return r
-		return {...r, after: {...r.after, ...(mt === "video" ? {videoUrl: url} : {imageUrl: url})}}
+		const url = proposedImageUrls.get(target)
+		// The edit set a new URL → it's the authoritative after-side value.
+		if (url) return {...r, after: {...r.after, ...(mt === "video" ? {videoUrl: url} : {imageUrl: url})}}
+		// The edit removed the URL → strip any base-version URL enrichWithMediaUrls inlined.
+		const after = r.after as {imageUrl?: string | null; videoUrl?: string | null}
+		if (unsetImageUrls.has(target) && (after.imageUrl || after.videoUrl)) {
+			return {...r, after: {...r.after, imageUrl: undefined, videoUrl: undefined}}
+		}
+		return r
 	}
 	// Mirror enrichWithMediaUrls: rewrite top-level, grouped, and block relations.
 	return {

--- a/api/src/versioned/v2/proposal-diff.ts
+++ b/api/src/versioned/v2/proposal-diff.ts
@@ -1,0 +1,400 @@
+/**
+ * v2 proposal diff — enriched, context-aware variants of the proposal endpoints.
+ *
+ * Mounted at /v2/versioned. Reuses v1's proposal state-construction wholesale
+ * (proposal load, edit decode, base-state fetch, op application, pagination,
+ * mode logic, errors) and swaps the diff+enrich tail: each affected entity is
+ * diffed with the GROUPED diff and run through the same enrichment chain as the
+ * entity-diff endpoint (blocks → blockConfig → names → media URLs), so relations
+ * carry resolved names + media URLs and blocks carry their folded values/config.
+ *
+ * v1 is unchanged; this is purely additive.
+ *
+ * NOTE: this slice keeps v1's pagination unit (the flat affected-entity list).
+ * Cross-parent block folding + media-property filtering (which require paginating
+ * over root entities) are the follow-up (Track B phases 2–3).
+ */
+
+import {decodeEditAuto, type Op} from "@geoprotocol/grc-20"
+import type {NodePgDatabase} from "drizzle-orm/node-postgres"
+import {Effect} from "effect"
+import type {NormalizedUuid} from "../../utils/uuid"
+import {diffGroupedEntitySnapshots} from "../diff"
+import {
+	applyOpsToSnapshot,
+	batchGetLiveSnapshots,
+	batchGetProposalsWithPublishActions,
+	batchGetVersionedSnapshots,
+	compareGroupedEdits,
+	DuplicateProposalError,
+	decodeCursor,
+	EditBlobDecodeFailedError,
+	EditBlobNotCachedError,
+	EditDecodeError,
+	editCreatedAtToSeconds,
+	emptySnapshot,
+	encodeCursor,
+	extractAffectedEntities,
+	fetchBaseData,
+	type GroupedProposalDiffError,
+	GroupSizeLimitError,
+	getIpfsCacheData,
+	getProposalStatus,
+	getProposalWithPublishAction,
+	InvalidCursorError,
+	MAX_GROUP_SIZE,
+	MissingPublishActionError,
+	MixedModeError,
+	type ProposalDiffError,
+	ProposalNotFoundError,
+	resolveVersionKeyBeforeTimestamp,
+	SpaceMismatchError,
+} from "../proposal-diff"
+import {
+	type BlockRelationEntry,
+	batchGetBlockRelationsForEntities,
+	batchGetBlockSnapshotsAtVersion,
+	batchGetLiveBlockRelationsForEntities,
+	batchGetLiveBlockSnapshots,
+	type QueryError,
+} from "../queries"
+import type {
+	BlockSnapshot,
+	EntitySnapshot,
+	GroupedEntitySnapshot,
+	GroupedProposalDiffMode,
+	ProposalStatus,
+} from "../types"
+import {enrichWithMediaUrls} from "./enrich"
+import {enrichBlockConfig} from "./enrich-block-config"
+import {enrichBlocks} from "./enrich-blocks"
+import {enrichNames} from "./enrich-names"
+import type {EntityDiffV2, PaginatedGroupedProposalDiffV2, PaginatedProposalDiffV2} from "./types"
+
+type Database = NodePgDatabase<Record<string, unknown>>
+
+/** Wrap a flat proposal EntitySnapshot as a GroupedEntitySnapshot.
+ *  Proposal snapshots already separate BLOCKS children into `.blocks`; there are
+ *  no dynamic (non-BLOCKS) groups in the proposal path, so `groups` is empty. */
+function toGrouped(s: EntitySnapshot): GroupedEntitySnapshot {
+	return {id: s.id, values: s.values, relations: s.relations, blocks: s.blocks, groupKeys: [], groups: {}}
+}
+
+/** Run the v2 enrichment chain on a single entity's before/after grouped snapshots. */
+function enrichEntity(
+	db: Database,
+	entityId: NormalizedUuid,
+	before: GroupedEntitySnapshot,
+	after: GroupedEntitySnapshot,
+	baseVersionKey: bigint | null,
+	spaceId: NormalizedUuid,
+): Effect.Effect<EntityDiffV2, QueryError> {
+	return Effect.gen(function* () {
+		// Proposals have no single "to" version (the proposed side is the edit
+		// applied in memory). Use the base version key where a DB lookup is needed;
+		// when null (active proposal) a 0 key makes the versioned lookup miss so the
+		// enrichers fall back to live state.
+		const vk = baseVersionKey ?? 0n
+		const raw = yield* diffGroupedEntitySnapshots(entityId, before, after)
+		const withBlocks = yield* enrichBlocks(raw, before, after)
+		const withConfig = yield* enrichBlockConfig(
+			db,
+			withBlocks,
+			entityId,
+			before,
+			after,
+			baseVersionKey,
+			vk,
+			spaceId,
+		)
+		const named = yield* enrichNames(db, withConfig, spaceId)
+		const withMedia = yield* enrichWithMediaUrls(db, named, {fromVersionKey: vk, toVersionKey: vk, spaceId})
+		// Spread dynamic group keys at the entity level (matches DiffResponseV2).
+		const {groups, ...rest} = withMedia
+		return {...rest, ...groups} as unknown as EntityDiffV2
+	})
+}
+
+/**
+ * Shared core: given the decoded ops + the page's entity ids, build the base
+ * states, apply the ops, and produce enriched grouped diffs for each entity.
+ * Reuses the exact base-state/block fetching v1 uses.
+ */
+function buildEnrichedEntities(
+	db: Database,
+	ops: Op[],
+	pageEntityIds: NormalizedUuid[],
+	status: ProposalStatus,
+	baseVersionKey: bigint | null,
+	spaceId: NormalizedUuid,
+): Effect.Effect<EntityDiffV2[], QueryError> {
+	return Effect.gen(function* () {
+		// 1. Base states (values + relations) — live / versioned / empty, per v1.
+		const baseStates = yield* fetchBaseData(
+			status,
+			baseVersionKey,
+			() => batchGetLiveSnapshots(db, pageEntityIds, spaceId),
+			(vk) => batchGetVersionedSnapshots(db, pageEntityIds, spaceId, vk),
+			() => {
+				const m = new Map<NormalizedUuid, EntitySnapshot>()
+				for (const id of pageEntityIds) m.set(id, emptySnapshot(id))
+				return m
+			},
+		)
+
+		// 2. Discover BLOCKS relations + block snapshots for the page entities.
+		const blockRelationsMap = yield* fetchBaseData(
+			status,
+			baseVersionKey,
+			() => batchGetLiveBlockRelationsForEntities(db, pageEntityIds, spaceId),
+			(vk) => batchGetBlockRelationsForEntities(db, pageEntityIds, vk, spaceId),
+			() => {
+				const m = new Map<NormalizedUuid, BlockRelationEntry[]>()
+				for (const id of pageEntityIds) m.set(id, [])
+				return m
+			},
+		)
+
+		const allBlockIds = new Set<NormalizedUuid>()
+		for (const entries of blockRelationsMap.values()) {
+			for (const entry of entries) allBlockIds.add(entry.blockEntityId)
+		}
+		const blockIdsList = Array.from(allBlockIds)
+		let blockSnapshotsMap: Map<NormalizedUuid, BlockSnapshot>
+		if (blockIdsList.length === 0) {
+			blockSnapshotsMap = new Map()
+		} else {
+			const blockSnapshots = yield* fetchBaseData(
+				status,
+				baseVersionKey,
+				() => batchGetLiveBlockSnapshots(db, blockIdsList, spaceId),
+				(vk) => batchGetBlockSnapshotsAtVersion(db, blockIdsList, vk, spaceId),
+				() => [] as BlockSnapshot[],
+			)
+			blockSnapshotsMap = new Map(blockSnapshots.map((b) => [b.id, b]))
+		}
+
+		// 3. Attach blocks to base states; build relation→block map for op matching.
+		const blocksRelationMap = new Map<NormalizedUuid, NormalizedUuid>()
+		for (const entityId of pageEntityIds) {
+			const entries = blockRelationsMap.get(entityId) ?? []
+			const baseState = baseStates.get(entityId)
+			if (baseState) {
+				baseState.blocks = entries
+					.map((entry) => {
+						blocksRelationMap.set(entry.relationId, entry.blockEntityId)
+						return blockSnapshotsMap.get(entry.blockEntityId)
+					})
+					.filter((b): b is BlockSnapshot => b !== undefined)
+			}
+		}
+
+		// 4. Per entity: apply ops → proposed, diff (grouped), enrich.
+		const out: EntityDiffV2[] = []
+		for (const entityId of pageEntityIds) {
+			const baseState = baseStates.get(entityId) ?? emptySnapshot(entityId)
+			const proposedState = applyOpsToSnapshot(baseState, ops, entityId, spaceId, blocksRelationMap)
+			// Cheap pre-check on the flat diff to skip unchanged entities before enrichment.
+			const before = toGrouped(baseState)
+			const after = toGrouped(proposedState)
+			const enriched = yield* enrichEntity(db, entityId, before, after, baseVersionKey, spaceId)
+			if (
+				enriched.values.length > 0 ||
+				enriched.relations.length > 0 ||
+				enriched.blocks.length > 0 ||
+				enriched.groupKeys.length > 0
+			) {
+				out.push(enriched)
+			}
+		}
+		return out
+	})
+}
+
+/** v2 single-proposal diff. */
+export function computeProposalDiffV2(
+	db: Database,
+	proposalId: NormalizedUuid,
+	spaceId: NormalizedUuid,
+	cursorStr?: string,
+	limit = 50,
+): Effect.Effect<PaginatedProposalDiffV2, ProposalDiffError> {
+	return Effect.gen(function* () {
+		const data = yield* getProposalWithPublishAction(db, proposalId)
+		if (!data) return yield* Effect.fail(new ProposalNotFoundError(proposalId))
+		const {proposal, contentUri} = data
+		const status = getProposalStatus(proposal)
+		if (proposal.spaceId !== spaceId) {
+			return yield* Effect.fail(new SpaceMismatchError(proposal.spaceId, spaceId))
+		}
+		if (!contentUri) {
+			return {
+				proposalId,
+				spaceId,
+				proposalStatus: status,
+				entities: [],
+				pagination: {cursor: null, hasMore: false, totalEntities: 0},
+			}
+		}
+
+		let startIndex = 0
+		let expectedTotalEntities: number | undefined
+		if (cursorStr) {
+			const cursor = decodeCursor(cursorStr)
+			if (cursor === null) return yield* Effect.fail(new InvalidCursorError(cursorStr))
+			startIndex = cursor.entityIndex
+			expectedTotalEntities = cursor.totalEntities
+		}
+
+		const cacheResult = yield* getIpfsCacheData(db, contentUri)
+		if (!cacheResult) return yield* Effect.fail(new EditBlobNotCachedError(contentUri))
+		if (cacheResult.isErrored) return yield* Effect.fail(new EditBlobDecodeFailedError(contentUri))
+		if (!cacheResult.data) return yield* Effect.fail(new EditBlobNotCachedError(contentUri))
+
+		const ops = yield* Effect.tryPromise({
+			try: async () => (await decodeEditAuto(cacheResult.data as Uint8Array)).ops,
+			catch: (error) => new EditDecodeError(error),
+		})
+
+		const entityIds = (yield* extractAffectedEntities(db, ops)).sort()
+		if (expectedTotalEntities !== undefined && expectedTotalEntities !== entityIds.length) {
+			return yield* Effect.fail(new InvalidCursorError(cursorStr ?? ""))
+		}
+		const pageEntityIds = entityIds.slice(startIndex, startIndex + limit)
+
+		let baseVersionKey: bigint | null = null
+		if (status !== "active") {
+			baseVersionKey = yield* resolveVersionKeyBeforeTimestamp(db, proposal.executedAt ?? proposal.endTime)
+		}
+
+		const entities = yield* buildEnrichedEntities(db, ops, pageEntityIds, status, baseVersionKey, spaceId)
+
+		const nextIndex = startIndex + limit
+		const hasMore = nextIndex < entityIds.length
+		return {
+			proposalId,
+			spaceId,
+			proposalStatus: status,
+			entities,
+			pagination: {
+				cursor: hasMore ? encodeCursor({entityIndex: nextIndex, totalEntities: entityIds.length}) : null,
+				hasMore,
+				totalEntities: entityIds.length,
+			},
+		}
+	}).pipe(Effect.withSpan("proposal-diff-v2.computeProposalDiffV2", {attributes: {proposalId, spaceId, limit}}))
+}
+
+/** v2 grouped (multi-proposal) diff. */
+export function computeGroupedProposalDiffV2(
+	db: Database,
+	proposalIds: NormalizedUuid[],
+	spaceId: NormalizedUuid,
+	cursorStr?: string,
+	limit = 50,
+): Effect.Effect<PaginatedGroupedProposalDiffV2, GroupedProposalDiffError> {
+	return Effect.gen(function* () {
+		if (proposalIds.length > MAX_GROUP_SIZE) {
+			return yield* Effect.fail(new GroupSizeLimitError(MAX_GROUP_SIZE, proposalIds.length))
+		}
+		const seen = new Set<NormalizedUuid>()
+		const duplicates: string[] = []
+		for (const id of proposalIds) {
+			if (seen.has(id)) duplicates.push(id)
+			seen.add(id)
+		}
+		if (duplicates.length > 0) return yield* Effect.fail(new DuplicateProposalError(duplicates))
+
+		const proposalsMap = yield* batchGetProposalsWithPublishActions(db, proposalIds)
+		for (const id of proposalIds) {
+			const d = proposalsMap.get(id)
+			if (!d) return yield* Effect.fail(new ProposalNotFoundError(id))
+			if (d.proposal.spaceId !== spaceId)
+				return yield* Effect.fail(new SpaceMismatchError(spaceId, d.proposal.spaceId))
+			if (!d.contentUri) return yield* Effect.fail(new MissingPublishActionError(id))
+		}
+
+		let activeCount = 0
+		let nonActiveCount = 0
+		for (const id of proposalIds) {
+			const d = proposalsMap.get(id)
+			if (!d) continue
+			if (getProposalStatus(d.proposal) === "active") activeCount++
+			else nonActiveCount++
+		}
+		if (activeCount > 0 && nonActiveCount > 0) {
+			return yield* Effect.fail(new MixedModeError(activeCount, nonActiveCount))
+		}
+		const mode: GroupedProposalDiffMode = activeCount > 0 ? "active" : "historical"
+
+		let startIndex = 0
+		let expectedTotalEntities: number | undefined
+		if (cursorStr) {
+			const cursor = decodeCursor(cursorStr)
+			if (cursor === null) return yield* Effect.fail(new InvalidCursorError(cursorStr))
+			startIndex = cursor.entityIndex
+			expectedTotalEntities = cursor.totalEntities
+		}
+
+		const blobs = yield* Effect.all(
+			proposalIds.map((id) => {
+				const contentUri = proposalsMap.get(id)?.contentUri ?? ""
+				return Effect.gen(function* () {
+					const cacheResult = yield* getIpfsCacheData(db, contentUri)
+					if (!cacheResult)
+						return yield* Effect.fail(new EditBlobNotCachedError(contentUri) as GroupedProposalDiffError)
+					if (cacheResult.isErrored)
+						return yield* Effect.fail(new EditBlobDecodeFailedError(contentUri) as GroupedProposalDiffError)
+					if (!cacheResult.data)
+						return yield* Effect.fail(new EditBlobNotCachedError(contentUri) as GroupedProposalDiffError)
+					return {proposalId: id, blob: cacheResult.data}
+				})
+			}),
+			{concurrency: "unbounded"},
+		)
+
+		const decodedEdits: {proposalId: NormalizedUuid; ops: Op[]; createdAt: bigint}[] = []
+		for (const {proposalId, blob} of blobs) {
+			const edit = yield* Effect.tryPromise({
+				try: async () => decodeEditAuto(blob),
+				catch: (error) => new EditDecodeError(error),
+			})
+			decodedEdits.push({proposalId, ops: edit.ops, createdAt: edit.createdAt})
+		}
+		decodedEdits.sort(compareGroupedEdits)
+		const allOps: Op[] = decodedEdits.flatMap((e) => e.ops)
+
+		const entityIds = (yield* extractAffectedEntities(db, allOps)).sort()
+		if (expectedTotalEntities !== undefined && expectedTotalEntities !== entityIds.length) {
+			return yield* Effect.fail(new InvalidCursorError(cursorStr ?? ""))
+		}
+		const pageEntityIds = entityIds.slice(startIndex, startIndex + limit)
+
+		let baseVersionKey: bigint | null = null
+		const firstEdit = decodedEdits[0]
+		if (mode === "historical" && firstEdit) {
+			baseVersionKey = yield* resolveVersionKeyBeforeTimestamp(db, editCreatedAtToSeconds(firstEdit.createdAt))
+		}
+		const fetchStatus: ProposalStatus = mode === "active" ? "active" : "closed"
+
+		const entities = yield* buildEnrichedEntities(db, allOps, pageEntityIds, fetchStatus, baseVersionKey, spaceId)
+
+		const nextIndex = startIndex + limit
+		const hasMore = nextIndex < entityIds.length
+		return {
+			proposalIds,
+			spaceId,
+			mode,
+			entities,
+			pagination: {
+				cursor: hasMore ? encodeCursor({entityIndex: nextIndex, totalEntities: entityIds.length}) : null,
+				hasMore,
+				totalEntities: entityIds.length,
+			},
+		}
+	}).pipe(
+		Effect.withSpan("proposal-diff-v2.computeGroupedProposalDiffV2", {
+			attributes: {proposalCount: proposalIds.length, spaceId, limit},
+		}),
+	)
+}

--- a/api/src/versioned/v2/proposal-diff.ts
+++ b/api/src/versioned/v2/proposal-diff.ts
@@ -126,7 +126,11 @@ function indexOps(ops: Op[]): OpsIndex {
 		for (const pv of values) {
 			if (normalizeUuid(idToUuid(pv.property as never)) !== IMAGE_URL_PROPERTY_ID) continue
 			const v = pv.value as {type?: string; value?: unknown}
-			if (v?.type === "text" && typeof v.value === "string") proposedImageUrls.set(entityId, v.value)
+			if (v?.type === "text" && typeof v.value === "string") {
+				// Last write wins: a set supersedes any earlier unset of this entity's url.
+				proposedImageUrls.set(entityId, v.value)
+				unsetImageUrls.delete(entityId)
+			}
 		}
 	}
 
@@ -153,7 +157,10 @@ function indexOps(ops: Op[]): OpsIndex {
 			noteImageUrl(normalizeUuid(idToUuid(op.id)), op.set)
 			for (const u of op.unset) {
 				if (normalizeUuid(idToUuid(u.property as never)) === IMAGE_URL_PROPERTY_ID) {
-					unsetImageUrls.add(normalizeUuid(idToUuid(op.id)))
+					const id = normalizeUuid(idToUuid(op.id))
+					// Last write wins: an unset supersedes any earlier set of this entity's url.
+					unsetImageUrls.add(id)
+					proposedImageUrls.delete(id)
 				}
 			}
 		}

--- a/api/src/versioned/v2/proposal-diff.ts
+++ b/api/src/versioned/v2/proposal-diff.ts
@@ -71,13 +71,15 @@ import type {
 	ProposalStatus,
 } from "../types"
 import {enrichWithMediaUrls} from "./enrich"
-import {enrichBlockConfig} from "./enrich-block-config"
 import {enrichBlocks} from "./enrich-blocks"
 import {enrichNames} from "./enrich-names"
 import {
 	type BlockParentEntry,
+	type BlocksReifiedEntry,
 	batchGetBlockParentsAtVersion,
+	batchGetBlocksRelationsByReifiedIdAtVersion,
 	batchGetLiveBlockParents,
+	batchGetLiveBlocksRelationsByReifiedId,
 	batchGetMediaUrls,
 	batchGetMediaUrlsAtVersion,
 } from "./queries"
@@ -105,12 +107,15 @@ interface OpsIndex {
 	mediaTyped: Map<NormalizedUuid, "image" | "video">
 	/** entity id → IMAGE_URL set by the edit (proposed-side media url). */
 	proposedImageUrls: Map<NormalizedUuid, string>
+	/** reified BLOCKS-relation id (from the edit) → its parent + data block. */
+	blocksReified: Map<NormalizedUuid, BlocksReifiedEntry>
 }
 
 function indexOps(ops: Op[]): OpsIndex {
 	const blockParents = new Map<NormalizedUuid, Set<NormalizedUuid>>()
 	const mediaTyped = new Map<NormalizedUuid, "image" | "video">()
 	const proposedImageUrls = new Map<NormalizedUuid, string>()
+	const blocksReified = new Map<NormalizedUuid, BlocksReifiedEntry>()
 
 	const noteImageUrl = (entityId: NormalizedUuid, values: {property: unknown; value: unknown}[]) => {
 		for (const pv of values) {
@@ -129,6 +134,8 @@ function indexOps(ops: Op[]): OpsIndex {
 				const set = blockParents.get(child) ?? new Set<NormalizedUuid>()
 				set.add(parent)
 				blockParents.set(child, set)
+				// The relation's reified entity id (op.id) carries the data block's config.
+				blocksReified.set(normalizeUuid(idToUuid(op.id)), {parentId: parent, dataBlockId: child})
 			} else if (typeId === TYPES_PROPERTY_ID) {
 				const to = normalizeUuid(idToUuid(op.to))
 				if (to === IMAGE_TYPE_ID || to === VIDEO_TYPE_ID) {
@@ -141,12 +148,24 @@ function indexOps(ops: Op[]): OpsIndex {
 			noteImageUrl(normalizeUuid(idToUuid(op.id)), op.set)
 		}
 	}
-	return {blockParents, mediaTyped, proposedImageUrls}
+	return {blockParents, mediaTyped, proposedImageUrls, blocksReified}
 }
 
 /** Wrap a flat proposal EntitySnapshot as a GroupedEntitySnapshot. */
 function toGrouped(s: EntitySnapshot): GroupedEntitySnapshot {
 	return {id: s.id, values: s.values, relations: s.relations, blocks: s.blocks, groupKeys: [], groups: {}}
+}
+
+/** Fold a reified BLOCKS-relation (config) entity's values/relations into a data
+ *  block snapshot. `enrichBlocks` then strips headline values + TYPES/BLOCKS
+ *  relations, leaving the data-block config (view/columns/sort) on the block. */
+function mergeConfig(block: BlockSnapshot, config: EntitySnapshot | undefined): BlockSnapshot {
+	if (!config) return block
+	return {
+		...block,
+		values: [...block.values, ...config.values],
+		relations: [...block.relations, ...config.relations],
+	}
 }
 
 interface RootContext {
@@ -155,6 +174,9 @@ interface RootContext {
 	blockChildren: Set<NormalizedUuid>
 	/** affected entities classified as media-property children (dropped + inlined). */
 	mediaChildren: Set<NormalizedUuid>
+	/** data block id → its reified BLOCKS-relation (config) entity id, when the
+	 *  edit touched the config; the config entity is folded into the block. */
+	configByDataBlock: Map<NormalizedUuid, NormalizedUuid>
 }
 
 /**
@@ -172,7 +194,7 @@ function resolveRoots(
 	return Effect.gen(function* () {
 		const opsIndex = indexOps(ops)
 
-		const [dbParents, dbMedia] = yield* Effect.all([
+		const [dbParents, dbMedia, dbReified] = yield* Effect.all([
 			fetchBaseData(
 				status,
 				baseVersionKey,
@@ -186,6 +208,14 @@ function resolveRoots(
 				() => batchGetMediaUrls(db, affected, spaceId),
 				(vk) => batchGetMediaUrlsAtVersion(db, affected, vk, spaceId),
 				() => new Map<NormalizedUuid, MediaEntity>(),
+			),
+			// Reified BLOCKS-relation (config) entities among the affected set.
+			fetchBaseData(
+				status,
+				baseVersionKey,
+				() => batchGetLiveBlocksRelationsByReifiedId(db, affected, spaceId),
+				(vk) => batchGetBlocksRelationsByReifiedIdAtVersion(db, affected, vk, spaceId),
+				() => new Map<NormalizedUuid, BlocksReifiedEntry>(),
 			),
 		])
 
@@ -215,16 +245,32 @@ function resolveRoots(
 			if (dbMedia.has(id) || opsIndex.mediaTyped.has(id)) mediaChildren.add(id)
 		}
 
-		const roots = new Set<NormalizedUuid>()
+		// Config entities: affected reified BLOCKS-relation entities (DB + edit ops).
+		// They are folded into their data block and never surface on their own.
+		const reified = new Map<NormalizedUuid, BlocksReifiedEntry>(dbReified)
+		for (const [id, entry] of opsIndex.blocksReified) reified.set(id, entry)
+		const configEntities = new Set<NormalizedUuid>()
+		const configByDataBlock = new Map<NormalizedUuid, NormalizedUuid>()
 		for (const id of affected) {
-			if (!blockChildren.has(id) && !mediaChildren.has(id)) roots.add(id)
-		}
-		// Orphan parents (a block changed but its parent wasn't in the affected set).
-		for (const p of parentRoots) {
-			if (!blockChildren.has(p) && !mediaChildren.has(p)) roots.add(p)
+			const entry = reified.get(id)
+			if (!entry) continue
+			configEntities.add(id)
+			configByDataBlock.set(entry.dataBlockId, id)
+			// The config's data block folds under its parent; make sure both are placed.
+			blockChildren.add(entry.dataBlockId)
+			parentRoots.add(entry.parentId)
 		}
 
-		return {roots: Array.from(roots).sort(), ctx: {opsIndex, blockChildren, mediaChildren}}
+		const roots = new Set<NormalizedUuid>()
+		for (const id of affected) {
+			if (!blockChildren.has(id) && !mediaChildren.has(id) && !configEntities.has(id)) roots.add(id)
+		}
+		// Orphan parents (a block/config changed but its parent wasn't in the affected set).
+		for (const p of parentRoots) {
+			if (!blockChildren.has(p) && !mediaChildren.has(p) && !configEntities.has(p)) roots.add(p)
+		}
+
+		return {roots: Array.from(roots).sort(), ctx: {opsIndex, blockChildren, mediaChildren, configByDataBlock}}
 	})
 }
 
@@ -256,9 +302,10 @@ function buildRootDiff(
 	return Effect.gen(function* () {
 		const vk = baseVersionKey ?? 0n
 		const raw = yield* diffGroupedEntitySnapshots(rootId, before, after)
+		// Data-block config is already merged into the block snapshots (proposal path),
+		// so we rely on enrichBlocks to fold it rather than the DB-only enrichBlockConfig.
 		const withBlocks = yield* enrichBlocks(raw, before, after)
-		const withConfig = yield* enrichBlockConfig(db, withBlocks, rootId, before, after, baseVersionKey, vk, spaceId)
-		const named = yield* enrichNames(db, withConfig, spaceId)
+		const named = yield* enrichNames(db, withBlocks, spaceId)
 		const withMedia = yield* enrichWithMediaUrls(db, named, {fromVersionKey: vk, toVersionKey: vk, spaceId})
 		const {groups, ...rest} = withMedia
 		const flattened = {...rest, ...groups} as unknown as EntityDiffV2
@@ -321,7 +368,45 @@ function buildFoldedPage(
 			for (const b of snaps) blockBaseById.set(b.id, b)
 		}
 
-		// 3. Attach base blocks to roots; build the relation→block map for op matching.
+		// 2b. Data-block config entities (reified BLOCKS-relation entities). Fetch each
+		//     one's base snapshot and compute its proposed state so the config diff can be
+		//     folded into the data block (before = base config, after = proposed config).
+		const pageRootsSet = new Set(pageRoots)
+		const pageBlockIds = new Set(existingBlockList)
+		for (const [child, parents] of ctx.opsIndex.blockParents) {
+			for (const p of parents) if (pageRootsSet.has(p)) pageBlockIds.add(child)
+		}
+		const configIdByBlock = new Map<NormalizedUuid, NormalizedUuid>()
+		for (const blockId of pageBlockIds) {
+			const cfg = ctx.configByDataBlock.get(blockId)
+			if (cfg) configIdByBlock.set(blockId, cfg)
+		}
+		const configIds = Array.from(new Set(configIdByBlock.values()))
+		const configBaseById = new Map<NormalizedUuid, EntitySnapshot>()
+		if (configIds.length > 0) {
+			const snaps = yield* fetchBaseData(
+				status,
+				baseVersionKey,
+				() => batchGetLiveSnapshots(db, configIds, spaceId),
+				(vk) => batchGetVersionedSnapshots(db, configIds, spaceId, vk),
+				() => {
+					const m = new Map<NormalizedUuid, EntitySnapshot>()
+					for (const id of configIds) m.set(id, emptySnapshot(id))
+					return m
+				},
+			)
+			for (const [id, s] of snaps) configBaseById.set(id, s)
+		}
+		const configBeforeByBlock = new Map<NormalizedUuid, EntitySnapshot>()
+		const configAfterByBlock = new Map<NormalizedUuid, EntitySnapshot>()
+		for (const [blockId, cfgId] of configIdByBlock) {
+			const base = configBaseById.get(cfgId) ?? emptySnapshot(cfgId)
+			configBeforeByBlock.set(blockId, base)
+			configAfterByBlock.set(blockId, applyOpsToSnapshot(base, ops, cfgId, spaceId, new Map()))
+		}
+
+		// 3. Attach base blocks to roots (with config folded in); build the
+		//    relation→block map for op matching.
 		const blocksRelationMap = new Map<NormalizedUuid, NormalizedUuid>()
 		for (const rootId of pageRoots) {
 			const entries = relMap.get(rootId) ?? []
@@ -329,7 +414,8 @@ function buildFoldedPage(
 			if (baseState) {
 				baseState.blocks = entries.map((e) => {
 					blocksRelationMap.set(e.relationId, e.blockEntityId)
-					return blockBaseById.get(e.blockEntityId) ?? {id: e.blockEntityId, values: [], relations: []}
+					const base = blockBaseById.get(e.blockEntityId) ?? {id: e.blockEntityId, values: [], relations: []}
+					return mergeConfig(base, configBeforeByBlock.get(e.blockEntityId))
 				})
 			}
 		}
@@ -346,7 +432,12 @@ function buildFoldedPage(
 				const existing = blockBaseById.get(b.id)
 				const blockBase: EntitySnapshot = existing ? {...existing, blocks: []} : emptySnapshot(b.id)
 				const proposed = applyOpsToSnapshot(blockBase, ops, b.id, spaceId, new Map())
-				return {id: proposed.id, values: proposed.values, relations: proposed.relations}
+				const blockSnap: BlockSnapshot = {
+					id: proposed.id,
+					values: proposed.values,
+					relations: proposed.relations,
+				}
+				return mergeConfig(blockSnap, configAfterByBlock.get(b.id))
 			})
 
 			const before = toGrouped(baseState)

--- a/api/src/versioned/v2/proposal-diff.ts
+++ b/api/src/versioned/v2/proposal-diff.ts
@@ -177,6 +177,9 @@ interface RootContext {
 	/** data block id → its reified BLOCKS-relation (config) entity id, when the
 	 *  edit touched the config; the config entity is folded into the block. */
 	configByDataBlock: Map<NormalizedUuid, NormalizedUuid>
+	/** media type of DB-typed media entities (existing IMAGE/VIDEO), so a proposal
+	 *  that only updates an already-typed entity's URL still inlines correctly. */
+	mediaTypeById: Map<NormalizedUuid, "image" | "video">
 }
 
 /**
@@ -241,6 +244,8 @@ function resolveRoots(
 		}
 
 		const mediaChildren = new Set<NormalizedUuid>()
+		const mediaTypeById = new Map<NormalizedUuid, "image" | "video">()
+		for (const [id, m] of dbMedia) mediaTypeById.set(id, m.mediaType)
 		for (const id of affected) {
 			if (dbMedia.has(id) || opsIndex.mediaTyped.has(id)) mediaChildren.add(id)
 		}
@@ -270,20 +275,31 @@ function resolveRoots(
 			if (!blockChildren.has(p) && !mediaChildren.has(p) && !configEntities.has(p)) roots.add(p)
 		}
 
-		return {roots: Array.from(roots).sort(), ctx: {opsIndex, blockChildren, mediaChildren, configByDataBlock}}
+		return {
+			roots: Array.from(roots).sort(),
+			ctx: {opsIndex, blockChildren, mediaChildren, configByDataBlock, mediaTypeById},
+		}
 	})
 }
 
-/** Inline proposed-side (edit-created) media URLs onto a root's relation afters. */
+/**
+ * Inline media URLs that the edit set on the relation's after side.
+ *
+ * Covers media entities typed in the edit (`opsIndex.mediaTyped`) AND existing
+ * DB-typed media entities whose IMAGE_URL the edit *updated* (`ctx.mediaTypeById`).
+ * The edit-set URL is the authoritative after-side value, so it overrides any
+ * base-version URL `enrichWithMediaUrls` may have inlined (which, for proposals,
+ * is resolved at the base version and would otherwise be stale).
+ */
 function inlineProposedMedia(diff: EntityDiffV2, ctx: RootContext): EntityDiffV2 {
 	const {mediaTyped, proposedImageUrls} = ctx.opsIndex
-	if (mediaTyped.size === 0) return diff
+	if (proposedImageUrls.size === 0) return diff
 	const apply = (r: RelationChangeV2): RelationChangeV2 => {
 		if (!r.after) return r
-		const target = r.after.toEntityId
-		const mt = mediaTyped.get(target)
-		const url = proposedImageUrls.get(target)
-		if (!mt || !url || r.after.imageUrl || r.after.videoUrl) return r
+		const url = proposedImageUrls.get(r.after.toEntityId)
+		if (!url) return r
+		const mt = mediaTyped.get(r.after.toEntityId) ?? ctx.mediaTypeById.get(r.after.toEntityId)
+		if (!mt) return r
 		return {...r, after: {...r.after, ...(mt === "video" ? {videoUrl: url} : {imageUrl: url})}}
 	}
 	return {...diff, relations: diff.relations.map(apply)}

--- a/api/src/versioned/v2/proposal-diff.ts
+++ b/api/src/versioned/v2/proposal-diff.ts
@@ -2,23 +2,27 @@
  * v2 proposal diff — enriched, context-aware variants of the proposal endpoints.
  *
  * Mounted at /v2/versioned. Reuses v1's proposal state-construction wholesale
- * (proposal load, edit decode, base-state fetch, op application, pagination,
- * mode logic, errors) and swaps the diff+enrich tail: each affected entity is
- * diffed with the GROUPED diff and run through the same enrichment chain as the
- * entity-diff endpoint (blocks → blockConfig → names → media URLs), so relations
- * carry resolved names + media URLs and blocks carry their folded values/config.
+ * (proposal load, edit decode, base-state fetch, op application, mode logic,
+ * errors) and replaces the diff+enrich tail with the option-A pipeline:
+ *
+ *   1. Resolve the *root* (renderable) entities: classify each affected entity
+ *      as a block child (BLOCKS backlink, DB + edit ops) or a media-property
+ *      child (IMAGE/VIDEO typed), and treat their parents as roots — including
+ *      parents that weren't themselves changed (e.g. editing a block's text).
+ *   2. Paginate over roots (not the flat affected list).
+ *   3. Per root, fold each block child under `blocks[]` with its own proposed
+ *      values/relations/config, drop media children and inline their URL onto
+ *      the parent's relation, and run the shared enrichment chain
+ *      (enrichBlocks → enrichBlockConfig → enrichNames → enrichWithMediaUrls).
  *
  * v1 is unchanged; this is purely additive.
- *
- * NOTE: this slice keeps v1's pagination unit (the flat affected-entity list).
- * Cross-parent block folding + media-property filtering (which require paginating
- * over root entities) are the follow-up (Track B phases 2–3).
  */
 
 import {decodeEditAuto, type Op} from "@geoprotocol/grc-20"
+import {SystemIds} from "@graphprotocol/grc-20"
 import type {NodePgDatabase} from "drizzle-orm/node-postgres"
 import {Effect} from "effect"
-import type {NormalizedUuid} from "../../utils/uuid"
+import {type NormalizedUuid, normalizeUuid} from "../../utils/uuid"
 import {diffGroupedEntitySnapshots} from "../diff"
 import {
 	applyOpsToSnapshot,
@@ -42,6 +46,7 @@ import {
 	getProposalStatus,
 	getProposalWithPublishAction,
 	InvalidCursorError,
+	idToUuid,
 	MAX_GROUP_SIZE,
 	MissingPublishActionError,
 	MixedModeError,
@@ -69,135 +74,284 @@ import {enrichWithMediaUrls} from "./enrich"
 import {enrichBlockConfig} from "./enrich-block-config"
 import {enrichBlocks} from "./enrich-blocks"
 import {enrichNames} from "./enrich-names"
-import type {EntityDiffV2, PaginatedGroupedProposalDiffV2, PaginatedProposalDiffV2} from "./types"
+import {
+	type BlockParentEntry,
+	batchGetBlockParentsAtVersion,
+	batchGetLiveBlockParents,
+	batchGetMediaUrls,
+	batchGetMediaUrlsAtVersion,
+} from "./queries"
+import type {
+	EntityDiffV2,
+	MediaEntity,
+	PaginatedGroupedProposalDiffV2,
+	PaginatedProposalDiffV2,
+	RelationChangeV2,
+} from "./types"
 
 type Database = NodePgDatabase<Record<string, unknown>>
 
-/** Wrap a flat proposal EntitySnapshot as a GroupedEntitySnapshot.
- *  Proposal snapshots already separate BLOCKS children into `.blocks`; there are
- *  no dynamic (non-BLOCKS) groups in the proposal path, so `groups` is empty. */
+const BLOCKS_TYPE_ID = normalizeUuid(SystemIds.BLOCKS)
+const TYPES_PROPERTY_ID = normalizeUuid(SystemIds.TYPES_PROPERTY)
+const IMAGE_TYPE_ID = normalizeUuid(SystemIds.IMAGE_TYPE)
+const VIDEO_TYPE_ID = normalizeUuid(SystemIds.VIDEO_TYPE)
+const IMAGE_URL_PROPERTY_ID = normalizeUuid(SystemIds.IMAGE_URL_PROPERTY)
+
+/** What the edit's ops tell us about parentage / media that the DB can't (new entities). */
+interface OpsIndex {
+	/** child block id → set of parent ids (from createRelation BLOCKS ops). */
+	blockParents: Map<NormalizedUuid, Set<NormalizedUuid>>
+	/** entity id → media type, for entities the edit types as IMAGE/VIDEO. */
+	mediaTyped: Map<NormalizedUuid, "image" | "video">
+	/** entity id → IMAGE_URL set by the edit (proposed-side media url). */
+	proposedImageUrls: Map<NormalizedUuid, string>
+}
+
+function indexOps(ops: Op[]): OpsIndex {
+	const blockParents = new Map<NormalizedUuid, Set<NormalizedUuid>>()
+	const mediaTyped = new Map<NormalizedUuid, "image" | "video">()
+	const proposedImageUrls = new Map<NormalizedUuid, string>()
+
+	const noteImageUrl = (entityId: NormalizedUuid, values: {property: unknown; value: unknown}[]) => {
+		for (const pv of values) {
+			if (normalizeUuid(idToUuid(pv.property as never)) !== IMAGE_URL_PROPERTY_ID) continue
+			const v = pv.value as {type?: string; value?: unknown}
+			if (v?.type === "text" && typeof v.value === "string") proposedImageUrls.set(entityId, v.value)
+		}
+	}
+
+	for (const op of ops) {
+		if (op.type === "createRelation") {
+			const typeId = normalizeUuid(idToUuid(op.relationType))
+			if (typeId === BLOCKS_TYPE_ID) {
+				const child = normalizeUuid(idToUuid(op.to))
+				const parent = normalizeUuid(idToUuid(op.from))
+				const set = blockParents.get(child) ?? new Set<NormalizedUuid>()
+				set.add(parent)
+				blockParents.set(child, set)
+			} else if (typeId === TYPES_PROPERTY_ID) {
+				const to = normalizeUuid(idToUuid(op.to))
+				if (to === IMAGE_TYPE_ID || to === VIDEO_TYPE_ID) {
+					mediaTyped.set(normalizeUuid(idToUuid(op.from)), to === VIDEO_TYPE_ID ? "video" : "image")
+				}
+			}
+		} else if (op.type === "createEntity") {
+			noteImageUrl(normalizeUuid(idToUuid(op.id)), op.values)
+		} else if (op.type === "updateEntity") {
+			noteImageUrl(normalizeUuid(idToUuid(op.id)), op.set)
+		}
+	}
+	return {blockParents, mediaTyped, proposedImageUrls}
+}
+
+/** Wrap a flat proposal EntitySnapshot as a GroupedEntitySnapshot. */
 function toGrouped(s: EntitySnapshot): GroupedEntitySnapshot {
 	return {id: s.id, values: s.values, relations: s.relations, blocks: s.blocks, groupKeys: [], groups: {}}
 }
 
-/** Run the v2 enrichment chain on a single entity's before/after grouped snapshots. */
-function enrichEntity(
+interface RootContext {
+	opsIndex: OpsIndex
+	/** affected entities classified as block children (folded under a parent). */
+	blockChildren: Set<NormalizedUuid>
+	/** affected entities classified as media-property children (dropped + inlined). */
+	mediaChildren: Set<NormalizedUuid>
+}
+
+/**
+ * Resolve the renderable root entities for a proposal's affected set, plus the
+ * classification context needed to fold/drop children.
+ */
+function resolveRoots(
 	db: Database,
-	entityId: NormalizedUuid,
+	ops: Op[],
+	affected: NormalizedUuid[],
+	status: ProposalStatus,
+	baseVersionKey: bigint | null,
+	spaceId: NormalizedUuid,
+): Effect.Effect<{roots: NormalizedUuid[]; ctx: RootContext}, QueryError> {
+	return Effect.gen(function* () {
+		const opsIndex = indexOps(ops)
+
+		const [dbParents, dbMedia] = yield* Effect.all([
+			fetchBaseData(
+				status,
+				baseVersionKey,
+				() => batchGetLiveBlockParents(db, affected, spaceId),
+				(vk) => batchGetBlockParentsAtVersion(db, affected, vk, spaceId),
+				() => new Map<NormalizedUuid, BlockParentEntry[]>(),
+			),
+			fetchBaseData(
+				status,
+				baseVersionKey,
+				() => batchGetMediaUrls(db, affected, spaceId),
+				(vk) => batchGetMediaUrlsAtVersion(db, affected, vk, spaceId),
+				() => new Map<NormalizedUuid, MediaEntity>(),
+			),
+		])
+
+		// child → parents, merging the DB backlink with new BLOCKS ops from the edit.
+		const childToParents = new Map<NormalizedUuid, Set<NormalizedUuid>>()
+		for (const [child, entries] of dbParents) {
+			childToParents.set(child, new Set(entries.map((e) => e.parentId)))
+		}
+		for (const [child, parents] of opsIndex.blockParents) {
+			const set = childToParents.get(child) ?? new Set<NormalizedUuid>()
+			for (const p of parents) set.add(p)
+			childToParents.set(child, set)
+		}
+
+		const blockChildren = new Set<NormalizedUuid>()
+		const parentRoots = new Set<NormalizedUuid>()
+		for (const id of affected) {
+			const parents = childToParents.get(id)
+			if (parents && parents.size > 0) {
+				blockChildren.add(id)
+				for (const p of parents) parentRoots.add(p)
+			}
+		}
+
+		const mediaChildren = new Set<NormalizedUuid>()
+		for (const id of affected) {
+			if (dbMedia.has(id) || opsIndex.mediaTyped.has(id)) mediaChildren.add(id)
+		}
+
+		const roots = new Set<NormalizedUuid>()
+		for (const id of affected) {
+			if (!blockChildren.has(id) && !mediaChildren.has(id)) roots.add(id)
+		}
+		// Orphan parents (a block changed but its parent wasn't in the affected set).
+		for (const p of parentRoots) {
+			if (!blockChildren.has(p) && !mediaChildren.has(p)) roots.add(p)
+		}
+
+		return {roots: Array.from(roots).sort(), ctx: {opsIndex, blockChildren, mediaChildren}}
+	})
+}
+
+/** Inline proposed-side (edit-created) media URLs onto a root's relation afters. */
+function inlineProposedMedia(diff: EntityDiffV2, ctx: RootContext): EntityDiffV2 {
+	const {mediaTyped, proposedImageUrls} = ctx.opsIndex
+	if (mediaTyped.size === 0) return diff
+	const apply = (r: RelationChangeV2): RelationChangeV2 => {
+		if (!r.after) return r
+		const target = r.after.toEntityId
+		const mt = mediaTyped.get(target)
+		const url = proposedImageUrls.get(target)
+		if (!mt || !url || r.after.imageUrl || r.after.videoUrl) return r
+		return {...r, after: {...r.after, ...(mt === "video" ? {videoUrl: url} : {imageUrl: url})}}
+	}
+	return {...diff, relations: diff.relations.map(apply)}
+}
+
+/** Build the folded, enriched diff for one root entity. */
+function buildRootDiff(
+	db: Database,
+	rootId: NormalizedUuid,
 	before: GroupedEntitySnapshot,
 	after: GroupedEntitySnapshot,
 	baseVersionKey: bigint | null,
 	spaceId: NormalizedUuid,
+	ctx: RootContext,
 ): Effect.Effect<EntityDiffV2, QueryError> {
 	return Effect.gen(function* () {
-		// Proposals have no single "to" version (the proposed side is the edit
-		// applied in memory). Use the base version key where a DB lookup is needed;
-		// when null (active proposal) a 0 key makes the versioned lookup miss so the
-		// enrichers fall back to live state.
 		const vk = baseVersionKey ?? 0n
-		const raw = yield* diffGroupedEntitySnapshots(entityId, before, after)
+		const raw = yield* diffGroupedEntitySnapshots(rootId, before, after)
 		const withBlocks = yield* enrichBlocks(raw, before, after)
-		const withConfig = yield* enrichBlockConfig(
-			db,
-			withBlocks,
-			entityId,
-			before,
-			after,
-			baseVersionKey,
-			vk,
-			spaceId,
-		)
+		const withConfig = yield* enrichBlockConfig(db, withBlocks, rootId, before, after, baseVersionKey, vk, spaceId)
 		const named = yield* enrichNames(db, withConfig, spaceId)
 		const withMedia = yield* enrichWithMediaUrls(db, named, {fromVersionKey: vk, toVersionKey: vk, spaceId})
-		// Spread dynamic group keys at the entity level (matches DiffResponseV2).
 		const {groups, ...rest} = withMedia
-		return {...rest, ...groups} as unknown as EntityDiffV2
+		const flattened = {...rest, ...groups} as unknown as EntityDiffV2
+		return inlineProposedMedia(flattened, ctx)
 	})
 }
 
-/**
- * Shared core: given the decoded ops + the page's entity ids, build the base
- * states, apply the ops, and produce enriched grouped diffs for each entity.
- * Reuses the exact base-state/block fetching v1 uses.
- */
-function buildEnrichedEntities(
+/** Build the folded, enriched entity diffs for a page of root entities. */
+function buildFoldedPage(
 	db: Database,
 	ops: Op[],
-	pageEntityIds: NormalizedUuid[],
+	pageRoots: NormalizedUuid[],
 	status: ProposalStatus,
 	baseVersionKey: bigint | null,
 	spaceId: NormalizedUuid,
+	ctx: RootContext,
 ): Effect.Effect<EntityDiffV2[], QueryError> {
 	return Effect.gen(function* () {
-		// 1. Base states (values + relations) — live / versioned / empty, per v1.
+		if (pageRoots.length === 0) return []
+
+		// 1. Base states (values + relations) for the roots.
 		const baseStates = yield* fetchBaseData(
 			status,
 			baseVersionKey,
-			() => batchGetLiveSnapshots(db, pageEntityIds, spaceId),
-			(vk) => batchGetVersionedSnapshots(db, pageEntityIds, spaceId, vk),
+			() => batchGetLiveSnapshots(db, pageRoots, spaceId),
+			(vk) => batchGetVersionedSnapshots(db, pageRoots, spaceId, vk),
 			() => {
 				const m = new Map<NormalizedUuid, EntitySnapshot>()
-				for (const id of pageEntityIds) m.set(id, emptySnapshot(id))
+				for (const id of pageRoots) m.set(id, emptySnapshot(id))
 				return m
 			},
 		)
 
-		// 2. Discover BLOCKS relations + block snapshots for the page entities.
-		const blockRelationsMap = yield* fetchBaseData(
+		// 2. Forward BLOCKS relations for the roots (existing block children at base).
+		const relMap = yield* fetchBaseData(
 			status,
 			baseVersionKey,
-			() => batchGetLiveBlockRelationsForEntities(db, pageEntityIds, spaceId),
-			(vk) => batchGetBlockRelationsForEntities(db, pageEntityIds, vk, spaceId),
+			() => batchGetLiveBlockRelationsForEntities(db, pageRoots, spaceId),
+			(vk) => batchGetBlockRelationsForEntities(db, pageRoots, vk, spaceId),
 			() => {
 				const m = new Map<NormalizedUuid, BlockRelationEntry[]>()
-				for (const id of pageEntityIds) m.set(id, [])
+				for (const id of pageRoots) m.set(id, [])
 				return m
 			},
 		)
 
-		const allBlockIds = new Set<NormalizedUuid>()
-		for (const entries of blockRelationsMap.values()) {
-			for (const entry of entries) allBlockIds.add(entry.blockEntityId)
-		}
-		const blockIdsList = Array.from(allBlockIds)
-		let blockSnapshotsMap: Map<NormalizedUuid, BlockSnapshot>
-		if (blockIdsList.length === 0) {
-			blockSnapshotsMap = new Map()
-		} else {
-			const blockSnapshots = yield* fetchBaseData(
+		// All block child ids that exist at base (to fetch their snapshots).
+		const existingBlockIds = new Set<NormalizedUuid>()
+		for (const entries of relMap.values()) for (const e of entries) existingBlockIds.add(e.blockEntityId)
+		const existingBlockList = Array.from(existingBlockIds)
+		const blockBaseById = new Map<NormalizedUuid, BlockSnapshot>()
+		if (existingBlockList.length > 0) {
+			const snaps = yield* fetchBaseData(
 				status,
 				baseVersionKey,
-				() => batchGetLiveBlockSnapshots(db, blockIdsList, spaceId),
-				(vk) => batchGetBlockSnapshotsAtVersion(db, blockIdsList, vk, spaceId),
+				() => batchGetLiveBlockSnapshots(db, existingBlockList, spaceId),
+				(vk) => batchGetBlockSnapshotsAtVersion(db, existingBlockList, vk, spaceId),
 				() => [] as BlockSnapshot[],
 			)
-			blockSnapshotsMap = new Map(blockSnapshots.map((b) => [b.id, b]))
+			for (const b of snaps) blockBaseById.set(b.id, b)
 		}
 
-		// 3. Attach blocks to base states; build relation→block map for op matching.
+		// 3. Attach base blocks to roots; build the relation→block map for op matching.
 		const blocksRelationMap = new Map<NormalizedUuid, NormalizedUuid>()
-		for (const entityId of pageEntityIds) {
-			const entries = blockRelationsMap.get(entityId) ?? []
-			const baseState = baseStates.get(entityId)
+		for (const rootId of pageRoots) {
+			const entries = relMap.get(rootId) ?? []
+			const baseState = baseStates.get(rootId)
 			if (baseState) {
-				baseState.blocks = entries
-					.map((entry) => {
-						blocksRelationMap.set(entry.relationId, entry.blockEntityId)
-						return blockSnapshotsMap.get(entry.blockEntityId)
-					})
-					.filter((b): b is BlockSnapshot => b !== undefined)
+				baseState.blocks = entries.map((e) => {
+					blocksRelationMap.set(e.relationId, e.blockEntityId)
+					return blockBaseById.get(e.blockEntityId) ?? {id: e.blockEntityId, values: [], relations: []}
+				})
 			}
 		}
 
-		// 4. Per entity: apply ops → proposed, diff (grouped), enrich.
+		// 4. Per root: compute proposed root + proposed block sub-snapshots, fold + enrich.
 		const out: EntityDiffV2[] = []
-		for (const entityId of pageEntityIds) {
-			const baseState = baseStates.get(entityId) ?? emptySnapshot(entityId)
-			const proposedState = applyOpsToSnapshot(baseState, ops, entityId, spaceId, blocksRelationMap)
-			// Cheap pre-check on the flat diff to skip unchanged entities before enrichment.
+		for (const rootId of pageRoots) {
+			const baseState = baseStates.get(rootId) ?? emptySnapshot(rootId)
+			const proposedRoot = applyOpsToSnapshot(baseState, ops, rootId, spaceId, blocksRelationMap)
+
+			// Each block child's OWN proposed snapshot (applyOps with entity = block) —
+			// applyOps on the parent only tracks block membership, not block content.
+			const afterBlocks: BlockSnapshot[] = proposedRoot.blocks.map((b) => {
+				const existing = blockBaseById.get(b.id)
+				const blockBase: EntitySnapshot = existing ? {...existing, blocks: []} : emptySnapshot(b.id)
+				const proposed = applyOpsToSnapshot(blockBase, ops, b.id, spaceId, new Map())
+				return {id: proposed.id, values: proposed.values, relations: proposed.relations}
+			})
+
 			const before = toGrouped(baseState)
-			const after = toGrouped(proposedState)
-			const enriched = yield* enrichEntity(db, entityId, before, after, baseVersionKey, spaceId)
+			const after = {...toGrouped(proposedRoot), blocks: afterBlocks}
+			const enriched = yield* buildRootDiff(db, rootId, before, after, baseVersionKey, spaceId, ctx)
 			if (
 				enriched.values.length > 0 ||
 				enriched.relations.length > 0 ||
@@ -211,7 +365,7 @@ function buildEnrichedEntities(
 	})
 }
 
-/** v2 single-proposal diff. */
+/** v2 single-proposal diff (folded, enriched, root-paginated). */
 export function computeProposalDiffV2(
 	db: Database,
 	proposalId: NormalizedUuid,
@@ -256,36 +410,38 @@ export function computeProposalDiffV2(
 			catch: (error) => new EditDecodeError(error),
 		})
 
-		const entityIds = (yield* extractAffectedEntities(db, ops)).sort()
-		if (expectedTotalEntities !== undefined && expectedTotalEntities !== entityIds.length) {
-			return yield* Effect.fail(new InvalidCursorError(cursorStr ?? ""))
-		}
-		const pageEntityIds = entityIds.slice(startIndex, startIndex + limit)
+		const affected = (yield* extractAffectedEntities(db, ops)).sort()
 
 		let baseVersionKey: bigint | null = null
 		if (status !== "active") {
 			baseVersionKey = yield* resolveVersionKeyBeforeTimestamp(db, proposal.executedAt ?? proposal.endTime)
 		}
 
-		const entities = yield* buildEnrichedEntities(db, ops, pageEntityIds, status, baseVersionKey, spaceId)
+		const {roots, ctx} = yield* resolveRoots(db, ops, affected, status, baseVersionKey, spaceId)
+		// Pagination unit is the renderable roots, not the flat affected list.
+		if (expectedTotalEntities !== undefined && expectedTotalEntities !== roots.length) {
+			return yield* Effect.fail(new InvalidCursorError(cursorStr ?? ""))
+		}
+		const pageRoots = roots.slice(startIndex, startIndex + limit)
+		const entities = yield* buildFoldedPage(db, ops, pageRoots, status, baseVersionKey, spaceId, ctx)
 
 		const nextIndex = startIndex + limit
-		const hasMore = nextIndex < entityIds.length
+		const hasMore = nextIndex < roots.length
 		return {
 			proposalId,
 			spaceId,
 			proposalStatus: status,
 			entities,
 			pagination: {
-				cursor: hasMore ? encodeCursor({entityIndex: nextIndex, totalEntities: entityIds.length}) : null,
+				cursor: hasMore ? encodeCursor({entityIndex: nextIndex, totalEntities: roots.length}) : null,
 				hasMore,
-				totalEntities: entityIds.length,
+				totalEntities: roots.length,
 			},
 		}
 	}).pipe(Effect.withSpan("proposal-diff-v2.computeProposalDiffV2", {attributes: {proposalId, spaceId, limit}}))
 }
 
-/** v2 grouped (multi-proposal) diff. */
+/** v2 grouped (multi-proposal) diff (folded, enriched, root-paginated). */
 export function computeGroupedProposalDiffV2(
 	db: Database,
 	proposalIds: NormalizedUuid[],
@@ -364,11 +520,7 @@ export function computeGroupedProposalDiffV2(
 		decodedEdits.sort(compareGroupedEdits)
 		const allOps: Op[] = decodedEdits.flatMap((e) => e.ops)
 
-		const entityIds = (yield* extractAffectedEntities(db, allOps)).sort()
-		if (expectedTotalEntities !== undefined && expectedTotalEntities !== entityIds.length) {
-			return yield* Effect.fail(new InvalidCursorError(cursorStr ?? ""))
-		}
-		const pageEntityIds = entityIds.slice(startIndex, startIndex + limit)
+		const affected = (yield* extractAffectedEntities(db, allOps)).sort()
 
 		let baseVersionKey: bigint | null = null
 		const firstEdit = decodedEdits[0]
@@ -377,19 +529,24 @@ export function computeGroupedProposalDiffV2(
 		}
 		const fetchStatus: ProposalStatus = mode === "active" ? "active" : "closed"
 
-		const entities = yield* buildEnrichedEntities(db, allOps, pageEntityIds, fetchStatus, baseVersionKey, spaceId)
+		const {roots, ctx} = yield* resolveRoots(db, allOps, affected, fetchStatus, baseVersionKey, spaceId)
+		if (expectedTotalEntities !== undefined && expectedTotalEntities !== roots.length) {
+			return yield* Effect.fail(new InvalidCursorError(cursorStr ?? ""))
+		}
+		const pageRoots = roots.slice(startIndex, startIndex + limit)
+		const entities = yield* buildFoldedPage(db, allOps, pageRoots, fetchStatus, baseVersionKey, spaceId, ctx)
 
 		const nextIndex = startIndex + limit
-		const hasMore = nextIndex < entityIds.length
+		const hasMore = nextIndex < roots.length
 		return {
 			proposalIds,
 			spaceId,
 			mode,
 			entities,
 			pagination: {
-				cursor: hasMore ? encodeCursor({entityIndex: nextIndex, totalEntities: entityIds.length}) : null,
+				cursor: hasMore ? encodeCursor({entityIndex: nextIndex, totalEntities: roots.length}) : null,
 				hasMore,
-				totalEntities: entityIds.length,
+				totalEntities: roots.length,
 			},
 		}
 	}).pipe(

--- a/api/src/versioned/v2/proposal-diff.ts
+++ b/api/src/versioned/v2/proposal-diff.ts
@@ -66,9 +66,11 @@ import {
 import type {
 	BlockSnapshot,
 	EntitySnapshot,
+	GroupedEntityDiff,
 	GroupedEntitySnapshot,
 	GroupedProposalDiffMode,
 	ProposalStatus,
+	RelationChange,
 } from "../types"
 import {enrichWithMediaUrls} from "./enrich"
 import {enrichBlocks} from "./enrich-blocks"
@@ -151,6 +153,9 @@ function indexOps(ops: Op[]): OpsIndex {
 	return {blockParents, mediaTyped, proposedImageUrls, blocksReified}
 }
 
+/** Composite key for per-(parent, block) config lookup. */
+const cfgKey = (parent: NormalizedUuid, block: NormalizedUuid) => `${parent}|${block}`
+
 /** Wrap a flat proposal EntitySnapshot as a GroupedEntitySnapshot. */
 function toGrouped(s: EntitySnapshot): GroupedEntitySnapshot {
 	return {id: s.id, values: s.values, relations: s.relations, blocks: s.blocks, groupKeys: [], groups: {}}
@@ -174,9 +179,10 @@ interface RootContext {
 	blockChildren: Set<NormalizedUuid>
 	/** affected entities classified as media-property children (dropped + inlined). */
 	mediaChildren: Set<NormalizedUuid>
-	/** data block id → its reified BLOCKS-relation (config) entity id, when the
-	 *  edit touched the config; the config entity is folded into the block. */
-	configByDataBlock: Map<NormalizedUuid, NormalizedUuid>
+	/** `${parentId}|${dataBlockId}` → its reified BLOCKS-relation (config) entity id,
+	 *  when the edit touched the config. Keyed per (parent, block) because the same
+	 *  data block can be embedded under multiple parents, each with its own config. */
+	configByParentBlock: Map<string, NormalizedUuid>
 	/** media type of DB-typed media entities (existing IMAGE/VIDEO), so a proposal
 	 *  that only updates an already-typed entity's URL still inlines correctly. */
 	mediaTypeById: Map<NormalizedUuid, "image" | "video">
@@ -255,12 +261,12 @@ function resolveRoots(
 		const reified = new Map<NormalizedUuid, BlocksReifiedEntry>(dbReified)
 		for (const [id, entry] of opsIndex.blocksReified) reified.set(id, entry)
 		const configEntities = new Set<NormalizedUuid>()
-		const configByDataBlock = new Map<NormalizedUuid, NormalizedUuid>()
+		const configByParentBlock = new Map<string, NormalizedUuid>()
 		for (const id of affected) {
 			const entry = reified.get(id)
 			if (!entry) continue
 			configEntities.add(id)
-			configByDataBlock.set(entry.dataBlockId, id)
+			configByParentBlock.set(cfgKey(entry.parentId, entry.dataBlockId), id)
 			// The config's data block folds under its parent; make sure both are placed.
 			blockChildren.add(entry.dataBlockId)
 			parentRoots.add(entry.parentId)
@@ -277,7 +283,7 @@ function resolveRoots(
 
 		return {
 			roots: Array.from(roots).sort(),
-			ctx: {opsIndex, blockChildren, mediaChildren, configByDataBlock, mediaTypeById},
+			ctx: {opsIndex, blockChildren, mediaChildren, configByParentBlock, mediaTypeById},
 		}
 	})
 }
@@ -291,10 +297,13 @@ function resolveRoots(
  * base-version URL `enrichWithMediaUrls` may have inlined (which, for proposals,
  * is resolved at the base version and would otherwise be stale).
  */
-function inlineProposedMedia(diff: EntityDiffV2, ctx: RootContext): EntityDiffV2 {
+function inlineProposedMedia(
+	diff: GroupedEntityDiff & {relations: RelationChangeV2[]},
+	ctx: RootContext,
+): GroupedEntityDiff & {relations: RelationChangeV2[]} {
 	const {mediaTyped, proposedImageUrls} = ctx.opsIndex
 	if (proposedImageUrls.size === 0) return diff
-	const apply = (r: RelationChangeV2): RelationChangeV2 => {
+	const apply = (r: RelationChange): RelationChangeV2 => {
 		if (!r.after) return r
 		const url = proposedImageUrls.get(r.after.toEntityId)
 		if (!url) return r
@@ -302,7 +311,22 @@ function inlineProposedMedia(diff: EntityDiffV2, ctx: RootContext): EntityDiffV2
 		if (!mt) return r
 		return {...r, after: {...r.after, ...(mt === "video" ? {videoUrl: url} : {imageUrl: url})}}
 	}
-	return {...diff, relations: diff.relations.map(apply)}
+	// Mirror enrichWithMediaUrls: rewrite top-level, grouped, and block relations.
+	return {
+		...diff,
+		relations: diff.relations.map(apply),
+		groups: Object.fromEntries(
+			Object.entries(diff.groups).map(([k, items]) => [
+				k,
+				items.map((item) =>
+					"relations" in item && item.relations ? {...item, relations: item.relations.map(apply)} : item,
+				),
+			]),
+		) as GroupedEntityDiff["groups"],
+		blocks: diff.blocks.map((block) =>
+			block.relations ? {...block, relations: block.relations.map(apply)} : block,
+		),
+	}
 }
 
 /** Build the folded, enriched diff for one root entity. */
@@ -323,9 +347,11 @@ function buildRootDiff(
 		const withBlocks = yield* enrichBlocks(raw, before, after)
 		const named = yield* enrichNames(db, withBlocks, spaceId)
 		const withMedia = yield* enrichWithMediaUrls(db, named, {fromVersionKey: vk, toVersionKey: vk, spaceId})
-		const {groups, ...rest} = withMedia
-		const flattened = {...rest, ...groups} as unknown as EntityDiffV2
-		return inlineProposedMedia(flattened, ctx)
+		// Override base-version media URLs with the edit's proposed URLs across top-level,
+		// grouped, and block relations (same structures enrichWithMediaUrls traverses).
+		const inlined = inlineProposedMedia(withMedia, ctx)
+		const {groups, ...rest} = inlined
+		return {...rest, ...groups} as unknown as EntityDiffV2
 	})
 }
 
@@ -384,20 +410,15 @@ function buildFoldedPage(
 			for (const b of snaps) blockBaseById.set(b.id, b)
 		}
 
-		// 2b. Data-block config entities (reified BLOCKS-relation entities). Fetch each
-		//     one's base snapshot and compute its proposed state so the config diff can be
-		//     folded into the data block (before = base config, after = proposed config).
+		// 2b. Data-block config entities (reified BLOCKS-relation entities), keyed per
+		//     (parent, block) so a block shared across parents keeps each parent's own
+		//     config. Fetch each config entity's base snapshot + proposed state so the
+		//     config diff folds into the data block (before = base, after = proposed).
 		const pageRootsSet = new Set(pageRoots)
-		const pageBlockIds = new Set(existingBlockList)
-		for (const [child, parents] of ctx.opsIndex.blockParents) {
-			for (const p of parents) if (pageRootsSet.has(p)) pageBlockIds.add(child)
-		}
-		const configIdByBlock = new Map<NormalizedUuid, NormalizedUuid>()
-		for (const blockId of pageBlockIds) {
-			const cfg = ctx.configByDataBlock.get(blockId)
-			if (cfg) configIdByBlock.set(blockId, cfg)
-		}
-		const configIds = Array.from(new Set(configIdByBlock.values()))
+		const configForPage = [...ctx.configByParentBlock.entries()].filter(([key]) =>
+			pageRootsSet.has(key.split("|")[0] as NormalizedUuid),
+		)
+		const configIds = Array.from(new Set(configForPage.map(([, cfgId]) => cfgId)))
 		const configBaseById = new Map<NormalizedUuid, EntitySnapshot>()
 		if (configIds.length > 0) {
 			const snaps = yield* fetchBaseData(
@@ -413,12 +434,13 @@ function buildFoldedPage(
 			)
 			for (const [id, s] of snaps) configBaseById.set(id, s)
 		}
-		const configBeforeByBlock = new Map<NormalizedUuid, EntitySnapshot>()
-		const configAfterByBlock = new Map<NormalizedUuid, EntitySnapshot>()
-		for (const [blockId, cfgId] of configIdByBlock) {
+		// (parent|block) → before/after config snapshot.
+		const configBefore = new Map<string, EntitySnapshot>()
+		const configAfter = new Map<string, EntitySnapshot>()
+		for (const [key, cfgId] of configForPage) {
 			const base = configBaseById.get(cfgId) ?? emptySnapshot(cfgId)
-			configBeforeByBlock.set(blockId, base)
-			configAfterByBlock.set(blockId, applyOpsToSnapshot(base, ops, cfgId, spaceId, new Map()))
+			configBefore.set(key, base)
+			configAfter.set(key, applyOpsToSnapshot(base, ops, cfgId, spaceId, new Map()))
 		}
 
 		// 3. Attach base blocks to roots (with config folded in); build the
@@ -431,7 +453,7 @@ function buildFoldedPage(
 				baseState.blocks = entries.map((e) => {
 					blocksRelationMap.set(e.relationId, e.blockEntityId)
 					const base = blockBaseById.get(e.blockEntityId) ?? {id: e.blockEntityId, values: [], relations: []}
-					return mergeConfig(base, configBeforeByBlock.get(e.blockEntityId))
+					return mergeConfig(base, configBefore.get(cfgKey(rootId, e.blockEntityId)))
 				})
 			}
 		}
@@ -453,7 +475,7 @@ function buildFoldedPage(
 					values: proposed.values,
 					relations: proposed.relations,
 				}
-				return mergeConfig(blockSnap, configAfterByBlock.get(b.id))
+				return mergeConfig(blockSnap, configAfter.get(cfgKey(rootId, b.id)))
 			})
 
 			const before = toGrouped(baseState)

--- a/api/src/versioned/v2/queries.ts
+++ b/api/src/versioned/v2/queries.ts
@@ -25,6 +25,88 @@ export interface BlockParentEntry {
 	relationId: NormalizedUuid
 }
 
+/** A reified BLOCKS-relation entity (the "block relation entity" that holds a
+ *  data block's view/columns/sort config), resolved to its parent + data block. */
+export interface BlocksReifiedEntry {
+	parentId: NormalizedUuid
+	dataBlockId: NormalizedUuid
+}
+
+/**
+ * Resolve reified-BLOCKS-relation entities: for each candidate entity id, if it
+ * is the reified `entity_id` of a BLOCKS relation, return that relation's parent
+ * (`from`) and data block (`to`). Used by the proposal diff to fold a data
+ * block's config (which lives on this reified entity) into the block.
+ */
+export function batchGetBlocksRelationsByReifiedIdAtVersion(
+	db: NodePgDatabase<Record<string, unknown>>,
+	reifiedIds: NormalizedUuid[],
+	versionKey: bigint,
+	spaceId: NormalizedUuid,
+): Effect.Effect<Map<NormalizedUuid, BlocksReifiedEntry>, QueryError> {
+	if (reifiedIds.length === 0) return Effect.succeed(new Map())
+	return Effect.tryPromise({
+		try: async () => {
+			const idsArray = `{${reifiedIds.join(",")}}`
+			const vk = versionKey.toString()
+			const result = await db.execute<{entity_id: string; from_entity_id: string; to_entity_id: string}>(sql`
+				SELECT entity_id, from_entity_id, to_entity_id
+				FROM relation_versions
+				WHERE entity_id = ANY(${idsArray}::uuid[])
+					AND type_id = ${BLOCKS_TYPE_ID}
+					AND space_id = ${spaceId}
+					AND valid_from_key <= ${vk}::bigint
+					AND (valid_to_key IS NULL OR valid_to_key > ${vk}::bigint)
+			`)
+			const map = new Map<NormalizedUuid, BlocksReifiedEntry>()
+			for (const row of result.rows) {
+				map.set(normalizeUuid(row.entity_id), {
+					parentId: normalizeUuid(row.from_entity_id),
+					dataBlockId: normalizeUuid(row.to_entity_id),
+				})
+			}
+			return map
+		},
+		catch: (error) => new QueryError("batchGetBlocksRelationsByReifiedIdAtVersion", error),
+	}).pipe(
+		Effect.withSpan("queries-v2.batchGetBlocksRelationsByReifiedIdAtVersion", {
+			attributes: {count: reifiedIds.length},
+		}),
+	)
+}
+
+/** Live-state variant of {@link batchGetBlocksRelationsByReifiedIdAtVersion}. */
+export function batchGetLiveBlocksRelationsByReifiedId(
+	db: NodePgDatabase<Record<string, unknown>>,
+	reifiedIds: NormalizedUuid[],
+	spaceId: NormalizedUuid,
+): Effect.Effect<Map<NormalizedUuid, BlocksReifiedEntry>, QueryError> {
+	if (reifiedIds.length === 0) return Effect.succeed(new Map())
+	return Effect.tryPromise({
+		try: async () => {
+			const idsArray = `{${reifiedIds.join(",")}}`
+			const result = await db.execute<{entity_id: string; from_entity_id: string; to_entity_id: string}>(sql`
+				SELECT entity_id, from_entity_id, to_entity_id
+				FROM relations
+				WHERE entity_id = ANY(${idsArray}::uuid[])
+					AND type_id = ${BLOCKS_TYPE_ID}
+					AND space_id = ${spaceId}
+			`)
+			const map = new Map<NormalizedUuid, BlocksReifiedEntry>()
+			for (const row of result.rows) {
+				map.set(normalizeUuid(row.entity_id), {
+					parentId: normalizeUuid(row.from_entity_id),
+					dataBlockId: normalizeUuid(row.to_entity_id),
+				})
+			}
+			return map
+		},
+		catch: (error) => new QueryError("batchGetLiveBlocksRelationsByReifiedId", error),
+	}).pipe(
+		Effect.withSpan("queries-v2.batchGetLiveBlocksRelationsByReifiedId", {attributes: {count: reifiedIds.length}}),
+	)
+}
+
 /**
  * Backlink resolver: for each child entity id, find the parent(s) that link to
  * it via a BLOCKS relation at `versionKey`. Used by the proposal diff to fold a

--- a/api/src/versioned/v2/queries.ts
+++ b/api/src/versioned/v2/queries.ts
@@ -19,6 +19,83 @@ const IMAGE_URL_PROPERTY_ID = normalizeUuid(SystemIds.IMAGE_URL_PROPERTY)
 const TYPES_PROPERTY_ID = normalizeUuid(SystemIds.TYPES_PROPERTY)
 const BLOCKS_TYPE_ID = normalizeUuid(SystemIds.BLOCKS)
 
+/** A BLOCKS relation pointing *at* a (block) entity: which parent owns it. */
+export interface BlockParentEntry {
+	parentId: NormalizedUuid
+	relationId: NormalizedUuid
+}
+
+/**
+ * Backlink resolver: for each child entity id, find the parent(s) that link to
+ * it via a BLOCKS relation at `versionKey`. Used by the proposal diff to fold a
+ * block under its parent even when the parent itself wasn't otherwise changed
+ * (e.g. editing a block's text doesn't touch the parent page).
+ */
+export function batchGetBlockParentsAtVersion(
+	db: NodePgDatabase<Record<string, unknown>>,
+	childIds: NormalizedUuid[],
+	versionKey: bigint,
+	spaceId: NormalizedUuid,
+): Effect.Effect<Map<NormalizedUuid, BlockParentEntry[]>, QueryError> {
+	if (childIds.length === 0) return Effect.succeed(new Map())
+	return Effect.tryPromise({
+		try: async () => {
+			const idsArray = `{${childIds.join(",")}}`
+			const vk = versionKey.toString()
+			const result = await db.execute<{to_entity_id: string; from_entity_id: string; relation_id: string}>(sql`
+				SELECT to_entity_id, from_entity_id, relation_id
+				FROM relation_versions
+				WHERE to_entity_id = ANY(${idsArray}::uuid[])
+					AND type_id = ${BLOCKS_TYPE_ID}
+					AND space_id = ${spaceId}
+					AND valid_from_key <= ${vk}::bigint
+					AND (valid_to_key IS NULL OR valid_to_key > ${vk}::bigint)
+			`)
+			const map = new Map<NormalizedUuid, BlockParentEntry[]>()
+			for (const row of result.rows) {
+				const child = normalizeUuid(row.to_entity_id)
+				const entry = {parentId: normalizeUuid(row.from_entity_id), relationId: normalizeUuid(row.relation_id)}
+				const list = map.get(child)
+				if (list) list.push(entry)
+				else map.set(child, [entry])
+			}
+			return map
+		},
+		catch: (error) => new QueryError("batchGetBlockParentsAtVersion", error),
+	}).pipe(Effect.withSpan("queries-v2.batchGetBlockParentsAtVersion", {attributes: {count: childIds.length}}))
+}
+
+/** Live-state variant of {@link batchGetBlockParentsAtVersion}. */
+export function batchGetLiveBlockParents(
+	db: NodePgDatabase<Record<string, unknown>>,
+	childIds: NormalizedUuid[],
+	spaceId: NormalizedUuid,
+): Effect.Effect<Map<NormalizedUuid, BlockParentEntry[]>, QueryError> {
+	if (childIds.length === 0) return Effect.succeed(new Map())
+	return Effect.tryPromise({
+		try: async () => {
+			const idsArray = `{${childIds.join(",")}}`
+			const result = await db.execute<{to_entity_id: string; from_entity_id: string; id: string}>(sql`
+				SELECT to_entity_id, from_entity_id, id
+				FROM relations
+				WHERE to_entity_id = ANY(${idsArray}::uuid[])
+					AND type_id = ${BLOCKS_TYPE_ID}
+					AND space_id = ${spaceId}
+			`)
+			const map = new Map<NormalizedUuid, BlockParentEntry[]>()
+			for (const row of result.rows) {
+				const child = normalizeUuid(row.to_entity_id)
+				const entry = {parentId: normalizeUuid(row.from_entity_id), relationId: normalizeUuid(row.id)}
+				const list = map.get(child)
+				if (list) list.push(entry)
+				else map.set(child, [entry])
+			}
+			return map
+		},
+		catch: (error) => new QueryError("batchGetLiveBlockParents", error),
+	}).pipe(Effect.withSpan("queries-v2.batchGetLiveBlockParents", {attributes: {count: childIds.length}}))
+}
+
 /**
  * For a parent entity's BLOCKS relations at `versionKey`, map each target
  * (data) block id → the BLOCKS relation's reified-relation entity id (= the

--- a/api/src/versioned/v2/router.ts
+++ b/api/src/versioned/v2/router.ts
@@ -13,14 +13,16 @@ import {Hono} from "hono"
 import {getProfilesBySpaceIds} from "../../profile/queries"
 import type {Profile} from "../../profile/types"
 import type {AppRuntime} from "../../services/runtime"
-import {isValidUuid, type NormalizedUuid, normalizeUuid, toDashedUuid} from "../../utils/uuid"
+import {isValidUuid, normalizeUuid, toDashedUuid} from "../../utils/uuid"
 import {diffGroupedEntitySnapshots} from "../diff"
 import {getGroupedEntitySnapshotAtVersion, type QueryError, resolveVersionKey} from "../queries"
-import type {DiffResponse, GroupedEntitySnapshot} from "../types"
+import {mapGroupedProposalError, validateGroupedRequest} from "../router"
+import type {GroupedEntitySnapshot} from "../types"
 import {enrichWithMediaUrls} from "./enrich"
 import {enrichBlockConfig} from "./enrich-block-config"
 import {enrichBlocks} from "./enrich-blocks"
 import {enrichNames} from "./enrich-names"
+import {computeGroupedProposalDiffV2, computeProposalDiffV2} from "./proposal-diff"
 import type {DiffResponseV2} from "./types"
 
 type AppEnv = {
@@ -203,6 +205,83 @@ export function createVersionedV2Router(db: Database, runtime: AppRuntime) {
 				}
 			},
 			onRight: (response: DiffResponseV2) => c.json(response as unknown as Record<string, unknown>, 200),
+		})
+	})
+
+	/**
+	 * GET /v2/versioned/proposals/:id/diff
+	 *
+	 * Enriched, context-aware variant of the v1 proposal diff: each entity is a
+	 * grouped diff with resolved names, media URLs on relations, and folded block
+	 * values/config — same enrichment as the entity-diff endpoint.
+	 */
+	router.get("/proposals/:id/diff", async (c) => {
+		const rawProposalId = c.req.param("id")
+		const rawSpaceId = c.req.query("spaceId")
+		const cursor = c.req.query("cursor")
+		const rawLimit = c.req.query("limit")
+
+		if (!isValidUuid(rawProposalId)) {
+			return c.json({error: "Invalid parameter", message: "Proposal ID must be a valid UUID"}, 400)
+		}
+		if (!rawSpaceId || !isValidUuid(rawSpaceId)) {
+			return c.json({error: "Invalid parameter", message: "spaceId must be a valid UUID"}, 400)
+		}
+		let limit = 50
+		if (rawLimit !== undefined) {
+			const parsed = Number.parseInt(rawLimit, 10)
+			if (Number.isNaN(parsed) || parsed < 1) {
+				return c.json({error: "Invalid parameter", message: "limit must be a positive integer"}, 400)
+			}
+			limit = Math.min(parsed, 100)
+		}
+
+		const program = computeProposalDiffV2(
+			db,
+			normalizeUuid(rawProposalId),
+			normalizeUuid(rawSpaceId),
+			cursor,
+			limit,
+		).pipe(Effect.withSpan("GET /v2/versioned/proposals/:id/diff"))
+
+		const result = await runtime.runPromise(Effect.either(program))
+		return Either.match(result, {
+			onLeft: (error) => {
+				const mapped = mapGroupedProposalError(error)
+				return c.json(mapped.body, mapped.status)
+			},
+			onRight: (diff) => c.json(diff as unknown as Record<string, unknown>, 200),
+		})
+	})
+
+	/**
+	 * GET /v2/versioned/proposal-groups/diff
+	 *
+	 * Enriched, context-aware variant of the v1 grouped (multi-proposal) diff.
+	 */
+	router.get("/proposal-groups/diff", async (c) => {
+		const validation = validateGroupedRequest({
+			spaceId: c.req.query("spaceId"),
+			proposalIds: c.req.query("proposalIds"),
+			cursor: c.req.query("cursor"),
+			limit: c.req.query("limit"),
+		})
+		if (!validation.ok) {
+			return c.json(validation.failure.body, validation.failure.status)
+		}
+		const {spaceId, proposalIds, cursor, limit} = validation.value
+
+		const program = computeGroupedProposalDiffV2(db, proposalIds, spaceId, cursor, limit).pipe(
+			Effect.withSpan("GET /v2/versioned/proposal-groups/diff"),
+		)
+
+		const result = await runtime.runPromise(Effect.either(program))
+		return Either.match(result, {
+			onLeft: (error) => {
+				const mapped = mapGroupedProposalError(error)
+				return c.json(mapped.body, mapped.status)
+			},
+			onRight: (diff) => c.json(diff as unknown as Record<string, unknown>, 200),
 		})
 	})
 

--- a/api/src/versioned/v2/types.ts
+++ b/api/src/versioned/v2/types.ts
@@ -10,7 +10,7 @@
  */
 
 import type {NormalizedUuid} from "../../utils/uuid"
-import type {DiffResponse, RelationChange} from "../types"
+import type {DiffResponse, DynamicGroupItem, GroupedEntityDiff, ProposalStatus, RelationChange} from "../types"
 
 /**
  * v2 relation-change endpoint payload.
@@ -48,4 +48,46 @@ export interface MediaEntity {
 	entityId: NormalizedUuid
 	url: string
 	mediaType: "image" | "video"
+}
+
+// ============================================================================
+// Proposal diff (v2)
+// ============================================================================
+
+/**
+ * A single enriched, context-aware entity diff in a proposal response.
+ *
+ * Same enrichment as the entity-diff endpoint (`DiffResponseV2`) minus the
+ * per-edit metadata: relations carry media URLs (`RelationChangeV2`), blocks are
+ * folded under `blocks[]` with their values/relations/config, names are
+ * resolved, and dynamic group keys are spread at the entity level. Block and
+ * media "property" child entities are folded into their parent rather than
+ * returned as separate top-level entries.
+ */
+export type EntityDiffV2 = Omit<GroupedEntityDiff, "relations" | "groups"> & {
+	relations: RelationChangeV2[]
+} & Record<NormalizedUuid, DynamicGroupItem[]>
+
+interface PaginationV2 {
+	cursor: string | null
+	hasMore: boolean
+	totalEntities: number
+}
+
+/** Response for `GET /v2/versioned/proposals/:id/diff`. */
+export interface PaginatedProposalDiffV2 {
+	proposalId: NormalizedUuid
+	spaceId: NormalizedUuid
+	proposalStatus: ProposalStatus
+	entities: EntityDiffV2[]
+	pagination: PaginationV2
+}
+
+/** Response for `GET /v2/versioned/proposal-groups/diff`. */
+export interface PaginatedGroupedProposalDiffV2 {
+	proposalIds: NormalizedUuid[]
+	spaceId: NormalizedUuid
+	mode: "active" | "historical"
+	entities: EntityDiffV2[]
+	pagination: PaginationV2
 }


### PR DESCRIPTION
Mirror of geobrowser/gaia#758, opened on the fork.

Adds the enriched, context-aware **v2 proposal diff endpoints** and brings them to **`postProcessDiffs` parity** so the geogenesis UI can switch to v2 and delete its client-side `postProcessDiffs` for the proposal path.

- `GET /v2/versioned/proposals/:id/diff`
- `GET /v2/versioned/proposal-groups/diff`

Purely additive — v1 is untouched. Completes Track B of `v2/context.md`.

## What you get
Each **root** entity comes back as a grouped `EntityDiffV2`:
- value changes carry `propertyName`; relation changes carry `typeName` + `toEntityName`, plus inlined `imageUrl`/`videoUrl`
- **block children folded** under `blocks[]` with their own proposed values/relations + data-block config
- **media-property entities** dropped from the top level, URL inlined on the parent relation

## Pipeline
`resolveRoots` (classify block/media/config children via DB backlinks + edit ops, promote parents incl. orphans to roots) → paginate over **roots** → `buildFoldedPage` (per-block proposed snapshots, config merge, media drop/inline) → shared enrichers. Reuses v1 state-construction wholesale.

## postProcessDiffs parity (all gaps closed)
- **data-block config merge for proposals** (config on the reified BLOCKS-relation entity, from the edit) — folded; reified entity no longer leaks top-level
- **media-property filter + inline** (incl. proposed-side URLs)
- **video blocks** (shared `diff.ts` → also fixes the entity endpoint), **ranking blocks** → dataBlock, **imageBlock via `IMAGE_TYPE`**

Accepted divergence: orphan new-block parent-guess heuristic (frontend L360–394) not ported — v2 resolves new blocks from the edit's BLOCKS ops.

## Tests / verification
DB-gated integration tests in `src/versioned/__tests__/` (CI runs them on `api/**`): v1↔v2 parity, name/media enrichment, grouped mode, error parity, block fold under orphan parent, media drop+inline, data-block config fold, video fold, ranking fold, root-pagination across a page boundary. Verified locally: **full versioned suite green (249)**, `tsc` + `biome` clean.

Merge into `dev` (squash).