### PR TITLE
feat(proposal-executor): add Books space to production membership auto-accept allowlist

### DIFF
--- a/proposal-executor/deployment/production/cronjob.yaml
+++ b/proposal-executor/deployment/production/cronjob.yaml
@@ -76,7 +76,7 @@ spec:
                 # Allowlisted DAO spaces for auto-accept (comma-separated bytes16).
                 # Empty string = kill switch: no detection, no votes.
                 - name: MEMBERSHIP_AUTOACCEPT_SPACE_IDS
-                  value: "0xc9f267dcb0d270718c2a3c45a64afd32,0x84a679ce188f061ac9a92380bac2bab5"
+                  value: "0xc9f267dcb0d270718c2a3c45a64afd32,0x84a679ce188f061ac9a92380bac2bab5,0x0477636ace64280fc43a9f440a502291"
                 - name: SPACE_REGISTRY_ADDRESS
                   value: "0xB01683b2f0d38d43fcD4D9aAB980166988924132"
                 - name: RPC_URL


### PR DESCRIPTION
Appends the Books DAO space (`0x0477636ace64280fc43a9f440a502291`) to `MEMBERSHIP_AUTOACCEPT_SPACE_IDS` in the production CronJob, so the membership bot auto-upvotes request-to-join proposals there. Allowlist goes from 2 → 3 spaces.

Note: this manifest only deploys to production on merge to `main`. For immediate effect the live CronJob has been patched directly via `kubectl`; this PR keeps git in sync so the next prod deploy doesn't revert it.
