### PR TITLE
feat(membership-acceptor): detect membership requests (M2)

### DIFF
--- a/membership-acceptor/README.md
+++ b/membership-acceptor/README.md
@@ -18,17 +18,23 @@ It is structured so it can later be extracted into its own repo that space
 admins deploy themselves, each running a sovereign acceptor with its own wallet
 and membership policy (allow-all, allow-verified, reputation, payment, …).
 
-## Status — Milestone 1 (webhook connectivity)
+## Status — Milestone 2 (membership-request detection)
 
-This milestone proves the pipe end to end. The service:
+The service:
 
 - exposes `POST /webhooks/geo` and verifies the `X-Geo-Signature` HMAC-SHA256
   header against `GEO_WEBHOOK_SECRET` (rejects unsigned/tampered requests with 401);
 - exposes `GET /health` for k8s probes;
-- logs a structured summary of every delivery it receives.
+- **detects membership requests** in the firehose — a `proposal_created` event
+  with `voting_mode == "fast"` and exactly one `add_member` action that still
+  looks open — and **de-duplicates** them by `proposal_id` (the fan-out delivers
+  one copy per editor of the space);
+- logs `membership request detected — would accept` for each unique match.
 
-It does **not** yet detect membership requests (M2) or cast votes (M3). Every
-authenticated webhook is acknowledged with `200`.
+It does **not** yet cast votes (M3) — a detected request is logged, and every
+authenticated webhook is acknowledged with `200`. Detection is payload-only and
+best-effort (a trigger, not a source of truth); the authoritative open/untouched
+check happens on-chain in M3 before any vote.
 
 > Implementation note: unlike `proposal-executor` (an Effect-TS CronJob), this is
 > a plain `Bun.serve` HTTP server. The request path is straightforward async
@@ -41,6 +47,7 @@ authenticated webhook is acknowledged with `200`.
 |---|---|
 | `src/index.ts` | Entry point — parse config, start server, graceful shutdown |
 | `src/server.ts` | Routes + request handling (`createApp` returns a testable fetch handler) |
+| `src/detect.ts` | Membership-request detection + `proposal_id` de-duplication |
 | `src/signature.ts` | `X-Geo-Signature` HMAC verification |
 | `src/config.ts` | Env parsing + validation (fail-fast) |
 | `src/telemetry.ts` | Sentry init + structured logger + flush |

--- a/membership-acceptor/src/detect.ts
+++ b/membership-acceptor/src/detect.ts
@@ -1,0 +1,108 @@
+/**
+ * Membership-request detection.
+ *
+ * The acceptor receives the full notification firehose. This module decides
+ * which deliveries are *membership requests* worth acting on, and de-duplicates
+ * the copies the notification fan-out produces.
+ *
+ * Detection is intentionally a cheap, payload-only check — it is a trigger, not
+ * a source of truth. The authoritative "is this still open / untouched" check
+ * happens on-chain in M3 before any vote is cast, because webhook payloads can
+ * be stale or racy.
+ */
+
+/** A delivery that matches the membership-request signature. */
+export interface MembershipRequest {
+	/** Proposal UUID (the dedupe key). */
+	proposalId: string
+	/** DAO space UUID the request is to join. */
+	spaceId: string
+	/**
+	 * Personal-space id of the user requesting membership — i.e. the space being
+	 * added to `spaceId`. Taken from the single `add_member` action's
+	 * `target_address`, which (despite the name) carries the requester's space id
+	 * as a hex-encoded bytes16. Passed through verbatim; M3
+	 * normalizes it as needed for the on-chain check.
+	 */
+	requesterSpaceId: string
+}
+
+// Membership-request signature (see WEBHOOK_INTEGRATION.md / notification-indexer models).
+const MEMBERSHIP_EVENT_TYPE = "proposal_created"
+const FAST_VOTING_MODE = "fast"
+const ADD_MEMBER_ACTION = "add_member"
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+	return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null
+}
+
+/**
+ * Return a {@link MembershipRequest} if `payload` is a fast-mode, single
+ * `add_member` `proposal_created` event that still looks open, else `null`.
+ *
+ * The "still open" check is best-effort from `settings.end_date`; the real
+ * voting-window / untouched check is on-chain in M3.
+ */
+export function detectMembershipRequest(
+	payload: unknown,
+	nowSeconds: number = Math.floor(Date.now() / 1000),
+): MembershipRequest | null {
+	const p = asRecord(payload)
+	if (!p) return null
+
+	if (p.event_type !== MEMBERSHIP_EVENT_TYPE) return null
+	if (p.voting_mode !== FAST_VOTING_MODE) return null
+
+	// Exactly one action, and it must be add_member.
+	if (!Array.isArray(p.actions) || p.actions.length !== 1) return null
+	const action = asRecord(p.actions[0])
+	if (!action || action.type !== ADD_MEMBER_ACTION) return null
+
+	const proposalId = typeof p.proposal_id === "string" ? p.proposal_id : null
+	const spaceId = typeof p.space_id === "string" ? p.space_id : null
+	if (!proposalId || !spaceId) return null
+
+	// Best-effort still-open check: if the payload advertises an end_date already
+	// in the past, the voting window is closed — skip. Authoritative check is M3.
+	const settings = asRecord(p.settings)
+	const endDate = settings?.end_date
+	if (typeof endDate === "number" && endDate <= nowSeconds) return null
+
+	const requesterSpaceId = typeof action.target_address === "string" ? action.target_address : ""
+	return {proposalId, spaceId, requesterSpaceId}
+}
+
+/**
+ * Bounded de-duplication set keyed by proposal id.
+ *
+ * The notification fan-out delivers one copy of `proposal_created` per editor of
+ * the space (distinct `idempotency_key`s, differing `user_space_id`), so the same
+ * proposal arrives N times. We must dedupe on `proposal_id`, NOT `idempotency_key`.
+ *
+ * This is in-memory and best-effort: it is reset on restart, which only means a
+ * proposal could be re-detected (and, in M3, re-checked on-chain — where the
+ * untouched/idempotency guard makes a redundant vote a no-op). It is not a
+ * durability mechanism.
+ */
+export class SeenProposals {
+	private readonly seenIds = new Set<string>()
+	private readonly insertionOrder: string[] = []
+
+	constructor(private readonly capacity = 10_000) {}
+
+	/**
+	 * Record `proposalId` and report whether it had already been seen.
+	 * Returns `true` if this is a duplicate, `false` if it is the first sighting.
+	 */
+	seen(proposalId: string): boolean {
+		if (this.seenIds.has(proposalId)) return true
+
+		this.seenIds.add(proposalId)
+		this.insertionOrder.push(proposalId)
+		if (this.insertionOrder.length > this.capacity) {
+			const evicted = this.insertionOrder.shift()
+			if (evicted !== undefined) this.seenIds.delete(evicted)
+		}
+		return false
+	}
+}

--- a/membership-acceptor/src/server.ts
+++ b/membership-acceptor/src/server.ts
@@ -5,12 +5,14 @@
  * it can be driven directly in unit tests (no bound port) and handed to
  * `Bun.serve` in production.
  *
- * Milestone 1 scope: prove connectivity. We verify the HMAC signature and log a
- * structured summary of every delivery. Detection (M2) and voting (M3) are not
- * here yet — every authenticated webhook is acknowledged with 200.
+ * Milestone 2 scope: verify the HMAC signature, then detect which deliveries are
+ * membership requests and de-duplicate them. Voting (M3) is not here yet — a
+ * detected request is logged as "would accept" and every authenticated webhook
+ * is acknowledged with 200.
  */
 
 import type {AcceptorConfig} from "./config.js"
+import {detectMembershipRequest, SeenProposals} from "./detect.js"
 import {verifySignature} from "./signature.js"
 import {log} from "./telemetry.js"
 
@@ -39,7 +41,7 @@ function json(body: unknown, status: number): Response {
 	})
 }
 
-async function handleWebhook(req: Request, config: AcceptorConfig): Promise<Response> {
+async function handleWebhook(req: Request, config: AcceptorConfig, seen: SeenProposals): Promise<Response> {
 	const signature = req.headers.get(SIGNATURE_HEADER)
 
 	// A missing or malformed signature header can never pass the HMAC check, so
@@ -71,8 +73,30 @@ async function handleWebhook(req: Request, config: AcceptorConfig): Promise<Resp
 		return json({error: "invalid JSON body"}, 400)
 	}
 
-	// M1: just observe. M2 will filter to membership requests; M3 will vote.
-	log.info("webhook received", summarize(payload))
+	// Every authenticated delivery is logged at debug (the firehose is large);
+	// membership requests are surfaced at info below.
+	log.debug("webhook received", summarize(payload))
+
+	const request = detectMembershipRequest(payload)
+	if (!request) {
+		return json({status: "ok"}, 200)
+	}
+
+	// Dedupe on proposal_id: the fan-out delivers one copy per editor.
+	if (seen.seen(request.proposalId)) {
+		log.debug("membership request already seen — deduped", {
+			proposal_id: request.proposalId,
+			space_id: request.spaceId,
+		})
+		return json({status: "ok"}, 200)
+	}
+
+	// M2 ends here: detected, not yet voted. M3 verifies on-chain and casts YES.
+	log.info("membership request detected — would accept", {
+		proposal_id: request.proposalId,
+		space_id: request.spaceId,
+		requester_space_id: request.requesterSpaceId,
+	})
 	return json({status: "ok"}, 200)
 }
 
@@ -84,6 +108,9 @@ async function handleWebhook(req: Request, config: AcceptorConfig): Promise<Resp
  *  - `POST /webhooks/geo` — notification webhook sink (HMAC-verified)
  */
 export function createApp(config: AcceptorConfig): (req: Request) => Promise<Response> {
+	// Dedupe state lives for the lifetime of the process (see SeenProposals).
+	const seen = new SeenProposals()
+
 	return async (req: Request): Promise<Response> => {
 		const {pathname} = new URL(req.url)
 
@@ -93,7 +120,7 @@ export function createApp(config: AcceptorConfig): (req: Request) => Promise<Res
 
 		if (req.method === "POST" && pathname === "/webhooks/geo") {
 			try {
-				return await handleWebhook(req, config)
+				return await handleWebhook(req, config, seen)
 			} catch (err) {
 				// Unexpected failure — 500 makes the delivery-worker retry rather than
 				// silently dropping the event.

--- a/membership-acceptor/tests/detect.test.ts
+++ b/membership-acceptor/tests/detect.test.ts
@@ -1,0 +1,122 @@
+import {describe, expect, test} from "bun:test"
+
+import {detectMembershipRequest, type MembershipRequest, SeenProposals} from "../src/detect.js"
+
+const NOW = 1_700_000_000
+
+/** A canonical fast-mode, single add_member proposal_created payload. */
+function membershipPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+	return {
+		version: 1,
+		event_type: "proposal_created",
+		category: "governance",
+		space_id: "d4f5a6b7-0000-0000-0000-000000000000",
+		proposal_id: "c3e4f5a6-0000-0000-0000-000000000000",
+		voting_mode: "fast",
+		// target_address carries the requester's personal-space id (not an EOA address).
+		actions: [{type: "add_member", target_address: "a1b2c3d4-0000-0000-0000-000000000000"}],
+		settings: {start_date: NOW - 10, end_date: NOW + 86_400, voting_mode: "fast"},
+		...overrides,
+	}
+}
+
+describe("detectMembershipRequest", () => {
+	test("detects a fast single-add_member proposal_created", () => {
+		const req = detectMembershipRequest(membershipPayload(), NOW)
+		expect(req).toEqual({
+			proposalId: "c3e4f5a6-0000-0000-0000-000000000000",
+			spaceId: "d4f5a6b7-0000-0000-0000-000000000000",
+			requesterSpaceId: "a1b2c3d4-0000-0000-0000-000000000000",
+		} satisfies MembershipRequest)
+	})
+
+	test("ignores non proposal_created events", () => {
+		expect(detectMembershipRequest(membershipPayload({event_type: "proposal_voted"}), NOW)).toBeNull()
+	})
+
+	test("ignores slow voting mode", () => {
+		expect(detectMembershipRequest(membershipPayload({voting_mode: "slow"}), NOW)).toBeNull()
+	})
+
+	test("ignores proposals with more than one action", () => {
+		const actions = [
+			{type: "add_member", target_address: "0xaaaa"},
+			{type: "add_editor", target_address: "0xbbbb"},
+		]
+		expect(detectMembershipRequest(membershipPayload({actions}), NOW)).toBeNull()
+	})
+
+	test("ignores a single non-add_member action", () => {
+		const actions = [{type: "add_editor", target_address: "0xbbbb"}]
+		expect(detectMembershipRequest(membershipPayload({actions}), NOW)).toBeNull()
+	})
+
+	test("ignores an empty actions array", () => {
+		expect(detectMembershipRequest(membershipPayload({actions: []}), NOW)).toBeNull()
+	})
+
+	test("ignores a payload missing proposal_id", () => {
+		const p = membershipPayload()
+		delete p.proposal_id
+		expect(detectMembershipRequest(p, NOW)).toBeNull()
+	})
+
+	test("ignores a payload missing space_id", () => {
+		const p = membershipPayload()
+		delete p.space_id
+		expect(detectMembershipRequest(p, NOW)).toBeNull()
+	})
+
+	test("best-effort: ignores a proposal whose end_date is already in the past", () => {
+		expect(detectMembershipRequest(membershipPayload({settings: {end_date: NOW - 1}}), NOW)).toBeNull()
+	})
+
+	test("detects when end_date is in the future", () => {
+		expect(detectMembershipRequest(membershipPayload({settings: {end_date: NOW + 1}}), NOW)).not.toBeNull()
+	})
+
+	test("detects when settings/end_date is absent (no window info to act on)", () => {
+		const p = membershipPayload()
+		delete p.settings
+		expect(detectMembershipRequest(p, NOW)).not.toBeNull()
+	})
+
+	test("requesterSpaceId is empty when target_address is missing", () => {
+		const actions = [{type: "add_member"}]
+		expect(detectMembershipRequest(membershipPayload({actions}), NOW)?.requesterSpaceId).toBe("")
+	})
+
+	test("returns null for non-object payloads", () => {
+		expect(detectMembershipRequest(null, NOW)).toBeNull()
+		expect(detectMembershipRequest("string", NOW)).toBeNull()
+		expect(detectMembershipRequest(42, NOW)).toBeNull()
+		expect(detectMembershipRequest([], NOW)).toBeNull()
+	})
+})
+
+describe("SeenProposals", () => {
+	test("first sighting is not a duplicate; second is", () => {
+		const seen = new SeenProposals()
+		expect(seen.seen("p1")).toBe(false)
+		expect(seen.seen("p1")).toBe(true)
+		expect(seen.seen("p1")).toBe(true)
+	})
+
+	test("tracks distinct ids independently", () => {
+		const seen = new SeenProposals()
+		expect(seen.seen("p1")).toBe(false)
+		expect(seen.seen("p2")).toBe(false)
+		expect(seen.seen("p1")).toBe(true)
+		expect(seen.seen("p2")).toBe(true)
+	})
+
+	test("evicts oldest ids beyond capacity (FIFO)", () => {
+		const seen = new SeenProposals(2)
+		expect(seen.seen("a")).toBe(false) // {a}
+		expect(seen.seen("b")).toBe(false) // {a,b}
+		expect(seen.seen("c")).toBe(false) // len>2 → evict "a" → {b,c}
+		expect(seen.seen("a")).toBe(false) // "a" was evicted → new again; evict "b" → {c,a}
+		expect(seen.seen("c")).toBe(true) // "c" still tracked
+		expect(seen.seen("b")).toBe(false) // "b" was evicted → new again
+	})
+})

--- a/membership-acceptor/tests/server.test.ts
+++ b/membership-acceptor/tests/server.test.ts
@@ -63,6 +63,36 @@ describe("POST /webhooks/geo", () => {
 		const res = await app(webhookRequest(tampered, signature))
 		expect(res.status).toBe(401)
 	})
+
+	test("accepts and acks a membership-request payload (M2 detection path)", async () => {
+		const membership = JSON.stringify({
+			version: 1,
+			event_type: "proposal_created",
+			category: "governance",
+			space_id: "d4f5a6b7-0000-0000-0000-000000000000",
+			proposal_id: "c3e4f5a6-0000-0000-0000-000000000000",
+			voting_mode: "fast",
+			actions: [{type: "add_member", target_address: "0x1234"}],
+		})
+		const res = await app(webhookRequest(membership, sign(membership)))
+		expect(res.status).toBe(200)
+		expect(await res.json()).toEqual({status: "ok"})
+	})
+
+	test("acks a duplicate membership delivery with 200 (deduped, no error)", async () => {
+		const membership = JSON.stringify({
+			event_type: "proposal_created",
+			space_id: "d4f5a6b7-0000-0000-0000-000000000000",
+			proposal_id: "dupe-proposal-id",
+			voting_mode: "fast",
+			actions: [{type: "add_member", target_address: "0x1234"}],
+		})
+		const sig = sign(membership)
+		const first = await app(webhookRequest(membership, sig))
+		const second = await app(webhookRequest(membership, sig))
+		expect(first.status).toBe(200)
+		expect(second.status).toBe(200)
+	})
 })
 
 describe("unknown routes", () => {


### PR DESCRIPTION
## What

Adds membership-request **detection** on top of the M1 connectivity layer. The acceptor receives the full notification firehose; this milestone decides which deliveries are membership requests and de-duplicates them.

This is **milestone 2 of 4** of the membership-acceptor stack. No voting yet — a detected request is logged as `would accept`; M3 verifies on-chain and casts the YES vote. Every authenticated webhook is still acknowledged with `200`.

> Stacked on #254 (M1). Base is `feat/membership-acceptor`; the diff is just the M2 files.

## Detection signature

A delivery is treated as a membership request when it is:

- `event_type == "proposal_created"`
- `voting_mode == "fast"`
- exactly one action, and its `type == "add_member"`
- has `proposal_id` and `space_id`
- still looks open — best-effort from `settings.end_date` (the authoritative voting-window / untouched check is on-chain in M3)

## Included

- **`src/detect.ts`** (new):
  - `detectMembershipRequest(payload, nowSeconds?)` — a pure, payload-only check returning `{ proposalId, spaceId, requesterSpaceId }` or `null`. Every untrusted field access is guarded so a malformed payload can't throw.
  - `SeenProposals` — a bounded FIFO de-dupe keyed on `proposal_id`. The fan-out delivers one copy of `proposal_created` per editor of the space (distinct `idempotency_key`s, differing `user_space_id`), so de-dupe must key on `proposal_id`, **not** `idempotency_key`. In-memory and best-effort (reset on restart → at worst a re-detection; M3's on-chain untouched/idempotency guard makes a redundant vote a no-op).
- **`src/server.ts`** — wires detection in after HMAC verification: generic deliveries log at `debug` (the firehose is large), detected membership requests at `info` (`membership request detected — would accept`). `createApp` owns the `SeenProposals` instance for the process lifetime.

## Notes on field semantics

- The action discriminator in the JSON is **`type`** (not `action_type`) — confirmed against `notification-indexer/src/models.rs` (`#[serde(rename = "type")]`), not just the integration doc.
- `requesterSpaceId` comes from the `add_member` action's `target_address`, which — despite the name — carries the **requester's personal-space id** (hermes' decode of `addMember(bytes16)`) as a hex-encoded bytes16, not an EOA address. It is passed through verbatim; M3 normalizes it for the on-chain check.

## Testing

- `bun run typecheck` ✓
- `bun run lint` (biome) ✓
- `bun test` — 40 tests ✓ (detection signature incl. negatives, best-effort `end_date`, FIFO de-dupe eviction, and the server membership + duplicate-delivery paths)

## Follow-ups (not in this PR)

- M3: on-chain verify (resolve DAO space, read tally/window, confirm untouched) + cast YES via `@geoprotocol/geo-sdk` `daoSpace.voteProposal`.
- Durable de-dupe is deferred to M3, where the on-chain check is the real idempotency guard.
