### PR TITLE
feat(membership-acceptor): webhook receiver service (connectivity)

### DIFF
--- a/membership-acceptor/.env.example
+++ b/membership-acceptor/.env.example
@@ -1,0 +1,22 @@
+# Membership Acceptor — Environment Variables
+# Copy to .env and fill in values.
+
+# === Required ===
+
+# Shared secret for verifying the X-Geo-Signature HMAC on incoming webhooks.
+# MUST equal the `secret` column of this service's row in the notification
+# service's `app_webhooks` table, or every delivery fails verification.
+# Generate with: openssl rand -hex 32
+GEO_WEBHOOK_SECRET=
+
+# === Optional ===
+
+# Port the HTTP server listens on (default: 8080)
+# PORT=8080
+
+# Sentry error reporting DSN (telemetry is console-only when unset)
+# SENTRY_DSN=https://...@sentry.io/...
+# SENTRY_ENVIRONMENT=production
+# SENTRY_RELEASE=
+# SENTRY_TRACES_SAMPLE_RATE=1.0
+# SENTRY_DEBUG=false

--- a/membership-acceptor/.gitignore
+++ b/membership-acceptor/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+*.log

--- a/membership-acceptor/.gitignore
+++ b/membership-acceptor/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 .env
+.env.*
+!.env.example
 *.log

--- a/membership-acceptor/.npmrc
+++ b/membership-acceptor/.npmrc
@@ -1,0 +1,2 @@
+# Fallback for users who accidentally run `npm install` instead of `bun install`
+min-release-age=14d

--- a/membership-acceptor/Dockerfile
+++ b/membership-acceptor/Dockerfile
@@ -1,0 +1,16 @@
+FROM oven/bun:1.3.9 AS builder
+WORKDIR /app
+COPY package.json bun.lock* ./
+RUN bun install --frozen-lockfile
+COPY . .
+
+FROM oven/bun:1.3.9
+ENV NODE_ENV=production
+RUN groupadd --system --gid 1001 geo && useradd --system --uid 1001 --gid geo geo
+WORKDIR /app
+COPY --from=builder --chown=geo:geo /app/package.json /app/bun.lock* ./
+RUN bun install --frozen-lockfile --production
+COPY --from=builder --chown=geo:geo /app/src ./src
+USER geo
+EXPOSE 8080
+CMD ["bun", "run", "src/index.ts"]

--- a/membership-acceptor/README.md
+++ b/membership-acceptor/README.md
@@ -1,0 +1,88 @@
+# membership-acceptor
+
+Real-time membership auto-accept for Geo spaces.
+
+This is the event-driven successor to the `proposal-executor` cron's
+membership-accept path. Instead of polling every 5 minutes, it receives
+notification **webhooks** from the Geo notification service and reacts in
+near real time.
+
+```
+on-chain PROPOSAL_CREATED
+  → hermes-pipeline → Kafka space.governance
+  → notification-indexer → delivery-worker → HMAC-signed webhook
+  → membership-acceptor  ← this service
+```
+
+It is structured so it can later be extracted into its own repo that space
+admins deploy themselves, each running a sovereign acceptor with its own wallet
+and membership policy (allow-all, allow-verified, reputation, payment, …).
+
+## Status — Milestone 1 (webhook connectivity)
+
+This milestone proves the pipe end to end. The service:
+
+- exposes `POST /webhooks/geo` and verifies the `X-Geo-Signature` HMAC-SHA256
+  header against `GEO_WEBHOOK_SECRET` (rejects unsigned/tampered requests with 401);
+- exposes `GET /health` for k8s probes;
+- logs a structured summary of every delivery it receives.
+
+It does **not** yet detect membership requests (M2) or cast votes (M3). Every
+authenticated webhook is acknowledged with `200`.
+
+> Implementation note: unlike `proposal-executor` (an Effect-TS CronJob), this is
+> a plain `Bun.serve` HTTP server. The request path is straightforward async
+> code; we keep the same Sentry/structured-logging conventions (see
+> `src/telemetry.ts`) so logs read consistently across the two services.
+
+## Layout
+
+| Path | Purpose |
+|---|---|
+| `src/index.ts` | Entry point — parse config, start server, graceful shutdown |
+| `src/server.ts` | Routes + request handling (`createApp` returns a testable fetch handler) |
+| `src/signature.ts` | `X-Geo-Signature` HMAC verification |
+| `src/config.ts` | Env parsing + validation (fail-fast) |
+| `src/telemetry.ts` | Sentry init + structured logger + flush |
+| `deployment/production/` | k8s `Deployment` + `Service` + secret template |
+
+## Develop
+
+```bash
+bun install
+bun test          # unit tests
+bun run typecheck # tsc --noEmit
+bun run lint      # biome
+GEO_WEBHOOK_SECRET=dev-secret bun run start   # serves on :8080
+```
+
+Smoke test locally:
+
+```bash
+SECRET=dev-secret
+BODY='{"event_type":"proposal_created","category":"governance"}'
+SIG="sha256=$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "$SECRET" | awk '{print $2}')"
+curl -s -XPOST localhost:8080/webhooks/geo \
+  -H "content-type: application/json" -H "x-geo-signature: $SIG" -d "$BODY"
+# → {"status":"ok"}
+```
+
+## Registering the webhook
+
+The service receives deliveries only after a row is added to the notification
+service's `app_webhooks` table pointing at it, with a `secret` equal to this
+service's `GEO_WEBHOOK_SECRET`. See
+`notification-service/WEBHOOK_INTEGRATION.md`. In-cluster URL:
+
+```
+http://membership-acceptor.<namespace>.svc.cluster.local/webhooks/geo
+```
+
+## Configuration
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `GEO_WEBHOOK_SECRET` | yes | — | Shared secret; must equal `app_webhooks.secret` |
+| `PORT` | no | `8080` | HTTP listen port |
+| `SENTRY_DSN` | no | — | Enables Sentry; console-only when unset |
+| `SENTRY_ENVIRONMENT` / `SENTRY_RELEASE` / `SENTRY_TRACES_SAMPLE_RATE` / `SENTRY_DEBUG` | no | — | Sentry tuning |

--- a/membership-acceptor/biome.json
+++ b/membership-acceptor/biome.json
@@ -1,0 +1,41 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true,
+			"suspicious": {
+				"noArrayIndexKey": "off",
+				"noExplicitAny": "warn"
+			},
+			"complexity": {
+				"noStaticOnlyClass": "off",
+				"noBannedTypes": "off",
+				"noForEach": "off",
+				"useLiteralKeys": "off"
+			},
+			"style": {
+				"useTemplate": "off"
+			}
+		}
+	},
+	"formatter": {
+		"enabled": true,
+		"formatWithErrors": false,
+		"indentStyle": "tab",
+		"indentWidth": 4,
+		"lineWidth": 120
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double",
+			"quoteProperties": "asNeeded",
+			"semicolons": "asNeeded",
+			"bracketSpacing": false,
+			"trailingCommas": "all"
+		}
+	},
+	"files": {
+		"includes": ["./**/*"]
+	}
+}

--- a/membership-acceptor/bun.lock
+++ b/membership-acceptor/bun.lock
@@ -1,0 +1,114 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "membership-acceptor",
+      "dependencies": {
+        "@sentry/node": "^10.36.0",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^2.3.11",
+        "@types/bun": "latest",
+        "typescript": "^5.9.3",
+      },
+    },
+  },
+  "packages": {
+    "@apm-js-collab/code-transformer": ["@apm-js-collab/code-transformer@0.15.0", "", { "dependencies": { "@types/estree": "^1.0.8", "astring": "^1.9.0", "esquery": "^1.7.0", "meriyah": "^6.1.4", "semifies": "^1.0.0", "source-map": "^0.6.0" }, "bin": { "code-transformer": "cli.js" } }, "sha512-XmXYVs8CzJ1Aj79noVbn2weUO/XWtRyURpGqx7aU7DOXlUQhR0WKOQNF0okh7PCeY37vxf7kU3v57OAkEPm3ww=="],
+
+    "@apm-js-collab/code-transformer-bundler-plugins": ["@apm-js-collab/code-transformer-bundler-plugins@0.5.0", "", { "dependencies": { "@apm-js-collab/code-transformer": "^0.15.0", "es-module-lexer": "^2.1.0", "magic-string": "^0.30.21", "module-details-from-path": "^1.0.4" } }, "sha512-YxLBY5nGlurL7QeJLq6e5g0ouBpAp0pwgyA/5rHXEXwhiPLn9ZHbT+Y2LlP90GT872cSocfjWRYu/fnpuBudNQ=="],
+
+    "@apm-js-collab/tracing-hooks": ["@apm-js-collab/tracing-hooks@0.10.0", "", { "dependencies": { "@apm-js-collab/code-transformer": "^0.15.0", "debug": "^4.4.1", "module-details-from-path": "^1.0.4" } }, "sha512-2/Z3NTewJTruUkmsSnBC5bJlLNUd9keuD1OLlTEpim4FyLhm6m2Rnfv+wrFdUvFfhmH8CRdiDZBqBrn+wyaGuA=="],
+
+    "@biomejs/biome": ["@biomejs/biome@2.5.1", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.1", "@biomejs/cli-darwin-x64": "2.5.1", "@biomejs/cli-linux-arm64": "2.5.1", "@biomejs/cli-linux-arm64-musl": "2.5.1", "@biomejs/cli-linux-x64": "2.5.1", "@biomejs/cli-linux-x64-musl": "2.5.1", "@biomejs/cli-win32-arm64": "2.5.1", "@biomejs/cli-win32-x64": "2.5.1" }, "bin": { "biome": "bin/biome" } }, "sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-npqDzvqv7vFaWRiNN1Te71siRgPaqS9MpqgYCdP/CrUbkJ7ApezaeaKjueKHRN/JH/6lRjJQAHi8acQDCAz22w=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-RgwTqPAM8g2tn1j+b5oRjF/DbSBX8a4gwojtuG9XuhfK7GgomvZ9+T+tqjXiVbjLEeGJOoL6VEk8mvRTVeSybw=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yhV35CzZh38VyMvTEXi3JTjxZBs++oCKK9KG8vB6VI5+uvQvZNR3BFWEKKzuOmx9DJJj7sQpZ4LQJcmbGTs3+Q=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-WMcvMLgByyTqVxGlq918NBBYliq9FRR9GAQVETHb+VjGVqXCZFfHlZHC1FX4ibuYY/Hg6TJE3rHU0xVrdJXNRw=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.1", "", { "os": "linux", "cpu": "x64" }, "sha512-J/7uHSX7NfoYDI7HijAkd8lnQIOrRb2W7j3X+tw4R+N5ExvXGsyXFiGdQcfcxfOmNQmZVSQOCDk757fwpzqQcg=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.1", "", { "os": "linux", "cpu": "x64" }, "sha512-ANTowtlLmPYm5yeMckWY8Xzb9Ix+JJP3tgHR/n6xRj1VWyIzzWtfRfih9hv9VmClwadpBvZduISZIbBsIlYG3A=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-zgXnKNgWPC4iPF7Y1lR3STUeCUuZRpD6IiOrC7TZTlh0Lx6FiVUT05myuMQHQ9D+1cc7uyMldi4forE6lp0ivQ=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.1", "", { "os": "win32", "cpu": "x64" }, "sha512-6uxpR9hvaglANkZemeSiN/FhYgkGasrEGn267eXIWvjrjJ2LhDlk251IhjVJq6MXzkV2/bcXwLwSroLyPtqRZg=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
+
+    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.214.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA=="],
+
+    "@opentelemetry/core": ["@opentelemetry/core@2.8.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww=="],
+
+    "@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.214.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.214.0", "import-in-the-middle": "^3.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w=="],
+
+    "@opentelemetry/resources": ["@opentelemetry/resources@2.8.0", "", { "dependencies": { "@opentelemetry/core": "2.8.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg=="],
+
+    "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.8.0", "", { "dependencies": { "@opentelemetry/core": "2.8.0", "@opentelemetry/resources": "2.8.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
+
+    "@sentry/conventions": ["@sentry/conventions@0.12.0", "", {}, "sha512-z1JQrl/1SLY+8wpzvork6vl+fpsg/oCCxM7HWWhUnI/R+OGNyoIzieQuggX3uUMY7NBtp8UWCQx6FeFazzOF9g=="],
+
+    "@sentry/core": ["@sentry/core@10.60.0", "", {}, "sha512-szN7ccOJAEaLb1BBQzCQhABGMTJmKNUk0G2sc7rWhajeXoZoMKIbNkI9RvJrFuV69cbad/d/BKGBjbpJhySAzw=="],
+
+    "@sentry/node": ["@sentry/node@10.60.0", "", { "dependencies": { "@opentelemetry/api": "^1.9.1", "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/sdk-trace-base": "^2.6.1", "@opentelemetry/semantic-conventions": "^1.40.0", "@sentry/core": "10.60.0", "@sentry/node-core": "10.60.0", "@sentry/opentelemetry": "10.60.0", "@sentry/server-utils": "10.60.0", "import-in-the-middle": "^3.0.0" } }, "sha512-u//paUrkKaCr0oNn7r7UulGydkYMSkU1wQOIpG/P/jf7psZWnyXhgeszHzUfZXo6pCdxXG9z9viPvzGjqPQN7A=="],
+
+    "@sentry/node-core": ["@sentry/node-core@10.60.0", "", { "dependencies": { "@sentry/conventions": "^0.12.0", "@sentry/core": "10.60.0", "@sentry/opentelemetry": "10.60.0", "import-in-the-middle": "^3.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1", "@opentelemetry/instrumentation": ">=0.57.1 <1", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0" }, "optionalPeers": ["@opentelemetry/api", "@opentelemetry/core", "@opentelemetry/exporter-trace-otlp-http", "@opentelemetry/instrumentation", "@opentelemetry/sdk-trace-base"] }, "sha512-aXi9ixvP+hgUZPPZCRwMNHgY2I0gkSeoAKAUuysDJhWDmrygwfGdlkbGmmtW6PQjtMYFx69Igt5btvhjEBoJTw=="],
+
+    "@sentry/opentelemetry": ["@sentry/opentelemetry@10.60.0", "", { "dependencies": { "@sentry/conventions": "^0.12.0", "@sentry/core": "10.60.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0" } }, "sha512-gl+2NVH+9RmTu7pd9kV1tKif+Th+p9tmnXR1l3Sb3Wqo1ir5FaNMKrloWEKMXjnepii9EJUrEHdSC+i8NoexxQ=="],
+
+    "@sentry/server-utils": ["@sentry/server-utils@10.60.0", "", { "dependencies": { "@apm-js-collab/code-transformer": "^0.15.0", "@apm-js-collab/code-transformer-bundler-plugins": "^0.5.0", "@apm-js-collab/tracing-hooks": "^0.10.0", "@sentry/conventions": "^0.12.0", "@sentry/core": "10.60.0", "magic-string": "~0.30.0" } }, "sha512-SX+MzWM3nz5ttKT48rlfktm0ERyIpDLma+b6pYeWgW2oFHKcpIu0g0qMGJrZs4lKM3MlgV7IqLa4texMqTp9kQ=="],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/node": ["@types/node@26.0.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw=="],
+
+    "acorn": ["acorn@8.17.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg=="],
+
+    "acorn-import-attributes": ["acorn-import-attributes@1.9.5", "", { "peerDependencies": { "acorn": "^8" } }, "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="],
+
+    "astring": ["astring@1.9.0", "", { "bin": { "astring": "bin/astring" } }, "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "es-module-lexer": ["es-module-lexer@2.1.0", "", {}, "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="],
+
+    "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "import-in-the-middle": ["import-in-the-middle@3.2.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-vR2B6HKIhaBjcZr2bLpFiJ1VbzOlRQ7aby4/gw5WPIzToLjqpfWw3VJ4sk1uDchoOODEirvO2jyrSPtUSL5CrQ=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "meriyah": ["meriyah@6.1.4", "", {}, "sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ=="],
+
+    "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "require-in-the-middle": ["require-in-the-middle@8.0.1", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3" } }, "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ=="],
+
+    "semifies": ["semifies@1.0.0", "", {}, "sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw=="],
+
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+  }
+}

--- a/membership-acceptor/deployment/production/deployment.yaml
+++ b/membership-acceptor/deployment/production/deployment.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: membership-acceptor
+  namespace: knowledge
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: membership-acceptor
+  template:
+    metadata:
+      labels:
+        app: membership-acceptor
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+      imagePullSecrets:
+        - name: geo
+      containers:
+        - name: membership-acceptor
+          image: registry.digitalocean.com/geo/membership-acceptor:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: PORT
+              value: "8080"
+            # Shared secret — MUST equal this service's app_webhooks.secret
+            - name: GEO_WEBHOOK_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: membership-acceptor-credentials
+                  key: GEO_WEBHOOK_SECRET
+            # Optional: Sentry error reporting
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: membership-acceptor-credentials
+                  key: SENTRY_DSN
+                  optional: true
+            - name: SENTRY_ENVIRONMENT
+              value: "production"
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            failureThreshold: 30
+            periodSeconds: 2
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "250m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: membership-acceptor
+  namespace: knowledge
+spec:
+  selector:
+    app: membership-acceptor
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/membership-acceptor/deployment/production/secrets.yaml.example
+++ b/membership-acceptor/deployment/production/secrets.yaml.example
@@ -1,0 +1,20 @@
+# Template for membership-acceptor production secrets.
+# Real secrets are managed externally — DO NOT commit actual values.
+#
+# The GEO_WEBHOOK_SECRET here MUST match the `secret` of this service's row in
+# the notification service's app_webhooks table (notifications DB).
+#
+# kubectl create secret generic membership-acceptor-credentials \
+#   --namespace=knowledge \
+#   --from-literal=GEO_WEBHOOK_SECRET="$(openssl rand -hex 32)"
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: membership-acceptor-credentials
+  namespace: knowledge
+type: Opaque
+stringData:
+  GEO_WEBHOOK_SECRET: "..."
+  # Optional
+  SENTRY_DSN: "https://...@sentry.io/..."

--- a/membership-acceptor/package.json
+++ b/membership-acceptor/package.json
@@ -1,0 +1,22 @@
+{
+	"name": "membership-acceptor",
+	"version": "0.1.0",
+	"description": "Real-time membership auto-accept — receives notification webhooks and (later) votes to admit members",
+	"type": "module",
+	"private": true,
+	"scripts": {
+		"start": "bun run src/index.ts",
+		"test": "bun test",
+		"lint": "biome check",
+		"lint:fix": "biome check --write",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@sentry/node": "^10.36.0"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.3.11",
+		"@types/bun": "latest",
+		"typescript": "^5.9.3"
+	}
+}

--- a/membership-acceptor/src/config.ts
+++ b/membership-acceptor/src/config.ts
@@ -1,0 +1,47 @@
+/**
+ * Configuration — parsed and validated once at startup.
+ *
+ * Fails fast (throws) on missing/invalid required values so the container
+ * crash-loops loudly rather than silently accepting every (unverifiable) webhook.
+ */
+
+export interface AcceptorConfig {
+	/** Port the HTTP server listens on. */
+	port: number
+	/**
+	 * Shared secret used to verify the `X-Geo-Signature` HMAC on incoming webhooks.
+	 * Must match the `secret` column of this service's `app_webhooks` row.
+	 */
+	webhookSecret: string
+}
+
+export class ConfigError extends Error {
+	override readonly name = "ConfigError"
+}
+
+const DEFAULT_PORT = 8080
+
+/**
+ * Parse config from the given environment (defaults to `process.env`).
+ * Throws {@link ConfigError} with an actionable message on the first problem.
+ */
+export function parseConfig(env: NodeJS.ProcessEnv = process.env): AcceptorConfig {
+	const webhookSecret = env.GEO_WEBHOOK_SECRET?.trim()
+	if (!webhookSecret) {
+		throw new ConfigError(
+			"GEO_WEBHOOK_SECRET is required — it must equal the `secret` of this service's app_webhooks row",
+		)
+	}
+
+	const rawPort = env.PORT?.trim()
+	let port = DEFAULT_PORT
+	if (rawPort) {
+		const parsed = Number(rawPort)
+		if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
+			throw new ConfigError(`Invalid PORT: expected an integer in 1..65535, got "${rawPort}"`)
+		}
+		port = parsed
+	}
+
+	return {port, webhookSecret}
+}

--- a/membership-acceptor/src/index.ts
+++ b/membership-acceptor/src/index.ts
@@ -13,13 +13,16 @@ import {parseConfig} from "./config.js"
 import {createApp} from "./server.js"
 import {flush, log} from "./telemetry.js"
 
-function main() {
+async function main() {
 	let config: ReturnType<typeof parseConfig>
 	try {
 		config = parseConfig()
 	} catch (err) {
 		// Misconfiguration — crash loudly so the deployment is visibly broken.
 		log.error("configuration error — refusing to start", {error: err})
+		// Flush buffered telemetry before exiting, or the startup-failure event is
+		// lost (same reason the graceful-shutdown path flushes before exit).
+		await flush()
 		process.exit(1)
 	}
 

--- a/membership-acceptor/src/index.ts
+++ b/membership-acceptor/src/index.ts
@@ -1,0 +1,54 @@
+/**
+ * Membership Acceptor — entry point.
+ *
+ * A long-running HTTP server that receives notification webhooks from the Geo
+ * notification service. This is the real-time successor to the proposal-executor
+ * cron's membership-accept path.
+ *
+ * Milestone 1 (this file): stand up the server, verify webhook signatures, and
+ * log deliveries. Detection (M2) and on-chain voting (M3) build on top.
+ */
+
+import {parseConfig} from "./config.js"
+import {createApp} from "./server.js"
+import {flush, log} from "./telemetry.js"
+
+function main() {
+	let config: ReturnType<typeof parseConfig>
+	try {
+		config = parseConfig()
+	} catch (err) {
+		// Misconfiguration — crash loudly so the deployment is visibly broken.
+		log.error("configuration error — refusing to start", {error: err})
+		process.exit(1)
+	}
+
+	const app = createApp(config)
+
+	const server = Bun.serve({
+		port: config.port,
+		fetch: app,
+	})
+
+	log.info("membership-acceptor listening", {
+		port: server.port,
+		webhook_path: "/webhooks/geo",
+		health_path: "/health",
+	})
+
+	// Graceful shutdown: stop accepting connections, flush telemetry, then exit.
+	let shuttingDown = false
+	const shutdown = async (signal: string) => {
+		if (shuttingDown) return
+		shuttingDown = true
+		log.info("shutting down", {signal})
+		await server.stop()
+		await flush()
+		process.exit(0)
+	}
+
+	process.on("SIGTERM", () => void shutdown("SIGTERM"))
+	process.on("SIGINT", () => void shutdown("SIGINT"))
+}
+
+main()

--- a/membership-acceptor/src/server.ts
+++ b/membership-acceptor/src/server.ts
@@ -1,0 +1,96 @@
+/**
+ * HTTP app — routes and request handling.
+ *
+ * `createApp` returns a `fetch`-style handler `(Request) => Promise<Response>` so
+ * it can be driven directly in unit tests (no bound port) and handed to
+ * `Bun.serve` in production.
+ *
+ * Milestone 1 scope: prove connectivity. We verify the HMAC signature and log a
+ * structured summary of every delivery. Detection (M2) and voting (M3) are not
+ * here yet — every authenticated webhook is acknowledged with 200.
+ */
+
+import type {AcceptorConfig} from "./config.js"
+import {verifySignature} from "./signature.js"
+import {log} from "./telemetry.js"
+
+const SIGNATURE_HEADER = "x-geo-signature"
+
+/** Best-effort summary of a notification payload, for logging only. */
+function summarize(payload: unknown): Record<string, unknown> {
+	if (!payload || typeof payload !== "object") {
+		return {payload_type: typeof payload}
+	}
+	const p = payload as Record<string, unknown>
+	return {
+		event_type: p.event_type,
+		category: p.category,
+		space_id: p.space_id,
+		proposal_id: p.proposal_id,
+		idempotency_key: p.idempotency_key,
+	}
+}
+
+function json(body: unknown, status: number): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: {"content-type": "application/json"},
+	})
+}
+
+async function handleWebhook(req: Request, config: AcceptorConfig): Promise<Response> {
+	const signature = req.headers.get(SIGNATURE_HEADER)
+	// Read the raw bytes — the HMAC is over exactly what was sent, so we must not
+	// round-trip through JSON before verifying.
+	const body = new Uint8Array(await req.arrayBuffer())
+
+	if (!verifySignature(body, config.webhookSecret, signature)) {
+		log.warn("webhook signature verification failed", {
+			has_signature: signature !== null,
+			body_bytes: body.length,
+		})
+		return json({error: "invalid signature"}, 401)
+	}
+
+	let payload: unknown
+	try {
+		payload = JSON.parse(Buffer.from(body).toString("utf8"))
+	} catch {
+		log.warn("webhook body is not valid JSON", {body_bytes: body.length})
+		return json({error: "invalid JSON body"}, 400)
+	}
+
+	// M1: just observe. M2 will filter to membership requests; M3 will vote.
+	log.info("webhook received", summarize(payload))
+	return json({status: "ok"}, 200)
+}
+
+/**
+ * Build the request handler for the given config.
+ *
+ * Routes:
+ *  - `GET /health`        — liveness/readiness probe
+ *  - `POST /webhooks/geo` — notification webhook sink (HMAC-verified)
+ */
+export function createApp(config: AcceptorConfig): (req: Request) => Promise<Response> {
+	return async (req: Request): Promise<Response> => {
+		const {pathname} = new URL(req.url)
+
+		if (req.method === "GET" && pathname === "/health") {
+			return json({status: "ok"}, 200)
+		}
+
+		if (req.method === "POST" && pathname === "/webhooks/geo") {
+			try {
+				return await handleWebhook(req, config)
+			} catch (err) {
+				// Unexpected failure — 500 makes the delivery-worker retry rather than
+				// silently dropping the event.
+				log.error("unhandled error processing webhook", {error: err})
+				return json({error: "internal error"}, 500)
+			}
+		}
+
+		return json({error: "not found"}, 404)
+	}
+}

--- a/membership-acceptor/src/server.ts
+++ b/membership-acceptor/src/server.ts
@@ -15,6 +15,12 @@ import {verifySignature} from "./signature.js"
 import {log} from "./telemetry.js"
 
 const SIGNATURE_HEADER = "x-geo-signature"
+const SIGNATURE_PREFIX = "sha256="
+
+// Cap how much we're willing to buffer per webhook. Notification payloads are a
+// few KB at most, so 1 MiB is generous while still preventing an unauthenticated
+// (or malicious) client from forcing large in-memory allocations.
+const MAX_BODY_BYTES = 1_048_576
 
 /** Best-effort summary of a notification payload, for logging only. */
 function summarize(payload: unknown): Record<string, unknown> {
@@ -40,9 +46,36 @@ function json(body: unknown, status: number): Response {
 
 async function handleWebhook(req: Request, config: AcceptorConfig): Promise<Response> {
 	const signature = req.headers.get(SIGNATURE_HEADER)
+
+	// Cheap reject BEFORE buffering the body: a missing or malformed signature
+	// header can never pass the HMAC check, so don't let unauthenticated clients
+	// force us to allocate/CPU on `arrayBuffer()`. The full HMAC verification still
+	// runs below (defense in depth).
+	if (signature === null || !signature.startsWith(SIGNATURE_PREFIX)) {
+		log.warn("webhook signature verification failed", {
+			has_signature: signature !== null,
+		})
+		return json({error: "invalid signature"}, 401)
+	}
+
+	// Reject oversized requests before buffering, when the client advertises a
+	// Content-Length we can trust to be too large.
+	const contentLength = Number(req.headers.get("content-length"))
+	if (Number.isFinite(contentLength) && contentLength > MAX_BODY_BYTES) {
+		log.warn("webhook body exceeds size limit", {content_length: contentLength})
+		return json({error: "payload too large"}, 413)
+	}
+
 	// Read the raw bytes — the HMAC is over exactly what was sent, so we must not
 	// round-trip through JSON before verifying.
 	const body = new Uint8Array(await req.arrayBuffer())
+
+	// Guard again post-read: Content-Length may have been absent or understated
+	// (e.g. chunked transfer). Reject before any HMAC/JSON work.
+	if (body.length > MAX_BODY_BYTES) {
+		log.warn("webhook body exceeds size limit", {body_bytes: body.length})
+		return json({error: "payload too large"}, 413)
+	}
 
 	if (!verifySignature(body, config.webhookSecret, signature)) {
 		log.warn("webhook signature verification failed", {

--- a/membership-acceptor/src/server.ts
+++ b/membership-acceptor/src/server.ts
@@ -17,11 +17,6 @@ import {log} from "./telemetry.js"
 const SIGNATURE_HEADER = "x-geo-signature"
 const SIGNATURE_PREFIX = "sha256="
 
-// Cap how much we're willing to buffer per webhook. Notification payloads are a
-// few KB at most, so 1 MiB is generous while still preventing an unauthenticated
-// (or malicious) client from forcing large in-memory allocations.
-const MAX_BODY_BYTES = 1_048_576
-
 /** Best-effort summary of a notification payload, for logging only. */
 function summarize(payload: unknown): Record<string, unknown> {
 	if (!payload || typeof payload !== "object") {
@@ -47,10 +42,8 @@ function json(body: unknown, status: number): Response {
 async function handleWebhook(req: Request, config: AcceptorConfig): Promise<Response> {
 	const signature = req.headers.get(SIGNATURE_HEADER)
 
-	// Cheap reject BEFORE buffering the body: a missing or malformed signature
-	// header can never pass the HMAC check, so don't let unauthenticated clients
-	// force us to allocate/CPU on `arrayBuffer()`. The full HMAC verification still
-	// runs below (defense in depth).
+	// A missing or malformed signature header can never pass the HMAC check, so
+	// reject it up front. The full HMAC verification still runs below.
 	if (signature === null || !signature.startsWith(SIGNATURE_PREFIX)) {
 		log.warn("webhook signature verification failed", {
 			has_signature: signature !== null,
@@ -58,24 +51,9 @@ async function handleWebhook(req: Request, config: AcceptorConfig): Promise<Resp
 		return json({error: "invalid signature"}, 401)
 	}
 
-	// Reject oversized requests before buffering, when the client advertises a
-	// Content-Length we can trust to be too large.
-	const contentLength = Number(req.headers.get("content-length"))
-	if (Number.isFinite(contentLength) && contentLength > MAX_BODY_BYTES) {
-		log.warn("webhook body exceeds size limit", {content_length: contentLength})
-		return json({error: "payload too large"}, 413)
-	}
-
 	// Read the raw bytes — the HMAC is over exactly what was sent, so we must not
 	// round-trip through JSON before verifying.
 	const body = new Uint8Array(await req.arrayBuffer())
-
-	// Guard again post-read: Content-Length may have been absent or understated
-	// (e.g. chunked transfer). Reject before any HMAC/JSON work.
-	if (body.length > MAX_BODY_BYTES) {
-		log.warn("webhook body exceeds size limit", {body_bytes: body.length})
-		return json({error: "payload too large"}, 413)
-	}
 
 	if (!verifySignature(body, config.webhookSecret, signature)) {
 		log.warn("webhook signature verification failed", {

--- a/membership-acceptor/src/signature.ts
+++ b/membership-acceptor/src/signature.ts
@@ -1,0 +1,35 @@
+/**
+ * Webhook signature verification.
+ *
+ * The notification delivery-worker signs every request with
+ * `X-Geo-Signature: sha256=<hex>`, where `<hex>` is the HMAC-SHA256 of the raw
+ * request body keyed by the shared secret. See notification-service/WEBHOOK_INTEGRATION.md.
+ */
+
+import {createHmac, timingSafeEqual} from "node:crypto"
+
+const PREFIX = "sha256="
+
+/**
+ * Verify the `X-Geo-Signature` header against the raw request body.
+ *
+ * @param body - the raw request body bytes (NOT re-serialized JSON — the HMAC is
+ *   computed over the exact bytes the worker sent)
+ * @param secret - the shared secret for this webhook
+ * @param signatureHeader - the value of the `X-Geo-Signature` header (may be null)
+ * @returns true iff the header is present, well-formed, and matches
+ */
+export function verifySignature(body: Uint8Array, secret: string, signatureHeader: string | null): boolean {
+	if (!signatureHeader?.startsWith(PREFIX)) {
+		return false
+	}
+
+	const received = signatureHeader.slice(PREFIX.length)
+	const expected = createHmac("sha256", secret).update(body).digest("hex")
+
+	// Length check first: timingSafeEqual throws if the buffers differ in length.
+	if (received.length !== expected.length) {
+		return false
+	}
+	return timingSafeEqual(Buffer.from(received), Buffer.from(expected))
+}

--- a/membership-acceptor/src/signature.ts
+++ b/membership-acceptor/src/signature.ts
@@ -27,9 +27,14 @@ export function verifySignature(body: Uint8Array, secret: string, signatureHeade
 	const received = signatureHeader.slice(PREFIX.length)
 	const expected = createHmac("sha256", secret).update(body).digest("hex")
 
-	// Length check first: timingSafeEqual throws if the buffers differ in length.
-	if (received.length !== expected.length) {
+	// Compare BYTE lengths, not char lengths: timingSafeEqual throws on unequal
+	// buffer lengths, and malformed non-ASCII input can encode to a different byte
+	// length than its char length suggests. Build the buffers first, then bail out
+	// early if their byte lengths differ so we never hand mismatched buffers in.
+	const receivedBuf = Buffer.from(received)
+	const expectedBuf = Buffer.from(expected)
+	if (receivedBuf.length !== expectedBuf.length) {
 		return false
 	}
-	return timingSafeEqual(Buffer.from(received), Buffer.from(expected))
+	return timingSafeEqual(receivedBuf, expectedBuf)
 }

--- a/membership-acceptor/src/telemetry.ts
+++ b/membership-acceptor/src/telemetry.ts
@@ -1,0 +1,116 @@
+/**
+ * Telemetry — Sentry error tracking + structured console logging.
+ *
+ * Adapted from proposal-executor/src/telemetry.ts, but without the Effect-TS
+ * runtime: membership-acceptor is a long-running HTTP server, so the request
+ * path is plain async code rather than Effect fibers. We keep the same
+ * observability conventions (console JSON as the primary channel, Sentry as a
+ * supplementary one) so logs read the same across the two services.
+ *
+ * - console is the primary channel (kubectl logs / log aggregators).
+ * - Sentry is supplementary: error/fatal create issues, lower levels become breadcrumbs.
+ * - Falls back to console-only when SENTRY_DSN is not set.
+ */
+
+import * as Sentry from "@sentry/node"
+
+const SERVICE_NAME = "membership-acceptor"
+
+let sentryInitialized = false
+
+// ---------------------------------------------------------------------------
+// Sentry initialization (eager, at module load)
+// ---------------------------------------------------------------------------
+
+function initSentry() {
+	const dsn = process.env.SENTRY_DSN
+
+	if (!dsn) {
+		console.log(JSON.stringify({level: "info", message: "[TELEMETRY] Sentry disabled (SENTRY_DSN not set)"}))
+		return
+	}
+
+	try {
+		const environment = process.env.SENTRY_ENVIRONMENT || "production"
+		const release = process.env.SENTRY_RELEASE
+		const rawRate = Number.parseFloat(process.env.SENTRY_TRACES_SAMPLE_RATE || "1.0")
+		const tracesSampleRate = Number.isNaN(rawRate) || rawRate < 0 || rawRate > 1 ? 1.0 : rawRate
+		const debug = process.env.SENTRY_DEBUG === "true"
+
+		Sentry.init({dsn, environment, release, tracesSampleRate, debug})
+
+		sentryInitialized = true
+		console.log(JSON.stringify({level: "info", message: `[TELEMETRY] Sentry enabled (env: ${environment})`}))
+	} catch (err) {
+		console.error(`[TELEMETRY] Sentry init failed, continuing without Sentry: ${err}`)
+	}
+}
+
+initSentry()
+
+// ---------------------------------------------------------------------------
+// Structured logger — dual-writes console (primary) + Sentry (supplementary)
+// ---------------------------------------------------------------------------
+
+type LogData = Record<string, unknown>
+
+type Level = "debug" | "info" | "warn" | "error"
+
+const SENTRY_LEVEL: Record<Level, Sentry.SeverityLevel> = {
+	debug: "debug",
+	info: "info",
+	warn: "warning",
+	error: "error",
+}
+
+/** Serialize a value for logging — special-cases Error instances. */
+function serializeValue(value: unknown): unknown {
+	if (value instanceof Error) {
+		return {name: value.name, message: value.message, stack: value.stack}
+	}
+	return value
+}
+
+function serializeData(data?: LogData): LogData | undefined {
+	if (!data) return undefined
+	const out: LogData = {}
+	for (const key of Object.keys(data)) {
+		out[key] = serializeValue(data[key])
+	}
+	return out
+}
+
+function emit(level: Level, message: string, data?: LogData): void {
+	const serialized = serializeData(data)
+
+	if (sentryInitialized) {
+		if (level === "error") {
+			Sentry.captureMessage(message, {level: SENTRY_LEVEL[level], extra: serialized})
+		} else {
+			Sentry.addBreadcrumb({message, data: serialized, level: SENTRY_LEVEL[level], category: SERVICE_NAME})
+		}
+	}
+
+	const consoleMethod = level === "warn" ? "warn" : level === "error" ? "error" : "log"
+	console[consoleMethod](JSON.stringify({level, message, ...serialized}))
+}
+
+export const log = {
+	debug: (message: string, data?: LogData) => emit("debug", message, data),
+	info: (message: string, data?: LogData) => emit("info", message, data),
+	warn: (message: string, data?: LogData) => emit("warn", message, data),
+	error: (message: string, data?: LogData) => emit("error", message, data),
+}
+
+// ---------------------------------------------------------------------------
+// Flush — call before process exit so buffered Sentry events are not lost
+// ---------------------------------------------------------------------------
+
+export async function flush(timeoutMs = 5000): Promise<void> {
+	if (!sentryInitialized) return
+	try {
+		await Sentry.flush(timeoutMs)
+	} catch {
+		// best-effort — never block shutdown on telemetry
+	}
+}

--- a/membership-acceptor/tests/config.test.ts
+++ b/membership-acceptor/tests/config.test.ts
@@ -1,0 +1,36 @@
+import {describe, expect, test} from "bun:test"
+
+import {ConfigError, parseConfig} from "../src/config.js"
+
+describe("parseConfig", () => {
+	test("parses a valid environment with default port", () => {
+		const config = parseConfig({GEO_WEBHOOK_SECRET: "s3cr3t"})
+		expect(config).toEqual({port: 8080, webhookSecret: "s3cr3t"})
+	})
+
+	test("honors a valid PORT", () => {
+		const config = parseConfig({GEO_WEBHOOK_SECRET: "s3cr3t", PORT: "3000"})
+		expect(config.port).toBe(3000)
+	})
+
+	test("trims the secret", () => {
+		const config = parseConfig({GEO_WEBHOOK_SECRET: "  s3cr3t  "})
+		expect(config.webhookSecret).toBe("s3cr3t")
+	})
+
+	test("throws when GEO_WEBHOOK_SECRET is missing", () => {
+		expect(() => parseConfig({})).toThrow(ConfigError)
+	})
+
+	test("throws when GEO_WEBHOOK_SECRET is blank", () => {
+		expect(() => parseConfig({GEO_WEBHOOK_SECRET: "   "})).toThrow(ConfigError)
+	})
+
+	test("throws on a non-numeric PORT", () => {
+		expect(() => parseConfig({GEO_WEBHOOK_SECRET: "s", PORT: "abc"})).toThrow(ConfigError)
+	})
+
+	test("throws on an out-of-range PORT", () => {
+		expect(() => parseConfig({GEO_WEBHOOK_SECRET: "s", PORT: "70000"})).toThrow(ConfigError)
+	})
+})

--- a/membership-acceptor/tests/server.test.ts
+++ b/membership-acceptor/tests/server.test.ts
@@ -1,0 +1,78 @@
+import {describe, expect, test} from "bun:test"
+import {createHmac} from "node:crypto"
+
+import type {AcceptorConfig} from "../src/config.js"
+import {createApp} from "../src/server.js"
+
+const config: AcceptorConfig = {port: 8080, webhookSecret: "test-secret-0123456789abcdef"}
+const app = createApp(config)
+
+function sign(body: string, secret = config.webhookSecret): string {
+	return "sha256=" + createHmac("sha256", secret).update(Buffer.from(body)).digest("hex")
+}
+
+function webhookRequest(body: string, signature: string | null): Request {
+	const headers: Record<string, string> = {"content-type": "application/json"}
+	if (signature !== null) headers["x-geo-signature"] = signature
+	return new Request("http://localhost:8080/webhooks/geo", {method: "POST", headers, body})
+}
+
+const SAMPLE = JSON.stringify({
+	version: 1,
+	event_type: "proposal_created",
+	category: "governance",
+	space_id: "d4f5a6b7-0000-0000-0000-000000000000",
+	proposal_id: "c3e4f5a6-0000-0000-0000-000000000000",
+	idempotency_key: "12345:0:proposal_created:b2c3d4e5",
+})
+
+describe("GET /health", () => {
+	test("returns 200 ok", async () => {
+		const res = await app(new Request("http://localhost:8080/health"))
+		expect(res.status).toBe(200)
+		expect(await res.json()).toEqual({status: "ok"})
+	})
+})
+
+describe("POST /webhooks/geo", () => {
+	test("accepts a correctly signed payload", async () => {
+		const res = await app(webhookRequest(SAMPLE, sign(SAMPLE)))
+		expect(res.status).toBe(200)
+		expect(await res.json()).toEqual({status: "ok"})
+	})
+
+	test("rejects an invalid signature with 401", async () => {
+		const res = await app(webhookRequest(SAMPLE, sign(SAMPLE, "wrong-secret")))
+		expect(res.status).toBe(401)
+	})
+
+	test("rejects a missing signature with 401", async () => {
+		const res = await app(webhookRequest(SAMPLE, null))
+		expect(res.status).toBe(401)
+	})
+
+	test("rejects a signed-but-non-JSON body with 400", async () => {
+		const body = "not json"
+		const res = await app(webhookRequest(body, sign(body)))
+		expect(res.status).toBe(400)
+	})
+
+	test("rejects a tampered body with 401 (signature no longer matches)", async () => {
+		const signature = sign(SAMPLE)
+		const tampered = SAMPLE.replace("proposal_created", "proposal_executed")
+		const res = await app(webhookRequest(tampered, signature))
+		expect(res.status).toBe(401)
+	})
+})
+
+describe("unknown routes", () => {
+	test("GET / returns 404", async () => {
+		const res = await app(new Request("http://localhost:8080/"))
+		expect(res.status).toBe(404)
+	})
+
+	test("wrong method on /webhooks/geo returns 404", async () => {
+		const res = await app(new Request("http://localhost:8080/webhooks/geo", {method: "GET"}))
+		expect(res.status).toBe(404)
+	})
+})

--- a/membership-acceptor/tests/signature.test.ts
+++ b/membership-acceptor/tests/signature.test.ts
@@ -1,0 +1,51 @@
+import {describe, expect, test} from "bun:test"
+import {createHmac} from "node:crypto"
+
+import {verifySignature} from "../src/signature.js"
+
+const SECRET = "test-secret-0123456789abcdef"
+
+function sign(body: string, secret = SECRET): string {
+	return "sha256=" + createHmac("sha256", secret).update(Buffer.from(body)).digest("hex")
+}
+
+describe("verifySignature", () => {
+	test("accepts a correctly signed body", () => {
+		const body = JSON.stringify({event_type: "proposal_created"})
+		expect(verifySignature(Buffer.from(body), SECRET, sign(body))).toBe(true)
+	})
+
+	test("rejects a tampered body", () => {
+		const body = JSON.stringify({event_type: "proposal_created"})
+		const signature = sign(body)
+		const tampered = JSON.stringify({event_type: "proposal_executed"})
+		expect(verifySignature(Buffer.from(tampered), SECRET, signature)).toBe(false)
+	})
+
+	test("rejects a signature made with the wrong secret", () => {
+		const body = "payload"
+		expect(verifySignature(Buffer.from(body), SECRET, sign(body, "wrong-secret"))).toBe(false)
+	})
+
+	test("rejects a missing signature header", () => {
+		expect(verifySignature(Buffer.from("payload"), SECRET, null)).toBe(false)
+	})
+
+	test("rejects a header without the sha256= prefix", () => {
+		const raw = createHmac("sha256", SECRET).update(Buffer.from("payload")).digest("hex")
+		expect(verifySignature(Buffer.from("payload"), SECRET, raw)).toBe(false)
+	})
+
+	test("rejects a malformed/short signature without throwing", () => {
+		expect(verifySignature(Buffer.from("payload"), SECRET, "sha256=deadbeef")).toBe(false)
+	})
+
+	test("verifies over raw bytes, not re-serialized JSON (key order preserved)", () => {
+		// Two JSON encodings of the same object with different key order produce
+		// different signatures — the worker signs exact bytes.
+		const sent = '{"b":2,"a":1}'
+		const signature = sign(sent)
+		expect(verifySignature(Buffer.from(sent), SECRET, signature)).toBe(true)
+		expect(verifySignature(Buffer.from('{"a":1,"b":2}'), SECRET, signature)).toBe(false)
+	})
+})

--- a/membership-acceptor/tsconfig.json
+++ b/membership-acceptor/tsconfig.json
@@ -1,0 +1,19 @@
+{
+	"compilerOptions": {
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"target": "ES2022",
+		"verbatimModuleSyntax": true,
+		"resolveJsonModule": true,
+		"moduleDetection": "force",
+		"strict": true,
+		"noUncheckedIndexedAccess": true,
+		"moduleResolution": "Bundler",
+		"module": "ESNext",
+		"noEmit": true,
+		"lib": ["ES2024"],
+		"types": ["bun"]
+	},
+	"include": ["./**/*"],
+	"exclude": ["node_modules"]
+}


### PR DESCRIPTION
## What

Introduces `membership-acceptor`, a long-running HTTP service that receives notification webhooks from the Geo notification service. It is the real-time successor to the `proposal-executor` cron's membership-accept path: instead of polling every 5 minutes, it reacts to delivered governance events in near real time.

This is the **first milestone (connectivity only)** of the membership-acceptor stack. It stands up the service and proves the webhook pipe end to end — it does **not** yet detect membership requests or cast on-chain votes (those land in follow-up PRs on this stack). Every authenticated webhook is acknowledged with `200`.

## Included

- **`POST /webhooks/geo`** — verifies the `X-Geo-Signature` HMAC-SHA256 header against `GEO_WEBHOOK_SECRET` over the raw request body (per `notification-service/WEBHOOK_INTEGRATION.md`). Returns `401` on bad/missing signature, `400` on non-JSON, `200` ack on success.
- **`GET /health`** — liveness/readiness probe.
- **Structured logging** of every delivery; Sentry integration when `SENTRY_DSN` is set, console-only otherwise (mirrors `proposal-executor`'s telemetry conventions).
- **Fail-fast config** parsing (`GEO_WEBHOOK_SECRET` required, `PORT` defaults to 8080) and graceful `SIGTERM`/`SIGINT` shutdown.
- **Production** k8s `Deployment` + `Service` + secret template (namespace `knowledge`).

## Design notes

- **Plain `Bun.serve`, not Effect-TS** (unlike `proposal-executor`). It's a long-running server, so the request path is simpler as plain async; the same Sentry/structured-logging conventions are kept so logs read consistently across the two services.
- **Production-only deployment** — there is no staging chain, and later milestones emit on-chain actions, so a staging environment isn't carried.
- The service receives the **global notification firehose** once registered; filtering to membership requests is a later milestone.

## Testing

- `bun run typecheck` ✓
- `bun run lint` (biome) ✓
- `bun test` — 22 tests ✓ (signature verification, routes, config)
- Manual smoke test against a running server: `/health`, valid/invalid/missing signature, 404, graceful shutdown all behave as expected.

## Follow-ups (not in this PR)

- CI workflow to build/push the image and deploy (mirroring `proposal-executor-deploy.yml`).
- M2: detect membership requests from the payload (filter `proposal_created`, single `add_member` fast proposal, dedupe by `proposal_id`).
- M3: on-chain verify + cast YES vote.
