### PR TITLE
chore: fix formatting & lint CI failures (governance-v2)

### DIFF
--- a/api/main.ts
+++ b/api/main.ts
@@ -98,9 +98,7 @@ if (opensearchUrl) {
 	const environment = process.env.ENVIRONMENT
 	const baseIndexAlias = process.env.INDEX_ALIAS ?? "entities"
 	const indexName =
-		environment === "staging" || environment === "testnet"
-			? `${environment}_${baseIndexAlias}`
-			: baseIndexAlias
+		environment === "staging" || environment === "testnet" ? `${environment}_${baseIndexAlias}` : baseIndexAlias
 
 	const searchClient = new OpenSearchClient(opensearchUrl, indexName)
 	await searchClient.init()

--- a/api/src/proposals/status.ts
+++ b/api/src/proposals/status.ts
@@ -83,15 +83,8 @@ export function computeProposalStatus(
 	// Skip the check when we can't evaluate it safely: totalEditors = 0 means
 	// the space has no indexed editors yet; universal = 0 means no configured
 	// early-execution threshold.
-	if (
-		!isVotingEnded &&
-		proposal.totalEditors > 0n &&
-		proposal.universalPercentageSupportThreshold > 0n
-	) {
-		const required = ceilDiv(
-			proposal.universalPercentageSupportThreshold * proposal.totalEditors,
-			RATIO_BASE,
-		)
+	if (!isVotingEnded && proposal.totalEditors > 0n && proposal.universalPercentageSupportThreshold > 0n) {
+		const required = ceilDiv(proposal.universalPercentageSupportThreshold * proposal.totalEditors, RATIO_BASE)
 		if (proposal.yesCount >= required) {
 			return {
 				status: "EXECUTABLE",
@@ -104,8 +97,7 @@ export function computeProposalStatus(
 
 	// Slow path — late execution (after voting ends).
 	const partial = proposal.partialPercentageSupportThreshold
-	const isThresholdReached =
-		(RATIO_BASE - partial) * proposal.yesCount > partial * proposal.noCount
+	const isThresholdReached = (RATIO_BASE - partial) * proposal.yesCount > partial * proposal.noCount
 
 	if (!isVotingEnded) {
 		return {

--- a/api/src/services/storage/schema.ts
+++ b/api/src/services/storage/schema.ts
@@ -592,15 +592,9 @@ export const proposalVersions = pgTable(
 		 * this constraint to make replays a no-op (and return the already-assigned
 		 * version number to the caller).
 		 */
-		unique("proposal_versions_idempotency_key").on(
-			table.proposalId,
-			table.versionCreatedAtBlock,
-		),
+		unique("proposal_versions_idempotency_key").on(table.proposalId, table.versionCreatedAtBlock),
 		// "Get the latest version for a proposal" — descending so the first hit is current.
-		index("proposal_versions_proposal_version_desc_idx").on(
-			table.proposalId,
-			table.proposalVersion.desc(),
-		),
+		index("proposal_versions_proposal_version_desc_idx").on(table.proposalId, table.proposalVersion.desc()),
 		// Supports "list proposals ordered by end_time of current version" type queries.
 		index("proposal_versions_end_time_idx").on(table.endTime),
 		index("proposal_versions_start_time_idx").on(table.startTime),
@@ -660,11 +654,7 @@ export const proposalActions = pgTable(
 		index("proposal_actions_action_type_idx").on(table.actionType),
 		// Composite index for the active proposal check query (hasActiveProposalForTarget)
 		// which filters by (proposal_id, action_type, target_id) in a correlated EXISTS subquery
-		index("proposal_actions_proposal_action_target_idx").on(
-			table.proposalId,
-			table.actionType,
-			table.targetId,
-		),
+		index("proposal_actions_proposal_action_target_idx").on(table.proposalId, table.actionType, table.targetId),
 	],
 )
 

--- a/hermes-schema/src/pb/governance.rs
+++ b/hermes-schema/src/pb/governance.rs
@@ -446,21 +446,13 @@ impl ProposalActionType {
             Self::ProposalActionFlag => "PROPOSAL_ACTION_FLAG",
             Self::ProposalActionUnflag => "PROPOSAL_ACTION_UNFLAG",
             Self::ProposalActionUnflagEditor => "PROPOSAL_ACTION_UNFLAG_EDITOR",
-            Self::ProposalActionUpdateVotingSettings => {
-                "PROPOSAL_ACTION_UPDATE_VOTING_SETTINGS"
-            }
+            Self::ProposalActionUpdateVotingSettings => "PROPOSAL_ACTION_UPDATE_VOTING_SETTINGS",
             Self::ProposalActionSubspaceVerified => "PROPOSAL_ACTION_SUBSPACE_VERIFIED",
-            Self::ProposalActionSubspaceUnverified => {
-                "PROPOSAL_ACTION_SUBSPACE_UNVERIFIED"
-            }
+            Self::ProposalActionSubspaceUnverified => "PROPOSAL_ACTION_SUBSPACE_UNVERIFIED",
             Self::ProposalActionSubspaceRelated => "PROPOSAL_ACTION_SUBSPACE_RELATED",
             Self::ProposalActionSubspaceUnrelated => "PROPOSAL_ACTION_SUBSPACE_UNRELATED",
-            Self::ProposalActionSubspaceTopicDeclared => {
-                "PROPOSAL_ACTION_SUBSPACE_TOPIC_DECLARED"
-            }
-            Self::ProposalActionSubspaceTopicRemoved => {
-                "PROPOSAL_ACTION_SUBSPACE_TOPIC_REMOVED"
-            }
+            Self::ProposalActionSubspaceTopicDeclared => "PROPOSAL_ACTION_SUBSPACE_TOPIC_DECLARED",
+            Self::ProposalActionSubspaceTopicRemoved => "PROPOSAL_ACTION_SUBSPACE_TOPIC_REMOVED",
             Self::ProposalActionSetTopic => "PROPOSAL_ACTION_SET_TOPIC",
             Self::ProposalActionUnsetTopic => "PROPOSAL_ACTION_UNSET_TOPIC",
         }
@@ -480,18 +472,10 @@ impl ProposalActionType {
             "PROPOSAL_ACTION_UPDATE_VOTING_SETTINGS" => {
                 Some(Self::ProposalActionUpdateVotingSettings)
             }
-            "PROPOSAL_ACTION_SUBSPACE_VERIFIED" => {
-                Some(Self::ProposalActionSubspaceVerified)
-            }
-            "PROPOSAL_ACTION_SUBSPACE_UNVERIFIED" => {
-                Some(Self::ProposalActionSubspaceUnverified)
-            }
-            "PROPOSAL_ACTION_SUBSPACE_RELATED" => {
-                Some(Self::ProposalActionSubspaceRelated)
-            }
-            "PROPOSAL_ACTION_SUBSPACE_UNRELATED" => {
-                Some(Self::ProposalActionSubspaceUnrelated)
-            }
+            "PROPOSAL_ACTION_SUBSPACE_VERIFIED" => Some(Self::ProposalActionSubspaceVerified),
+            "PROPOSAL_ACTION_SUBSPACE_UNVERIFIED" => Some(Self::ProposalActionSubspaceUnverified),
+            "PROPOSAL_ACTION_SUBSPACE_RELATED" => Some(Self::ProposalActionSubspaceRelated),
+            "PROPOSAL_ACTION_SUBSPACE_UNRELATED" => Some(Self::ProposalActionSubspaceUnrelated),
             "PROPOSAL_ACTION_SUBSPACE_TOPIC_DECLARED" => {
                 Some(Self::ProposalActionSubspaceTopicDeclared)
             }

--- a/kg-indexer/src/consumer.rs
+++ b/kg-indexer/src/consumer.rs
@@ -294,10 +294,7 @@ pub fn parse_message(
                     let voting_settings_updated =
                         hermes_schema::pb::governance::HermesVotingSettingsUpdated::decode(payload)
                             .map_err(|e| {
-                                IndexerError::decode(format!(
-                                    "HermesVotingSettingsUpdated: {}",
-                                    e
-                                ))
+                                IndexerError::decode(format!("HermesVotingSettingsUpdated: {}", e))
                             })?;
                     Ok(KgMessage::VotingSettingsUpdated(voting_settings_updated))
                 }
@@ -350,8 +347,12 @@ mod tests {
         };
         let payload = msg.encode_to_vec();
 
-        let parsed =
-            parse_message("space.governance", &payload, Some("VOTING_SETTINGS_UPDATED")).unwrap();
+        let parsed = parse_message(
+            "space.governance",
+            &payload,
+            Some("VOTING_SETTINGS_UPDATED"),
+        )
+        .unwrap();
 
         match parsed {
             KgMessage::VotingSettingsUpdated(event) => {

--- a/kg-indexer/tests/governance_storage_integration.rs
+++ b/kg-indexer/tests/governance_storage_integration.rs
@@ -221,7 +221,10 @@ async fn test_upsert_space_voting_settings_overwrites_on_conflict() {
     .await
     .unwrap();
 
-    assert_eq!(row.0, 999_999, "partial threshold must reflect latest upsert");
+    assert_eq!(
+        row.0, 999_999,
+        "partial threshold must reflect latest upsert"
+    );
     assert_eq!(row.1, 2_000, "updated_at_block must reflect latest upsert");
 
     cleanup_space_voting_settings(&pool, space_id).await;

--- a/proposal-executor/tests/detect.test.ts
+++ b/proposal-executor/tests/detect.test.ts
@@ -132,7 +132,9 @@ describe("V2 detection SQL", () => {
 		// Any threshold compare must be a V2 field (partial/universal/flat),
 		// not the bare `threshold`.
 		for (const m of matches) {
-			expect(m).toMatch(/partial_percentage_support_threshold|universal_percentage_support_threshold|flat_support_threshold/)
+			expect(m).toMatch(
+				/partial_percentage_support_threshold|universal_percentage_support_threshold|flat_support_threshold/,
+			)
 		}
 	})
 

--- a/search-admin/src/main.rs
+++ b/search-admin/src/main.rs
@@ -80,7 +80,10 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     // Validate environment value
-    if cli.environment != "staging" && cli.environment != "testnet" && cli.environment != "production" {
+    if cli.environment != "staging"
+        && cli.environment != "testnet"
+        && cli.environment != "production"
+    {
         error!(
             environment = %cli.environment,
             "ENVIRONMENT must be 'staging', 'testnet' or 'production'"


### PR DESCRIPTION
## What

Fixes the **formatting/lint CI failures** on `feat/governance-v2-contract-migration` — the `Build & Lint` job and the `check` job's `format:check` / `lint` scripts. Pure formatting; **no behavior changes**.

## Why

After syncing `dev` into the governance-v2 branch (#241), biome and `cargo fmt` flagged files that weren't formatted to each tool's current rules — blocking CI on #206.

## Changes

**TypeScript (biome)**
- `api/main.ts`
- `api/src/proposals/status.ts`
- `api/src/services/storage/schema.ts`
- `proposal-executor/tests/detect.test.ts`

**Rust (cargo fmt)**
- `hermes-schema/src/pb/governance.rs` _(generated)_
- `kg-indexer/src/consumer.rs`
- `kg-indexer/tests/governance_storage_integration.rs`
- `search-admin/src/main.rs`

## Notes

- Whitespace / line-wrapping only — no logic changes.
- The remaining E2E build failures (notification-indexer using pre-V2 governance proto fields) are **out of scope** here and handled separately.