### PR TITLE
chore(scoring): lower cronjob resource requests/limits

### DIFF
--- a/scoring-service/deployment/production/cronjob.yaml
+++ b/scoring-service/deployment/production/cronjob.yaml
@@ -87,8 +87,8 @@ spec:
                       optional: true
               resources:
                 requests:
+                  memory: "1280Mi"
+                  cpu: "500m"
+                limits:
                   memory: "2048Mi"
                   cpu: "1000m"
-                limits:
-                  memory: "4096Mi"
-                  cpu: "2000m"

--- a/scoring-service/deployment/staging/cronjob.yaml
+++ b/scoring-service/deployment/staging/cronjob.yaml
@@ -62,8 +62,8 @@ spec:
                   value: "z_score_sigmoid"
               resources:
                 requests:
+                  memory: "1280Mi"
+                  cpu: "500m"
+                limits:
                   memory: "2048Mi"
                   cpu: "1000m"
-                limits:
-                  memory: "4096Mi"
-                  cpu: "2000m"


### PR DESCRIPTION
## What

Lowers the scoring cronjob's Kubernetes resource requests/limits so it schedules reliably under current cluster capacity, and brings the manifests in line with the values already patched live (so the next deploy doesn't revert them).

| | before | after |
|---|---|---|
| requests | `2048Mi` / `1000m` | `1280Mi` / `500m` |
| limits | `4096Mi` / `2000m` | `2048Mi` / `1000m` |

Applied identically to both `production` and `staging` manifests.

## Notes

- Pairs with the `rank_spaces` performance work on this branch — the lighter footprint is viable now that space scoring is no longer doing the quadratic per-space scans.

Part of GEO-709.
