### PR TITLE
perf(scoring): precompute per-space tallies to de-quadratic space scoring

### DIFF
--- a/scoring-service/cronjob/src/algorithm/models.py
+++ b/scoring-service/cronjob/src/algorithm/models.py
@@ -152,9 +152,9 @@ class Space:
 
     def calculate_space_score(
         self,
-        entities: list[Entity],
-        users: list[User],
         spaces: list["Space"],
+        member_counts: dict[str, int],
+        entity_counts: dict[str, int],
         root_space_id: str = ROOT_SPACE_ID,
     ) -> None:
         """Calculate space score based on distance from root (GEO)."""
@@ -168,12 +168,8 @@ class Space:
         else:
             self.space_score = SPACE_SCORE_DECAY_BASE**DISCONNECTED_SPACE_DEPTH
 
-        self.member_count = sum(
-            1 for user in users if self.id in user.member_spaces or self.id in user.editor_spaces
-        )
-        self.entity_count = len(
-            [e for e in entities if any(p.space_id == self.id for p in e.perspectives)]
-        )
+        self.member_count = member_counts.get(self.id, 0)
+        self.entity_count = entity_counts.get(self.id, 0)
 
     def _calculate_distance_to_root(
         self, spaces: list["Space"], root_space_id: str, max_depth: int = MAX_SPACE_DEPTH

--- a/scoring-service/cronjob/src/algorithm/scoring.py
+++ b/scoring-service/cronjob/src/algorithm/scoring.py
@@ -3,6 +3,7 @@
 import logging
 import math
 import time
+from collections import Counter, defaultdict
 from datetime import datetime
 
 import numpy as np
@@ -16,6 +17,34 @@ ACTIVITY_WEIGHT = 0.1           # Activity weight in composite space score (10%)
 from .utils import calculate_space_distances
 
 logger = logging.getLogger(__name__)
+
+
+def compute_space_aggregates(
+    entities: list[Entity], users: list[User]
+) -> tuple[dict[str, int], dict[str, int]]:
+    """Precompute per-space member and entity counts in a single pass.
+
+    Returns:
+        ``(member_counts, entity_counts)`` keyed by space id. ``member_counts`` counts
+        each user once per space they are a member or editor of; ``entity_counts``
+        counts distinct entities that have at least one perspective in the space.
+    """
+    member_counts: Counter[str] = Counter()
+    for user in users:
+        # Union dedups users who are both member and editor of the same space,
+        # matching the previous `member_spaces or editor_spaces` semantics.
+        for space_id in user.member_spaces | user.editor_spaces:
+            member_counts[space_id] += 1
+
+    # Track distinct entity ids per space so an entity with several perspectives in the
+    # same space is counted once (matches the previous list-comprehension semantics).
+    entity_ids_by_space: dict[str, set[str]] = defaultdict(set)
+    for entity in entities:
+        for perspective in entity.perspectives:
+            entity_ids_by_space[perspective.space_id].add(entity.id)
+    entity_counts = {space_id: len(ids) for space_id, ids in entity_ids_by_space.items()}
+
+    return dict(member_counts), entity_counts
 
 
 class EntityScorer:
@@ -281,8 +310,9 @@ class RankingEngine:
 
         # Step 0: Calculate space scores if spaces are provided
         if spaces is not None:
+            member_counts, entity_counts = compute_space_aggregates(entities, users)
             for space in spaces:
-                space.calculate_space_score(entities, users, spaces)
+                space.calculate_space_score(spaces, member_counts, entity_counts)
 
         # Step 1: Apply distance-based weighting to votes if enabled
         processed_votes = votes
@@ -365,9 +395,11 @@ class RankingEngine:
         total = len(spaces)
         log_interval = max(1, total // 4)
 
+        member_counts, entity_counts = compute_space_aggregates(entities, users)
+
         # Calculate scores for all spaces
         for i, space in enumerate(spaces):
-            space.calculate_space_score(entities, users, spaces)
+            space.calculate_space_score(spaces, member_counts, entity_counts)
 
             if self.config.use_activity_metrics:
                 space.activity_score = self.space_scorer.calculate_activity_score(space, entities)

--- a/scoring-service/cronjob/tests/test_scoring_data_provider.py
+++ b/scoring-service/cronjob/tests/test_scoring_data_provider.py
@@ -342,7 +342,7 @@ class TestSpaceScoreCalculation:
         spaces = [root, child_1, child_3]
 
         for space in spaces:
-            space.calculate_space_score([], [], spaces)
+            space.calculate_space_score(spaces, {}, {})
 
         assert root.space_score == 1.0
         assert root.space_score > child_1.space_score

--- a/scoring-service/cronjob/tests/test_space_aggregates.py
+++ b/scoring-service/cronjob/tests/test_space_aggregates.py
@@ -1,0 +1,95 @@
+"""Tests for the precomputed per-space tallies used in space scoring.
+
+These cover ``compute_space_aggregates`` and verify that ``Space.calculate_space_score``
+reads ``member_count`` / ``entity_count`` from the required precomputed tallies.
+"""
+
+from datetime import datetime
+
+from src.algorithm.models import Entity, Perspective, Space, User
+from src.algorithm.scoring import compute_space_aggregates
+
+
+def _entity(entity_id: str, space_ids: list[str]) -> Entity:
+    """Build an entity with one perspective per given space id."""
+    now = datetime.now()
+    entity = Entity(id=entity_id, created_at=now)
+    entity.perspectives = [
+        Perspective(
+            id=f"{entity_id}-{i}",
+            space_id=space_id,
+            entity_id=entity_id,
+            created_at=now,
+        )
+        for i, space_id in enumerate(space_ids)
+    ]
+    return entity
+
+
+def test_member_counts_dedup_member_and_editor() -> None:
+    """A user who is both member and editor of a space is counted once."""
+    users = [
+        User(id="u1", member_spaces={"s0", "s1"}, editor_spaces=set()),
+        User(id="u2", member_spaces={"s1"}, editor_spaces={"s2"}),
+        # u3 is BOTH member and editor of s2 -> must count once for s2.
+        User(id="u3", member_spaces={"s0", "s2"}, editor_spaces={"s2"}),
+    ]
+
+    member_counts, _ = compute_space_aggregates([], users)
+
+    assert member_counts == {"s0": 2, "s1": 2, "s2": 2}
+
+
+def test_entity_counts_dedup_multiple_perspectives_same_space() -> None:
+    """An entity with multiple perspectives in one space counts once for that space."""
+    entities = [
+        _entity("e1", ["s1", "s2"]),       # in s1 and s2
+        _entity("e2", ["s1"]),             # in s1
+        _entity("e3", ["s2", "s2", "s2"]),  # 3 perspectives, all in s2 -> count once
+    ]
+
+    _, entity_counts = compute_space_aggregates(entities, [])
+
+    assert entity_counts == {"s1": 2, "s2": 2}
+
+
+def test_empty_inputs_produce_empty_tallies() -> None:
+    member_counts, entity_counts = compute_space_aggregates([], [])
+    assert member_counts == {}
+    assert entity_counts == {}
+
+
+def test_calculate_space_score_reads_counts_from_tallies() -> None:
+    """calculate_space_score populates member/entity counts from the required tallies."""
+    now = datetime.now()
+    spaces = [
+        Space(id="s0", created_at=now, distance_to_root=0),
+        Space(id="s1", created_at=now, distance_to_root=1),
+        Space(id="s2", created_at=now, distance_to_root=2),
+        Space(id="s3", created_at=now, distance_to_root=3),  # absent from both tallies
+    ]
+    users = [
+        User(id="u1", member_spaces={"s0", "s1"}, editor_spaces=set()),
+        User(id="u2", member_spaces={"s1"}, editor_spaces={"s2"}),
+        User(id="u3", member_spaces={"s0", "s2"}, editor_spaces={"s2"}),
+    ]
+    entities = [
+        _entity("e1", ["s1", "s2"]),
+        _entity("e2", ["s1"]),
+        _entity("e3", ["s2", "s2"]),  # dedup within s2
+    ]
+
+    member_counts, entity_counts = compute_space_aggregates(entities, users)
+
+    for space in spaces:
+        space.calculate_space_score(spaces, member_counts, entity_counts)
+
+    by_id = {s.id: s for s in spaces}
+    assert by_id["s0"].member_count == 2
+    assert by_id["s1"].member_count == 2
+    assert by_id["s2"].member_count == 2
+    assert by_id["s1"].entity_count == 2
+    assert by_id["s2"].entity_count == 2
+    # A space absent from the tallies defaults to zero counts.
+    assert by_id["s3"].member_count == 0
+    assert by_id["s3"].entity_count == 0


### PR DESCRIPTION
## What

`Space.calculate_space_score` scanned all users (`O(U)`) and all entities with a nested perspective walk (`O(E×P)`) **for every space** — across ~1126 spaces, and in two hot loops per pipeline (`rank_spaces` and `rank_entities` Step 0). This was the `rank_spaces` bottleneck (~8 min for 281/1126 spaces), not the topology BFS.

This inverts the loops: a new `compute_space_aggregates()` builds the member/entity counts in a single pass, and each space then does an `O(1)` dict lookup.

- `member_counts`: `Counter` over `member_spaces | editor_spaces` (dedups a user who is both member and editor — matches the old `or`).
- `entity_counts`: distinct entity ids per space via sets (an entity with multiple perspectives in one space counts once — matches the old `len([...])`).
- `calculate_space_score` now **requires** the tallies (no inline fallback); the orphaned `entities`/`users` params were removed.

## Impact

Overall space scoring goes from `O(S × (U + E×P))` → `O(U + E×P + S)`. Plain dicts/sets — algorithmic fix, not pandas.

## Notes

- First of a stack; the BFS-removal cleanup (`_calculate_distance_to_root`) follows in a separate PR on top of this.
- Tests: `compute_space_aggregates` dedup/empty cases + `calculate_space_score` reading counts from the required tallies.

Part of GEO-709.
