### PR TITLE
fix(notification-indexer): resolve space & proposer display names from page entity

### DIFF
--- a/notification-service/notification-indexer/src/main.rs
+++ b/notification-service/notification-indexer/src/main.rs
@@ -1383,6 +1383,22 @@ async fn enrich_payload(
                 }
             }
 
+            // Member/editor target display names — name *who* an editor/member
+            // request is about. `target_address` on add_member/add_editor actions
+            // is the target's personal-space UUID (hermes decodes addMember(bytes16)
+            // into it), so it resolves to a name like any other space.
+            if let Some(actions) = gov.actions.as_mut() {
+                for action in actions.iter_mut() {
+                    if matches!(action.action_type.as_str(), "add_member" | "add_editor") {
+                        if let Some(target) = action.target_address.as_deref() {
+                            if let Ok(target_space_id) = uuid::Uuid::parse_str(target) {
+                                action.target_name = storage.lookup_space_name(target_space_id).await;
+                            }
+                        }
+                    }
+                }
+            }
+
             // Vote tallies (proposal_voted events only)
             if event.event_type == NotificationEventType::ProposalVoted {
                 if let Ok(pid) = uuid::Uuid::parse_str(&gov.proposal_id) {

--- a/notification-service/notification-indexer/src/main.rs
+++ b/notification-service/notification-indexer/src/main.rs
@@ -1392,7 +1392,8 @@ async fn enrich_payload(
                     if matches!(action.action_type.as_str(), "add_member" | "add_editor") {
                         if let Some(target) = action.target_address.as_deref() {
                             if let Ok(target_space_id) = uuid::Uuid::parse_str(target) {
-                                action.target_name = storage.lookup_space_name(target_space_id).await;
+                                action.target_name =
+                                    storage.lookup_space_name(target_space_id).await;
                             }
                         }
                     }

--- a/notification-service/notification-indexer/src/main.rs
+++ b/notification-service/notification-indexer/src/main.rs
@@ -1365,10 +1365,14 @@ async fn enrich_payload(
                 gov.proposal_name = storage.lookup_proposal_name(pid).await;
             }
 
-            // Proposer display name
+            // Proposer display name. `proposer_id` is the proposer's personal-space
+            // UUID (proposals.proposed_by), so its display name lives on that
+            // space's page entity — resolve it the same way as the space name, not
+            // via lookup_entity_name on the bare id (which only finds the
+            // "Space <uuid>" placeholder, scoped to the wrong space → null).
             if let Some(ref proposer_id) = gov.proposer_id {
                 if let Ok(pid) = uuid::Uuid::parse_str(proposer_id) {
-                    gov.proposer_name = storage.lookup_entity_name(pid, space_id).await;
+                    gov.proposer_name = storage.lookup_space_name(pid).await;
                 }
             }
 

--- a/notification-service/notification-indexer/src/main.rs
+++ b/notification-service/notification-indexer/src/main.rs
@@ -1349,8 +1349,14 @@ async fn enrich_payload(
 ) {
     use notification_indexer::models::{NotificationData, NotificationEventType};
 
-    // Space name (common to all event types)
-    event.payload.space_name = storage.lookup_entity_name(space_id, space_id).await;
+    // Space name (common to all event types). Prefer the space's page-entity
+    // display name (e.g. "Wonderland"); fall back to the bare space entity's
+    // name (the auto-generated "Space <uuid>" placeholder) only if there is no
+    // page entity / name.
+    event.payload.space_name = match storage.lookup_space_name(space_id).await {
+        Some(name) => Some(name),
+        None => storage.lookup_entity_name(space_id, space_id).await,
+    };
 
     match &mut event.payload.data {
         NotificationData::Governance(ref mut gov) => {

--- a/notification-service/notification-indexer/src/models.rs
+++ b/notification-service/notification-indexer/src/models.rs
@@ -208,6 +208,11 @@ pub struct ActionSummary {
     /// Target address (hex-encoded, for member/editor actions).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub target_address: Option<String>,
+    /// Display name of the target member/editor, resolved from `target_address`
+    /// — which carries the target's personal-space UUID (hermes' decode of
+    /// `addMember(bytes16)`), so it resolves like any space name. Best-effort.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_name: Option<String>,
     /// Target space ID (for subspace actions).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub target_space_id: Option<String>,

--- a/notification-service/notification-indexer/src/storage.rs
+++ b/notification-service/notification-indexer/src/storage.rs
@@ -549,6 +549,12 @@ impl Storage {
     /// Name values are not space-scoped (matching the API's `entities_name`),
     /// so we match on `entity_id` only. Returns `None` if the space has no page
     /// entity or it has no name.
+    ///
+    /// The schema enforces no uniqueness on the matched relation/value keys (an
+    /// entity can carry multiple Name values, e.g. per `language`), so we apply
+    /// a deterministic tie-break before `LIMIT 1` — same convention as the API's
+    /// `batchGetEntityNames`: pick the lowest page-entity id, prefer the Name
+    /// value defined in this space, then the lowest value id.
     pub async fn lookup_space_name(&self, space_id: Uuid) -> Option<String> {
         sqlx::query_scalar::<_, String>(
             r#"
@@ -560,6 +566,7 @@ impl Storage {
               AND r.to_entity_id = $3
               AND v.property_id = $4
               AND v.text IS NOT NULL
+            ORDER BY r.from_entity_id, (v.space_id = $1) DESC, v.id
             LIMIT 1
             "#,
         )

--- a/notification-service/notification-indexer/src/storage.rs
+++ b/notification-service/notification-indexer/src/storage.rs
@@ -538,6 +538,41 @@ impl Storage {
         .flatten()
     }
 
+    /// Look up a space's display name (e.g. "Wonderland").
+    ///
+    /// The bare `space_id` entity only carries the auto-generated placeholder
+    /// ("Space <uuid>"). The real name lives on the space's *page entity* — the
+    /// entity inside the space with a Types relation to SPACE_TYPE (the same
+    /// "front page entity" pattern as `lookup_entity_space`, and what the API's
+    /// `spaces_page` function resolves). We read that entity's Name value.
+    ///
+    /// Name values are not space-scoped (matching the API's `entities_name`),
+    /// so we match on `entity_id` only. Returns `None` if the space has no page
+    /// entity or it has no name.
+    pub async fn lookup_space_name(&self, space_id: Uuid) -> Option<String> {
+        sqlx::query_scalar::<_, String>(
+            r#"
+            SELECT v.text
+            FROM relations r
+            JOIN "values" v ON v.entity_id = r.from_entity_id
+            WHERE r.space_id = $1
+              AND r.type_id = $2
+              AND r.to_entity_id = $3
+              AND v.property_id = $4
+              AND v.text IS NOT NULL
+            LIMIT 1
+            "#,
+        )
+        .bind(space_id)
+        .bind(ids::types_relation_type())
+        .bind(ids::space_type())
+        .bind(ids::name_property())
+        .fetch_optional(&self.pool)
+        .await
+        .ok()
+        .flatten()
+    }
+
     /// Look up the human-readable name for a proposal from the proposals table.
     pub async fn lookup_proposal_name(&self, proposal_id: Uuid) -> Option<String> {
         sqlx::query_scalar::<_, String>(


### PR DESCRIPTION
Resolves notification `space_name` **and** `proposer_name` from the correct **page entity** instead of the bare space-id entity (which only holds the `Space <uuid>` placeholder).

**Commits:**
1. `space_name` via new `Storage::lookup_space_name` (Types→SPACE_TYPE page entity). Verified `1638f271…` → "Wonderland".
2. Deterministic `ORDER BY` tie-break (qodo finding; same convention as the API's `batchGetEntityNames`).
3. `proposer_name` via `lookup_space_name(proposer_id)` — `proposer_id` is the proposer's personal-space UUID, so its name lives on that space's page entity. Verified `f3dab79c…` → "Preston Mantel" (was null).

`cargo check -p notification-indexer` passes. Companion app-side copy change: geobrowser/geo-notifications#7.

Note: `voter_name` and bounty `curator_name` have the same latent bug (lookup_entity_name on a space UUID) — left for a follow-up since those notification types aren't exercised yet.