### PR TITLE
refactor(scoring): drop in-model BFS, topology indexer is source of truth for distance

### DIFF
--- a/scoring-service/cronjob/src/algorithm/models.py
+++ b/scoring-service/cronjob/src/algorithm/models.py
@@ -10,7 +10,6 @@ from src.constants import ROOT_SPACE_ID
 
 SPACE_SCORE_DECAY_BASE = 0.8        # Base for space score decay calculation
 DISCONNECTED_SPACE_DEPTH = 11       # Depth used for disconnected spaces (no path to root)
-MAX_SPACE_DEPTH = 10                # Maximum depth for parent traversal
 
 __all__ = [
     "VoteType",
@@ -157,58 +156,21 @@ class Space:
         entity_counts: dict[str, int],
         root_space_id: str = ROOT_SPACE_ID,
     ) -> None:
-        """Calculate space score based on distance from root (GEO)."""
-        # If distance_to_root was pre-set by the topology indexer, skip BFS.
-        if self.distance_to_root is None:
-            self.distance_to_root = self._calculate_distance_to_root(spaces, root_space_id)
+        """Calculate space score based on distance from root (GEO).
 
-        # Calculate space score based on distance to root
-        if self.distance_to_root >= 0:
-            self.space_score = SPACE_SCORE_DECAY_BASE**self.distance_to_root
-        else:
-            self.space_score = SPACE_SCORE_DECAY_BASE**DISCONNECTED_SPACE_DEPTH
+        ``distance_to_root`` is computed upstream by the topology indexer (atlas) and
+        read from the ``scoring_topology_distances`` table. The invariant is: a space
+        with no topology entry is not connected to the root, so it is treated as
+        disconnected. ``distance_to_root`` should already be set by the data provider;
+        ``None`` is handled defensively here as disconnected.
+        """
+        if self.distance_to_root is None:
+            self.distance_to_root = DISCONNECTED_SPACE_DEPTH
+
+        self.space_score = SPACE_SCORE_DECAY_BASE**self.distance_to_root
 
         self.member_count = member_counts.get(self.id, 0)
         self.entity_count = entity_counts.get(self.id, 0)
-
-    def _calculate_distance_to_root(
-        self, spaces: list["Space"], root_space_id: str, max_depth: int = MAX_SPACE_DEPTH
-    ) -> int:
-        """Calculate the number of hops from this space to the root space."""
-        if self.id == root_space_id:
-            return 0
-
-        if not self.parent_space_id:
-            return max_depth + 1
-
-        # Build space lookup for parent traversal
-        space_lookup = {space.id: space for space in spaces}
-
-        # FIXME: we should support multi-parent space-subspace relations
-        # Calculate distance with depth protection
-        distance = 1
-        current_space_id: str | None = self.parent_space_id
-        visited = {self.id}
-
-        while (
-            current_space_id is not None
-            and current_space_id not in visited
-            and distance <= max_depth
-        ):
-            visited.add(current_space_id)
-
-            if current_space_id == root_space_id:
-                return distance
-
-            current_space = space_lookup.get(current_space_id)
-            if not current_space:
-                break
-
-            distance += 1
-            current_space_id = current_space.parent_space_id
-
-        # Return invalid distance if no path found
-        return max_depth + 1
 
 
 @dataclass

--- a/scoring-service/cronjob/src/scoring_data_provider/scoring_data_provider.py
+++ b/scoring-service/cronjob/src/scoring_data_provider/scoring_data_provider.py
@@ -223,11 +223,15 @@ class ScoringDataProvider:
         has to derive them — it only consumes pre-computed distances.
         """
         spaces = []
-        non_root_spaces = {str(space_id) for (space_id,) in space_rows if space_id != ROOT_SPACE_ID}
+        # spaces.id comes back from psycopg as a uuid.UUID, while ROOT_SPACE_ID is a
+        # string — compare on the string form so root detection actually works.
+        non_root_spaces = {
+            str(space_id) for (space_id,) in space_rows if str(space_id) != ROOT_SPACE_ID
+        }
 
         for (space_id,) in space_rows:
             space_id_str = str(space_id)
-            is_root = space_id == ROOT_SPACE_ID
+            is_root = space_id_str == ROOT_SPACE_ID
             sub_space_ids = non_root_spaces if is_root else set()
             parent_space_id = None if is_root else ROOT_SPACE_ID
             distance_to_root = 0 if is_root else 1

--- a/scoring-service/cronjob/src/scoring_data_provider/scoring_data_provider.py
+++ b/scoring-service/cronjob/src/scoring_data_provider/scoring_data_provider.py
@@ -215,14 +215,22 @@ class ScoringDataProvider:
         return spaces
 
     def _build_spaces_flat(self, space_rows: list[tuple]) -> list[Space]:
-        """Build Space objects using flat hierarchy (all children of root)."""
+        """Build Space objects using flat hierarchy (all children of root).
+
+        Fallback used when the topology indexer has not populated
+        scoring_topology_distances yet. Distances are set explicitly here (0 for root,
+        1 for every other space as a direct child of root) so the scoring model never
+        has to derive them — it only consumes pre-computed distances.
+        """
         spaces = []
         non_root_spaces = {str(space_id) for (space_id,) in space_rows if space_id != ROOT_SPACE_ID}
 
         for (space_id,) in space_rows:
             space_id_str = str(space_id)
-            sub_space_ids = non_root_spaces if space_id == ROOT_SPACE_ID else set()
-            parent_space_id = None if space_id == ROOT_SPACE_ID else ROOT_SPACE_ID
+            is_root = space_id == ROOT_SPACE_ID
+            sub_space_ids = non_root_spaces if is_root else set()
+            parent_space_id = None if is_root else ROOT_SPACE_ID
+            distance_to_root = 0 if is_root else 1
             spaces.append(
                 Space(
                     id=space_id_str,
@@ -230,6 +238,7 @@ class ScoringDataProvider:
                     created_at=datetime.now(),
                     parent_space_id=parent_space_id,
                     subspace_ids=sub_space_ids,
+                    distance_to_root=distance_to_root,
                 )
             )
 

--- a/scoring-service/cronjob/tests/test_scoring_data_provider.py
+++ b/scoring-service/cronjob/tests/test_scoring_data_provider.py
@@ -5,7 +5,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from src.algorithm.models import Space, VoteType
+from src.algorithm.models import (
+    DISCONNECTED_SPACE_DEPTH,
+    SPACE_SCORE_DECAY_BASE,
+    Space,
+    VoteType,
+)
 from src.constants import ROOT_SPACE_ID
 from src.scoring_data_provider import ScoringDataProvider, ScoringData
 
@@ -304,9 +309,12 @@ class TestScoringDataProvider:
             root = next(s for s in spaces if s.id == ROOT_SPACE_ID)
             assert root.parent_space_id is None
             assert "space-1" in root.subspace_ids
+            # Flat fallback sets distances explicitly: root=0, every other space=1.
+            assert root.distance_to_root == 0
 
             child = next(s for s in spaces if s.id == "space-1")
             assert child.parent_space_id == ROOT_SPACE_ID
+            assert child.distance_to_root == 1
 
     def test_fetch_scoring_topology_distances(self) -> None:
         """Test that topology distances are fetched correctly."""
@@ -347,3 +355,13 @@ class TestSpaceScoreCalculation:
         assert root.space_score == 1.0
         assert root.space_score > child_1.space_score
         assert child_1.space_score > child_3.space_score
+
+    def test_unset_distance_defaults_to_disconnected(self) -> None:
+        """A space with no distance (no topology entry) is scored as disconnected."""
+        now = datetime.now()
+        space = Space(id="orphan", created_at=now, distance_to_root=None)
+
+        space.calculate_space_score([space], {}, {})
+
+        assert space.distance_to_root == DISCONNECTED_SPACE_DEPTH
+        assert space.space_score == SPACE_SCORE_DECAY_BASE**DISCONNECTED_SPACE_DEPTH

--- a/scoring-service/cronjob/tests/test_scoring_data_provider.py
+++ b/scoring-service/cronjob/tests/test_scoring_data_provider.py
@@ -1,5 +1,6 @@
 """Unit tests for the ScoringDataProvider module."""
 
+import uuid
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
@@ -313,6 +314,41 @@ class TestScoringDataProvider:
             assert root.distance_to_root == 0
 
             child = next(s for s in spaces if s.id == "space-1")
+            assert child.parent_space_id == ROOT_SPACE_ID
+            assert child.distance_to_root == 1
+
+    def test_flat_fallback_identifies_root_with_uuid_ids(self) -> None:
+        """Flat fallback must detect the root even when spaces.id rows are uuid.UUID.
+
+        psycopg returns UUID columns as uuid.UUID objects, not strings. Comparing the
+        raw uuid.UUID against the string ROOT_SPACE_ID is always False, which would
+        misclassify the root as a child (distance 1, self-parent). Root detection must
+        use the string form.
+        """
+        with patch("src.scoring_data_provider.scoring_data_provider.psycopg.connect") as mock_connect:
+            mock_conn = MagicMock()
+            mock_cursor = MagicMock()
+            mock_connect.return_value.__enter__.return_value = mock_conn
+            mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+            child_id = uuid.uuid4()
+            mock_cursor.fetchall.side_effect = [
+                # spaces query — ids come back as uuid.UUID objects (production behavior)
+                [(uuid.UUID(ROOT_SPACE_ID),), (child_id,)],
+                # topology distances query — empty (indexer hasn't run)
+                [],
+            ]
+
+            provider = ScoringDataProvider("postgresql://test:test@localhost/test")
+            spaces = provider._fetch_spaces(mock_conn)
+
+            root = next(s for s in spaces if s.id == ROOT_SPACE_ID)
+            assert root.parent_space_id is None
+            assert root.distance_to_root == 0
+            assert str(child_id) in root.subspace_ids
+            assert ROOT_SPACE_ID not in root.subspace_ids
+
+            child = next(s for s in spaces if s.id == str(child_id))
             assert child.parent_space_id == ROOT_SPACE_ID
             assert child.distance_to_root == 1
 


### PR DESCRIPTION
> **Stacked on #245** — base is `scoring-perf-tallies`. Review/merge #245 first; GitHub will auto-retarget this to `dev` once it lands.

## What

`distance_to_root` is computed upstream by the topology indexer (`atlas`) and read from the `scoring_topology_distances` table. The in-model BFS (`_calculate_distance_to_root`) was a parallel, legacy way to derive connectivity from `parent_space_id` chains — it no longer runs in production (the data provider always sets `distance_to_root`) and could diverge from the indexer.

This removes it and makes the scoring model a pure consumer of pre-computed distances.

- **Invariant:** a space with no topology entry is not connected to the root and is scored as disconnected.
- `calculate_space_score` now treats `distance_to_root is None` as `DISCONNECTED_SPACE_DEPTH`; the dead `>= 0 / else` branch is dropped (distances are never negative).
- Deleted `_calculate_distance_to_root` and the now-unused `MAX_SPACE_DEPTH` constant.
- `_build_spaces_flat` sets `distance_to_root` explicitly (`0` for root, `1` for every other space) so the "indexer hasn't run yet" fallback still yields distance-1 scores and the model never derives distances itself.

## Notes

- `Space.parent_space_id` and `utils.calculate_space_distances` are left untouched — only used by the `use_distance_weighting` path (off by default, mutually exclusive with `filter_non_members`).
- `spaces` / `root_space_id` params on `calculate_space_score` are now unused (kept to avoid re-touching the call sites from #245); can be stripped in a follow-up.
- Tests: flat-fallback explicit-distance assertions + `None` distance defaults to disconnected.

Part of GEO-709.
