### PR TITLE
feat(membership-acceptor): on-chain vote + policy seam (M3)

### DIFF
--- a/membership-acceptor/.env.example
+++ b/membership-acceptor/.env.example
@@ -9,7 +9,34 @@
 # Generate with: openssl rand -hex 32
 GEO_WEBHOOK_SECRET=
 
+# Signing key for the Safe smart account that owns the acceptor's personal space
+# (0x-prefixed, 64 hex chars). This account must be an EDITOR of every space in
+# MEMBERSHIP_AUTOACCEPT_SPACE_IDS, or its votes revert.
+ACCEPTOR_PRIVATE_KEY=0x...
+
+# The acceptor's personal-space id (bytes16, 0x + 32 hex chars).
+ACCEPTOR_SPACE_ID=0x...
+
+# SpaceRegistry contract address.
+SPACE_REGISTRY_ADDRESS=0xB01683b2f0d38d43fcD4D9aAB980166988924132
+
+# Chain RPC endpoint (may contain an API key).
+RPC_URL=https://...
+
+# Pimlico bundler/paymaster API key (gas sponsorship).
+PIMLICO_API_KEY=pim_...
+
+# Geo GraphQL endpoint — used by policies (e.g. the editor check).
+GRAPHQL_ENDPOINT=https://...
+
+# DAO space IDs (UUIDs, comma-separated) this acceptor auto-accepts.
+# Empty = accept none (effective kill switch).
+MEMBERSHIP_AUTOACCEPT_SPACE_IDS=
+
 # === Optional ===
+
+# Chain ID: 80451 (mainnet, default) or 19411 (testnet)
+# CHAIN_ID=80451
 
 # Port the HTTP server listens on (default: 8080)
 # PORT=8080

--- a/membership-acceptor/.env.example
+++ b/membership-acceptor/.env.example
@@ -29,8 +29,8 @@ PIMLICO_API_KEY=pim_...
 # Geo GraphQL endpoint — used by policies (e.g. the editor check).
 GRAPHQL_ENDPOINT=https://...
 
-# DAO space IDs (UUIDs, comma-separated) this acceptor auto-accepts.
-# Empty = accept none (effective kill switch).
+# DAO space ids this acceptor auto-accepts: comma-separated, as 0x-prefixed
+# bytes16 hex (dashed UUIDs are also accepted). Empty = accept none (kill switch).
 MEMBERSHIP_AUTOACCEPT_SPACE_IDS=
 
 # === Optional ===

--- a/membership-acceptor/README.md
+++ b/membership-acceptor/README.md
@@ -18,7 +18,7 @@ It is structured so it can later be extracted into its own repo that space
 admins deploy themselves, each running a sovereign acceptor with its own wallet
 and membership policy (allow-all, allow-verified, reputation, payment, …).
 
-## Status — Milestone 2 (membership-request detection)
+## Status — Milestone 3 (on-chain vote)
 
 The service:
 
@@ -26,20 +26,60 @@ The service:
   header against `GEO_WEBHOOK_SECRET` (rejects unsigned/tampered requests with 401);
 - exposes `GET /health` for k8s probes;
 - **detects membership requests** in the firehose — a `proposal_created` event
-  with `voting_mode == "fast"` and exactly one `add_member` action that still
-  looks open — and **de-duplicates** them by `proposal_id` (the fan-out delivers
-  one copy per editor of the space);
-- logs `membership request detected — would accept` for each unique match.
+  with `voting_mode == "fast"` and exactly one `add_member` action — gates them by
+  the `MEMBERSHIP_AUTOACCEPT_SPACE_IDS` allowlist, and **de-duplicates** by
+  `proposal_id` (the fan-out delivers one copy per editor of the space);
+- runs a **policy** (API-backed rules — see below) before voting;
+- **casts the YES vote** for each unique allowed+accepted request via the acceptor's Safe
+  smart account (`SpaceRegistry.enter(PROPOSAL_VOTED, Yes)`, gas-sponsored by
+  Pimlico). Fast-path threshold = 1, so the YES executes the AddMember in the same
+  transaction — admitting the member.
 
-It does **not** yet cast votes (M3) — a detected request is logged, and every
-authenticated webhook is acknowledged with `200`. Detection is payload-only and
-best-effort (a trigger, not a source of truth); the authoritative open/untouched
-check happens on-chain in M3 before any vote.
+### The "simple" model (no on-chain pre-reads)
+
+The contract is the source of truth, so there is **no** read-before-vote. We mark
+the proposal seen, attempt the vote, and classify the result:
+
+| Outcome | HTTP | Behavior |
+|---|---|---|
+| `voted` | `200` | YES landed; member admitted. |
+| `benign` (on-chain revert: already voted/executed/closed, or not an editor) | `200` | Nothing to retry — ack so the delivery-worker stops. |
+| `infra` (RPC/bundler failure) | `503` | Roll back the dedupe mark and signal a retry. |
+
+This eliminates the check-then-act race a read-before-vote design would have: a
+duplicate that slips past in-memory dedupe (restart, 2nd replica) simply reverts
+on-chain → no double-admit, just a wasted tx. **Keep `replicas: 1`** — dedupe is
+per-process.
+
+> **Prerequisite:** the acceptor's Safe smart account (`ACCEPTOR_PRIVATE_KEY` /
+> `ACCEPTOR_SPACE_ID`) must be an **editor** of every space in
+> `MEMBERSHIP_AUTOACCEPT_SPACE_IDS`, or its votes revert (`benign`, logged loudly).
+
+### Policies (the BYO extension point)
+
+Requests pass through a cheap→expensive funnel:
+
+```
+detect → WHITELIST (config Set, no I/O) → dedupe → POLICY (GraphQL) → vote
+```
+
+A `Policy` is `(request, ctx) => Promise<{accept, reason}>`; `ctx` carries a
+`GraphQLClient` so a space can express rules backed by API data (reputation,
+payment, external auth, …) without touching the webhook/voting plumbing. Compose
+several with `composePolicies(...)` (AND semantics, first denial wins).
+
+The shipped reference policy is **`editorPolicy`**: it confirms the acceptor is an
+editor of the target space via the `editor(spaceId, memberSpaceId)` GraphQL query.
+It **fails open** — an API error/timeout never suppresses a vote; the chain stays
+the final authority (a genuine non-editor just reverts). Configure the endpoint
+with `GRAPHQL_ENDPOINT`. Add your own policies in `src/index.ts`:
+`composePolicies(editorPolicy, myReputationPolicy)`.
 
 > Implementation note: unlike `proposal-executor` (an Effect-TS CronJob), this is
-> a plain `Bun.serve` HTTP server. The request path is straightforward async
-> code; we keep the same Sentry/structured-logging conventions (see
-> `src/telemetry.ts`) so logs read consistently across the two services.
+> a plain `Bun.serve` HTTP server. The on-chain pieces (ABI, `enter()` encoding,
+> Safe smart wallet) are ported from `proposal-executor` because the published
+> `@geoprotocol/geo-sdk` voting helpers are hardcoded to testnet in the current
+> version and cannot drive a mainnet vote.
 
 ## Layout
 
@@ -48,6 +88,11 @@ check happens on-chain in M3 before any vote.
 | `src/index.ts` | Entry point — parse config, start server, graceful shutdown |
 | `src/server.ts` | Routes + request handling (`createApp` returns a testable fetch handler) |
 | `src/detect.ts` | Membership-request detection + `proposal_id` de-duplication |
+| `src/vote.ts` | The acceptor: whitelist + run policy + cast the YES vote, classify the result |
+| `src/policy.ts` | Policy seam + `composePolicies` + the reference `editorPolicy` |
+| `src/graphql.ts` | Minimal GraphQL client used by policies |
+| `src/wallet.ts` | Safe smart-account setup (Pimlico-sponsored) |
+| `src/contracts.ts` | SpaceRegistry ABI, chains, `enter()` encoding, revert classification |
 | `src/signature.ts` | `X-Geo-Signature` HMAC verification |
 | `src/config.ts` | Env parsing + validation (fail-fast) |
 | `src/telemetry.ts` | Sentry init + structured logger + flush |

--- a/membership-acceptor/bun.lock
+++ b/membership-acceptor/bun.lock
@@ -6,6 +6,8 @@
       "name": "membership-acceptor",
       "dependencies": {
         "@sentry/node": "^10.36.0",
+        "permissionless": "^0.3.2",
+        "viem": "^2.43.5",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.3.11",
@@ -15,6 +17,8 @@
     },
   },
   "packages": {
+    "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
+
     "@apm-js-collab/code-transformer": ["@apm-js-collab/code-transformer@0.15.0", "", { "dependencies": { "@types/estree": "^1.0.8", "astring": "^1.9.0", "esquery": "^1.7.0", "meriyah": "^6.1.4", "semifies": "^1.0.0", "source-map": "^0.6.0" }, "bin": { "code-transformer": "cli.js" } }, "sha512-XmXYVs8CzJ1Aj79noVbn2weUO/XWtRyURpGqx7aU7DOXlUQhR0WKOQNF0okh7PCeY37vxf7kU3v57OAkEPm3ww=="],
 
     "@apm-js-collab/code-transformer-bundler-plugins": ["@apm-js-collab/code-transformer-bundler-plugins@0.5.0", "", { "dependencies": { "@apm-js-collab/code-transformer": "^0.15.0", "es-module-lexer": "^2.1.0", "magic-string": "^0.30.21", "module-details-from-path": "^1.0.4" } }, "sha512-YxLBY5nGlurL7QeJLq6e5g0ouBpAp0pwgyA/5rHXEXwhiPLn9ZHbT+Y2LlP90GT872cSocfjWRYu/fnpuBudNQ=="],
@@ -41,6 +45,12 @@
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
+    "@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
+
+    "@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
+
+    "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
     "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.214.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA=="],
@@ -54,6 +64,12 @@
     "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.8.0", "", { "dependencies": { "@opentelemetry/core": "2.8.0", "@opentelemetry/resources": "2.8.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ=="],
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
+
+    "@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "@scure/bip32": ["@scure/bip32@1.7.0", "", { "dependencies": { "@noble/curves": "~1.9.0", "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw=="],
+
+    "@scure/bip39": ["@scure/bip39@1.6.0", "", { "dependencies": { "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A=="],
 
     "@sentry/conventions": ["@sentry/conventions@0.12.0", "", {}, "sha512-z1JQrl/1SLY+8wpzvork6vl+fpsg/oCCxM7HWWhUnI/R+OGNyoIzieQuggX3uUMY7NBtp8UWCQx6FeFazzOF9g=="],
 
@@ -73,6 +89,8 @@
 
     "@types/node": ["@types/node@26.0.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw=="],
 
+    "abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
+
     "acorn": ["acorn@8.17.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg=="],
 
     "acorn-import-attributes": ["acorn-import-attributes@1.9.5", "", { "peerDependencies": { "acorn": "^8" } }, "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="],
@@ -91,7 +109,11 @@
 
     "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
+    "eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
+
     "import-in-the-middle": ["import-in-the-middle@3.2.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-vR2B6HKIhaBjcZr2bLpFiJ1VbzOlRQ7aby4/gw5WPIzToLjqpfWw3VJ4sk1uDchoOODEirvO2jyrSPtUSL5CrQ=="],
+
+    "isows": ["isows@1.0.7", "", { "peerDependencies": { "ws": "*" } }, "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -100,6 +122,10 @@
     "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "ox": ["ox@0.14.29", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.2.3", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg=="],
+
+    "permissionless": ["permissionless@0.3.6", "", { "peerDependencies": { "ox": "^0.11.3", "viem": "^2.44.4" }, "optionalPeers": ["ox"] }, "sha512-7RstRCNwJc/kO9Q/ZJpgSPclXez8CaGU77PeYNaWpHCU1kRetu+7kqEUFcIFLdz47F7jpOwtsbAU56hn27c4mg=="],
 
     "require-in-the-middle": ["require-in-the-middle@8.0.1", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3" } }, "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ=="],
 
@@ -110,5 +136,9 @@
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "viem": ["viem@2.53.1", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.14.29", "ws": "8.20.1" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-FhfJ/SW73CVosiyVLmIMVgKDRKYV1AGCLzZoHYvmNayyVff63Qi1ocPCk59LqC/cNw244RbBJjHnmxqXkE7NpA=="],
+
+    "ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
   }
 }

--- a/membership-acceptor/deployment/production/deployment.yaml
+++ b/membership-acceptor/deployment/production/deployment.yaml
@@ -34,6 +34,35 @@ spec:
                 secretKeyRef:
                   name: membership-acceptor-credentials
                   key: GEO_WEBHOOK_SECRET
+            # Voting identity (sensitive)
+            - name: ACCEPTOR_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: membership-acceptor-credentials
+                  key: ACCEPTOR_PRIVATE_KEY
+            - name: PIMLICO_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: membership-acceptor-credentials
+                  key: PIMLICO_API_KEY
+            - name: RPC_URL
+              valueFrom:
+                secretKeyRef:
+                  name: membership-acceptor-credentials
+                  key: RPC_URL
+            # Non-sensitive config
+            - name: ACCEPTOR_SPACE_ID
+              value: "0x24208422558b4ac801e24a71a889dfad" # acceptor's personal-space id (bytes16)
+            - name: SPACE_REGISTRY_ADDRESS
+              value: "0xB01683b2f0d38d43fcD4D9aAB980166988924132"
+            - name: CHAIN_ID
+              value: "19411"
+            - name: GRAPHQL_ENDPOINT
+              value: "https://testnet-api.geobrowser.io/graphql" # Geo GraphQL endpoint (policies, e.g. editor check)
+            # DAO spaces this acceptor auto-accepts (comma-separated UUIDs).
+            # Empty = accept none.
+            - name: MEMBERSHIP_AUTOACCEPT_SPACE_IDS
+              value: "0xc9f267dcb0d270718c2a3c45a64afd32,0x84a679ce188f061ac9a92380bac2bab5,0x0477636ace64280fc43a9f440a502291"
             # Optional: Sentry error reporting
             - name: SENTRY_DSN
               valueFrom:

--- a/membership-acceptor/deployment/production/deployment.yaml
+++ b/membership-acceptor/deployment/production/deployment.yaml
@@ -59,8 +59,8 @@ spec:
               value: "19411"
             - name: GRAPHQL_ENDPOINT
               value: "https://testnet-api.geobrowser.io/graphql" # Geo GraphQL endpoint (policies, e.g. editor check)
-            # DAO spaces this acceptor auto-accepts (comma-separated UUIDs).
-            # Empty = accept none.
+            # DAO spaces this acceptor auto-accepts: comma-separated space ids as
+            # 0x-prefixed bytes16 hex (dashed UUIDs also accepted). Empty = accept none.
             - name: MEMBERSHIP_AUTOACCEPT_SPACE_IDS
               value: "0xc9f267dcb0d270718c2a3c45a64afd32,0x84a679ce188f061ac9a92380bac2bab5,0x0477636ace64280fc43a9f440a502291"
             # Optional: Sentry error reporting

--- a/membership-acceptor/deployment/production/secrets.yaml.example
+++ b/membership-acceptor/deployment/production/secrets.yaml.example
@@ -4,9 +4,15 @@
 # The GEO_WEBHOOK_SECRET here MUST match the `secret` of this service's row in
 # the notification service's app_webhooks table (notifications DB).
 #
+# The ACCEPTOR_PRIVATE_KEY's smart account must be an EDITOR of every space in
+# MEMBERSHIP_AUTOACCEPT_SPACE_IDS, or its votes revert.
+#
 # kubectl create secret generic membership-acceptor-credentials \
 #   --namespace=knowledge \
-#   --from-literal=GEO_WEBHOOK_SECRET="$(openssl rand -hex 32)"
+#   --from-literal=GEO_WEBHOOK_SECRET="$(openssl rand -hex 32)" \
+#   --from-literal=ACCEPTOR_PRIVATE_KEY='0x...' \
+#   --from-literal=PIMLICO_API_KEY='pim_...' \
+#   --from-literal=RPC_URL='https://...'
 
 apiVersion: v1
 kind: Secret
@@ -16,5 +22,8 @@ metadata:
 type: Opaque
 stringData:
   GEO_WEBHOOK_SECRET: "..."
+  ACCEPTOR_PRIVATE_KEY: "0x..."
+  PIMLICO_API_KEY: "pim_..."
+  RPC_URL: "https://..."
   # Optional
   SENTRY_DSN: "https://...@sentry.io/..."

--- a/membership-acceptor/package.json
+++ b/membership-acceptor/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "membership-acceptor",
 	"version": "0.1.0",
-	"description": "Real-time membership auto-accept — receives notification webhooks and (later) votes to admit members",
+	"description": "Real-time membership auto-accept — receives notification webhooks and votes to admit members",
 	"type": "module",
 	"private": true,
 	"scripts": {
@@ -12,7 +12,9 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@sentry/node": "^10.36.0"
+		"@sentry/node": "^10.36.0",
+		"permissionless": "^0.3.2",
+		"viem": "^2.43.5"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.3.11",

--- a/membership-acceptor/src/config.ts
+++ b/membership-acceptor/src/config.ts
@@ -6,7 +6,7 @@
  * webhooks.
  */
 
-import type {SupportedChainId} from "./contracts.js"
+import {type SupportedChainId, toBytes16Hex} from "./contracts.js"
 
 export interface AppConfig {
 	/** Port the HTTP server listens on. */
@@ -34,8 +34,10 @@ export interface AppConfig {
 	graphqlEndpoint: string
 
 	/**
-	 * Spaces this acceptor auto-accepts (DAO space UUIDs, lowercased). A request
-	 * for any other space is ignored. Empty ⇒ accept none (effective kill switch).
+	 * Spaces this acceptor auto-accepts, canonicalized to `0x`-prefixed bytes16 hex
+	 * (see {@link toBytes16Hex}) so they compare equal to a converted webhook
+	 * `space_id`. A request for any other space is ignored. Empty ⇒ accept none
+	 * (effective kill switch).
 	 */
 	autoacceptSpaceIds: ReadonlySet<string>
 }
@@ -104,12 +106,21 @@ export function parseConfig(env: NodeJS.ProcessEnv = process.env): AppConfig {
 		throw new ConfigError(`Invalid CHAIN_ID: expected 80451 (mainnet) or 19411 (testnet), got "${rawChainId}"`)
 	}
 
-	const autoacceptSpaceIds = new Set(
-		(env.MEMBERSHIP_AUTOACCEPT_SPACE_IDS ?? "")
-			.split(",")
-			.map((s) => s.trim().toLowerCase())
-			.filter((s) => s.length > 0),
-	)
+	// Canonicalize every allowlist entry to 0x bytes16 and validate it, so a
+	// typo'd id fails fast at startup instead of silently never matching. Incoming
+	// webhook space_ids are converted the same way before lookup (see allowsSpace).
+	const autoacceptSpaceIds = new Set<string>()
+	for (const raw of (env.MEMBERSHIP_AUTOACCEPT_SPACE_IDS ?? "").split(",")) {
+		const trimmed = raw.trim()
+		if (!trimmed) continue
+		const key = toBytes16Hex(trimmed)
+		if (!BYTES16_RE.test(key)) {
+			throw new ConfigError(
+				`Invalid MEMBERSHIP_AUTOACCEPT_SPACE_IDS entry "${trimmed}": expected a space id (bytes16 hex or UUID)`,
+			)
+		}
+		autoacceptSpaceIds.add(key)
+	}
 
 	return {
 		port,

--- a/membership-acceptor/src/config.ts
+++ b/membership-acceptor/src/config.ts
@@ -2,10 +2,13 @@
  * Configuration — parsed and validated once at startup.
  *
  * Fails fast (throws) on missing/invalid required values so the container
- * crash-loops loudly rather than silently accepting every (unverifiable) webhook.
+ * crash-loops loudly rather than silently mis-voting or accepting unverifiable
+ * webhooks.
  */
 
-export interface AcceptorConfig {
+import type {SupportedChainId} from "./contracts.js"
+
+export interface AppConfig {
 	/** Port the HTTP server listens on. */
 	port: number
 	/**
@@ -13,6 +16,28 @@ export interface AcceptorConfig {
 	 * Must match the `secret` column of this service's `app_webhooks` row.
 	 */
 	webhookSecret: string
+
+	// --- Voting identity / chain ---
+	/** Signing key for the Safe smart account that owns the acceptor's personal space. */
+	acceptorPrivateKey: `0x${string}`
+	/** The acceptor's personal-space id (bytes16 hex) — the enter() `_fromSpaceId`. */
+	acceptorSpaceId: `0x${string}`
+	/** SpaceRegistry contract address. */
+	spaceRegistryAddress: `0x${string}`
+	/** Chain RPC endpoint (may contain an API key). */
+	rpcUrl: string
+	/** Pimlico bundler/paymaster API key (gas sponsorship). */
+	pimlicoApiKey: string
+	/** 80451 (mainnet) or 19411 (testnet). */
+	chainId: SupportedChainId
+	/** Geo GraphQL endpoint — used by policies (e.g. the editor check). */
+	graphqlEndpoint: string
+
+	/**
+	 * Spaces this acceptor auto-accepts (DAO space UUIDs, lowercased). A request
+	 * for any other space is ignored. Empty ⇒ accept none (effective kill switch).
+	 */
+	autoacceptSpaceIds: ReadonlySet<string>
 }
 
 export class ConfigError extends Error {
@@ -20,12 +45,21 @@ export class ConfigError extends Error {
 }
 
 const DEFAULT_PORT = 8080
+const PRIVATE_KEY_RE = /^0x[0-9a-fA-F]{64}$/
+const BYTES16_RE = /^0x[0-9a-fA-F]{32}$/
+const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/
+
+function required(env: NodeJS.ProcessEnv, key: string): string {
+	const value = env[key]?.trim()
+	if (!value) throw new ConfigError(`${key} is required`)
+	return value
+}
 
 /**
  * Parse config from the given environment (defaults to `process.env`).
  * Throws {@link ConfigError} with an actionable message on the first problem.
  */
-export function parseConfig(env: NodeJS.ProcessEnv = process.env): AcceptorConfig {
+export function parseConfig(env: NodeJS.ProcessEnv = process.env): AppConfig {
 	const webhookSecret = env.GEO_WEBHOOK_SECRET?.trim()
 	if (!webhookSecret) {
 		throw new ConfigError(
@@ -43,5 +77,50 @@ export function parseConfig(env: NodeJS.ProcessEnv = process.env): AcceptorConfi
 		port = parsed
 	}
 
-	return {port, webhookSecret}
+	// Accept the private key with or without the 0x prefix.
+	let acceptorPrivateKey = required(env, "ACCEPTOR_PRIVATE_KEY")
+	if (!acceptorPrivateKey.startsWith("0x")) acceptorPrivateKey = `0x${acceptorPrivateKey}`
+	if (!PRIVATE_KEY_RE.test(acceptorPrivateKey)) {
+		throw new ConfigError("Invalid ACCEPTOR_PRIVATE_KEY: expected a 32-byte hex key (0x + 64 hex chars)")
+	}
+
+	const acceptorSpaceId = required(env, "ACCEPTOR_SPACE_ID")
+	if (!BYTES16_RE.test(acceptorSpaceId)) {
+		throw new ConfigError("Invalid ACCEPTOR_SPACE_ID: expected bytes16 hex (0x + 32 hex chars)")
+	}
+
+	const spaceRegistryAddress = required(env, "SPACE_REGISTRY_ADDRESS")
+	if (!ADDRESS_RE.test(spaceRegistryAddress)) {
+		throw new ConfigError("Invalid SPACE_REGISTRY_ADDRESS: expected an address (0x + 40 hex chars)")
+	}
+
+	const rpcUrl = required(env, "RPC_URL")
+	const pimlicoApiKey = required(env, "PIMLICO_API_KEY")
+	const graphqlEndpoint = required(env, "GRAPHQL_ENDPOINT")
+
+	const rawChainId = env.CHAIN_ID?.trim() || "80451"
+	const chainId = Number(rawChainId)
+	if (chainId !== 80451 && chainId !== 19411) {
+		throw new ConfigError(`Invalid CHAIN_ID: expected 80451 (mainnet) or 19411 (testnet), got "${rawChainId}"`)
+	}
+
+	const autoacceptSpaceIds = new Set(
+		(env.MEMBERSHIP_AUTOACCEPT_SPACE_IDS ?? "")
+			.split(",")
+			.map((s) => s.trim().toLowerCase())
+			.filter((s) => s.length > 0),
+	)
+
+	return {
+		port,
+		webhookSecret,
+		acceptorPrivateKey: acceptorPrivateKey as `0x${string}`,
+		acceptorSpaceId: acceptorSpaceId as `0x${string}`,
+		spaceRegistryAddress: spaceRegistryAddress as `0x${string}`,
+		rpcUrl,
+		pimlicoApiKey,
+		chainId: chainId as SupportedChainId,
+		graphqlEndpoint,
+		autoacceptSpaceIds,
+	}
 }

--- a/membership-acceptor/src/contracts.ts
+++ b/membership-acceptor/src/contracts.ts
@@ -100,6 +100,17 @@ export function uuidToBytes16(uuid: string): Hex {
 	return `0x${stripped}` as Hex
 }
 
+/**
+ * Canonicalize any Geo space id to `0x`-prefixed, dashless, lowercase bytes16 hex.
+ * Accepts a dashed UUID (as delivered in webhook `space_id`) or an already-`0x`
+ * bytes16 value, so the two representations compare equal. Pure formatting — does
+ * not validate length (callers that need that check the result against a regex).
+ * @example toBytes16Hex("c9f267dc-b0d2-7071-8c2a-3c45a64afd32") → "0xc9f267dcb0d270718c2a3c45a64afd32"
+ */
+export function toBytes16Hex(id: string): `0x${string}` {
+	return `0x${id.replace(/^0x/i, "").replace(/-/g, "").toLowerCase()}`
+}
+
 /** Pad a bytes16 hex (32 hex chars) to bytes32 (64 hex chars) with trailing zeros. */
 export function padBytes16ToBytes32(bytes16Hex: Hex): Hex {
 	const withoutPrefix = bytes16Hex.startsWith("0x") ? bytes16Hex.slice(2) : bytes16Hex
@@ -127,25 +138,38 @@ export function encodeVoteData(proposalIdHex: Hex, voteOption: number): Hex {
 // ---------------------------------------------------------------------------
 
 /**
- * viem/permissionless error names that indicate an on-chain revert. The chain
- * rejecting a vote (already voted / executed / window closed / not an editor) is
- * a *benign* outcome for us — there is nothing to retry — so we must distinguish
- * it from an infrastructure error (RPC/bundler hiccup) which SHOULD be retried.
+ * Classifying a failure as a *revert* makes it benign (no retry); classifying it
+ * as infra makes it retry. So we only treat a failure as a revert on a STRONG,
+ * unambiguous signal, and let everything else fall through to infra (retryable).
+ *
+ * `ContractFunctionRevertedError` is viem's definite "the contract reverted"
+ * error. We intentionally do NOT key off the broader `ContractFunctionExecutionError`
+ * / `CallExecutionError` wrappers — those also wrap RPC/estimation failures, and
+ * misreading one of those as benign would silently drop a real admission attempt.
  */
-const REVERT_ERROR_NAMES = new Set([
-	"ContractFunctionRevertedError",
-	"ContractFunctionExecutionError",
-	"CallExecutionError",
-])
+const REVERT_ERROR_NAME = "ContractFunctionRevertedError"
 
-const REVERT_MESSAGE_PATTERNS = ["revert", "execution reverted", "CALL_EXCEPTION", "UserOperation reverted"]
+/**
+ * Definite on-chain revert signals: the EVM revert prefix and the governance
+ * custom errors this vote can legitimately hit (already voted/executed/closed, or
+ * not an editor). Anything else is treated as infra and retried.
+ */
+const REVERT_MESSAGE_PATTERNS = [
+	"execution reverted",
+	"CanNotVote",
+	"CanNotExecute",
+	"ProposalAlreadyExecuted",
+	"AlreadyVoted",
+	"InvalidAction",
+	"already executed",
+]
 
-/** True if `error` looks like an on-chain revert (vs. an infrastructure failure). */
+/** True if `error` is unambiguously an on-chain revert (vs. an infrastructure failure). */
 export function isRevert(error: unknown): boolean {
 	const name = error instanceof Error ? error.name : typeof error
-	if (REVERT_ERROR_NAMES.has(name)) return true
+	if (name === REVERT_ERROR_NAME) return true
 
-	if (error instanceof Error && error.cause instanceof Error && REVERT_ERROR_NAMES.has(error.cause.name)) {
+	if (error instanceof Error && error.cause instanceof Error && error.cause.name === REVERT_ERROR_NAME) {
 		return true
 	}
 

--- a/membership-acceptor/src/contracts.ts
+++ b/membership-acceptor/src/contracts.ts
@@ -1,0 +1,161 @@
+/**
+ * Contract ABI, chain definitions, governance constants, encoding helpers, and
+ * revert classification for casting the membership YES vote.
+ *
+ * Ported from proposal-executor/src/{contracts,execute}.ts (which forked geo-cli),
+ * trimmed to what the acceptor needs and de-Effect-ified (plain functions).
+ *
+ * Why not @geoprotocol/geo-sdk: its `daoSpace.voteProposal` hardcodes the TESTNET
+ * registry address and `getSmartAccountWalletClient` hardcodes chain 19411 + a
+ * testnet bundler, so it cannot drive a mainnet vote in the published version.
+ * We reuse the proven viem path instead.
+ */
+
+import {type Address, type Chain, encodeAbiParameters, type Hex} from "viem"
+
+// ---------------------------------------------------------------------------
+// SpaceRegistry ABI — only enter() is needed (we cast votes, never read).
+// ---------------------------------------------------------------------------
+
+export const SpaceRegistryAbi = [
+	{
+		inputs: [
+			{internalType: "bytes16", name: "_fromSpaceId", type: "bytes16"},
+			{internalType: "bytes16", name: "_toSpaceId", type: "bytes16"},
+			{internalType: "bytes32", name: "_action", type: "bytes32"},
+			{internalType: "bytes32", name: "_topic", type: "bytes32"},
+			{internalType: "bytes", name: "_data", type: "bytes"},
+			{internalType: "bytes", name: "_signature", type: "bytes"},
+		],
+		name: "enter",
+		outputs: [],
+		stateMutability: "nonpayable",
+		type: "function",
+	},
+] as const
+
+// ---------------------------------------------------------------------------
+// Chain definitions
+// ---------------------------------------------------------------------------
+
+export const mainnetChain: Chain = {
+	id: 80451,
+	name: "Geo Genesis",
+	nativeCurrency: {name: "Ethereum", symbol: "ETH", decimals: 18},
+	rpcUrls: {default: {http: ["https://rpc-geo-genesis-h0q2s21xx8.t.conduit.xyz"]}},
+}
+
+export const testnetChain: Chain = {
+	id: 19411,
+	name: "Geo Genesis Testnet",
+	nativeCurrency: {name: "Ethereum", symbol: "ETH", decimals: 18},
+	rpcUrls: {default: {http: ["https://rpc-geo-test-zc16z3tcvf.t.conduit.xyz"]}},
+}
+
+export type SupportedChainId = 80451 | 19411
+
+export function getChain(chainId: SupportedChainId): Chain {
+	if (chainId === 80451) return mainnetChain
+	if (chainId === 19411) return testnetChain
+	const _exhaustive: never = chainId
+	throw new Error(`Unsupported chain ID: ${_exhaustive}`)
+}
+
+/** Safe deployment addresses for Geo Testnet (canonical addresses differ there). */
+export const TESTNET_SAFE_ADDRESSES = {
+	safeModuleSetupAddress: "0x2dd68b007B46fBe91B9A7c3EDa5A7a1063cB5b47" as const,
+	safe4337ModuleAddress: "0x75cf11467937ce3F2f357CE24ffc3DBF8fD5c226" as const,
+	safeProxyFactoryAddress: "0xd9d2Ba03a7754250FDD71333F444636471CACBC4" as const,
+	safeSingletonAddress: "0x639245e8476E03e789a244f279b5843b9633b2E7" as const,
+	multiSendAddress: "0x7B21BBDBdE8D01Df591fdc2dc0bE9956Dde1e16C" as const,
+	multiSendCallOnlyAddress: "0x32228dDEA8b9A2bd7f2d71A958fF241D79ca5eEC" as const,
+}
+
+// ---------------------------------------------------------------------------
+// Governance constants
+// ---------------------------------------------------------------------------
+
+/** keccak256('GOVERNANCE.PROPOSAL_VOTED') — action hash for casting a vote via enter() */
+export const PROPOSAL_VOTED_ACTION = "0x4ebf5f29676cedf7e2e4d346a8433289278f95a9fda73691dc1ce24574d5819e" as Hex
+
+/** IDAOSpace.VoteOption.Yes (enum: None=0, Yes=1, No=2, Abstain=3). */
+export const VOTE_YES = 1
+
+/** Empty signature — ignored when msg.sender == _fromSpace. */
+export const EMPTY_SIGNATURE = "0x" as Hex
+
+// ---------------------------------------------------------------------------
+// Encoding helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a UUID string to a bytes16 hex value (strip dashes, prefix 0x).
+ * @example uuidToBytes16("550e8400-e29b-41d4-a716-446655440000") → "0x550e8400e29b41d4a716446655440000"
+ */
+export function uuidToBytes16(uuid: string): Hex {
+	const stripped = uuid.replace(/-/g, "")
+	if (stripped.length !== 32 || !/^[0-9a-fA-F]+$/.test(stripped)) {
+		throw new Error(`Invalid UUID for bytes16 conversion: ${uuid}`)
+	}
+	return `0x${stripped}` as Hex
+}
+
+/** Pad a bytes16 hex (32 hex chars) to bytes32 (64 hex chars) with trailing zeros. */
+export function padBytes16ToBytes32(bytes16Hex: Hex): Hex {
+	const withoutPrefix = bytes16Hex.startsWith("0x") ? bytes16Hex.slice(2) : bytes16Hex
+	if (withoutPrefix.length !== 32) {
+		throw new Error(`Invalid bytes16: expected 32 hex chars, got ${withoutPrefix.length}`)
+	}
+	return `0x${withoutPrefix}${"0".repeat(32)}` as Hex
+}
+
+/**
+ * ABI-encode the PROPOSAL_VOTED data payload: abi.encode(bytes16 proposalId, uint8 voteOption).
+ */
+export function encodeVoteData(proposalIdHex: Hex, voteOption: number): Hex {
+	return encodeAbiParameters(
+		[
+			{name: "proposalId", type: "bytes16"},
+			{name: "voteOption", type: "uint8"},
+		],
+		[proposalIdHex, voteOption],
+	)
+}
+
+// ---------------------------------------------------------------------------
+// Revert classification
+// ---------------------------------------------------------------------------
+
+/**
+ * viem/permissionless error names that indicate an on-chain revert. The chain
+ * rejecting a vote (already voted / executed / window closed / not an editor) is
+ * a *benign* outcome for us — there is nothing to retry — so we must distinguish
+ * it from an infrastructure error (RPC/bundler hiccup) which SHOULD be retried.
+ */
+const REVERT_ERROR_NAMES = new Set([
+	"ContractFunctionRevertedError",
+	"ContractFunctionExecutionError",
+	"CallExecutionError",
+])
+
+const REVERT_MESSAGE_PATTERNS = ["revert", "execution reverted", "CALL_EXCEPTION", "UserOperation reverted"]
+
+/** True if `error` looks like an on-chain revert (vs. an infrastructure failure). */
+export function isRevert(error: unknown): boolean {
+	const name = error instanceof Error ? error.name : typeof error
+	if (REVERT_ERROR_NAMES.has(name)) return true
+
+	if (error instanceof Error && error.cause instanceof Error && REVERT_ERROR_NAMES.has(error.cause.name)) {
+		return true
+	}
+
+	const message = String(error)
+	return REVERT_MESSAGE_PATTERNS.some((p) => message.includes(p))
+}
+
+/** Never leak a bundler URL's API key into a log/error message. */
+export function sanitizeError(error: unknown): string {
+	return String(error).replace(/apikey=[^\s&"]+/gi, "apikey=<redacted>")
+}
+
+export type {Address}

--- a/membership-acceptor/src/detect.ts
+++ b/membership-acceptor/src/detect.ts
@@ -105,4 +105,19 @@ export class SeenProposals {
 		}
 		return false
 	}
+
+	/**
+	 * Forget `proposalId` so it can be processed again.
+	 *
+	 * Used to roll back an optimistic `seen()` after an infrastructure failure:
+	 * we mark before voting (so the concurrent fan-out copies dedupe), but if the
+	 * vote fails for a retryable reason we must un-mark, or the delivery-worker's
+	 * retry would be silently deduped and the vote never lands. (We leave the id
+	 * recorded for benign reverts and successes — those should not retry.)
+	 */
+	unmark(proposalId: string): void {
+		if (!this.seenIds.delete(proposalId)) return
+		const idx = this.insertionOrder.indexOf(proposalId)
+		if (idx !== -1) this.insertionOrder.splice(idx, 1)
+	}
 }

--- a/membership-acceptor/src/graphql.ts
+++ b/membership-acceptor/src/graphql.ts
@@ -1,0 +1,74 @@
+/**
+ * Minimal GraphQL client for the Geo API.
+ *
+ * This is the shared primitive for BYO policies: a policy receives a
+ * {@link GraphQLClient} and uses it to fetch whatever data its decision needs
+ * (editor status, reputation, payment, …). Kept deliberately thin — POST a
+ * query, surface HTTP and GraphQL-level errors, bound it with a timeout.
+ */
+
+export class GraphQLError extends Error {
+	override readonly name = "GraphQLError"
+}
+
+export interface GraphQLClient {
+	/**
+	 * Execute `query` and return its `data`, typed as `T`. Throws {@link GraphQLError}
+	 * on a network/HTTP failure, a timeout, or a non-empty GraphQL `errors` array.
+	 */
+	query<T>(query: string, variables?: Record<string, unknown>): Promise<T>
+}
+
+export interface GraphQLClientOptions {
+	endpoint: string
+	/** Abort the request after this many ms (default 10s). */
+	timeoutMs?: number
+	/** Extra headers (e.g. auth) merged onto the request. */
+	headers?: Record<string, string>
+}
+
+const DEFAULT_TIMEOUT_MS = 10_000
+
+export function createGraphQLClient(opts: GraphQLClientOptions): GraphQLClient {
+	const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS
+
+	return {
+		async query<T>(query: string, variables?: Record<string, unknown>): Promise<T> {
+			const controller = new AbortController()
+			const timer = setTimeout(() => controller.abort(), timeoutMs)
+
+			let response: Response
+			try {
+				response = await fetch(opts.endpoint, {
+					method: "POST",
+					headers: {"content-type": "application/json", ...opts.headers},
+					body: JSON.stringify({query, variables}),
+					signal: controller.signal,
+				})
+			} catch (err) {
+				throw new GraphQLError(`request failed: ${err instanceof Error ? err.message : String(err)}`)
+			} finally {
+				clearTimeout(timer)
+			}
+
+			if (!response.ok) {
+				throw new GraphQLError(`HTTP ${response.status} ${response.statusText}`)
+			}
+
+			let body: {data?: T; errors?: Array<{message: string}>}
+			try {
+				body = (await response.json()) as typeof body
+			} catch (err) {
+				throw new GraphQLError(`invalid JSON response: ${err instanceof Error ? err.message : String(err)}`)
+			}
+
+			if (body.errors && body.errors.length > 0) {
+				throw new GraphQLError(body.errors.map((e) => e.message).join("; "))
+			}
+			if (body.data === undefined || body.data === null) {
+				throw new GraphQLError("response had no data")
+			}
+			return body.data
+		},
+	}
+}

--- a/membership-acceptor/src/index.ts
+++ b/membership-acceptor/src/index.ts
@@ -5,13 +5,17 @@
  * notification service. This is the real-time successor to the proposal-executor
  * cron's membership-accept path.
  *
- * Milestone 1 (this file): stand up the server, verify webhook signatures, and
- * log deliveries. Detection (M2) and on-chain voting (M3) build on top.
+ * Verifies webhook signatures, detects membership requests, and casts the YES
+ * vote on-chain via the acceptor's smart wallet.
  */
 
 import {parseConfig} from "./config.js"
+import {createGraphQLClient} from "./graphql.js"
+import {composePolicies, editorPolicy} from "./policy.js"
 import {createApp} from "./server.js"
 import {flush, log} from "./telemetry.js"
+import {createAcceptor} from "./vote.js"
+import {createSmartWallet} from "./wallet.js"
 
 async function main() {
 	let config: ReturnType<typeof parseConfig>
@@ -26,7 +30,38 @@ async function main() {
 		process.exit(1)
 	}
 
-	const app = createApp(config)
+	if (config.autoacceptSpaceIds.size === 0) {
+		// Not fatal, but the acceptor will ignore every request — make it obvious.
+		log.warn("MEMBERSHIP_AUTOACCEPT_SPACE_IDS is empty — no requests will be accepted")
+	}
+
+	let acceptor: ReturnType<typeof createAcceptor>
+	try {
+		const wallet = await createSmartWallet({
+			privateKey: config.acceptorPrivateKey,
+			pimlicoApiKey: config.pimlicoApiKey,
+			rpcUrl: config.rpcUrl,
+			chainId: config.chainId,
+		})
+		log.info("acceptor wallet ready", {safe_address: wallet.safeAddress, chain_id: config.chainId})
+		const graphql = createGraphQLClient({endpoint: config.graphqlEndpoint})
+		// The editor check is the reference policy; space-defined policies compose here.
+		const policy = composePolicies(editorPolicy)
+		acceptor = createAcceptor({
+			wallet,
+			acceptorSpaceId: config.acceptorSpaceId,
+			spaceRegistryAddress: config.spaceRegistryAddress,
+			allowlist: config.autoacceptSpaceIds,
+			policy,
+			graphql,
+		})
+	} catch (err) {
+		log.error("failed to initialize acceptor wallet — refusing to start", {error: err})
+		await flush()
+		process.exit(1)
+	}
+
+	const app = createApp(config, acceptor)
 
 	const server = Bun.serve({
 		port: config.port,

--- a/membership-acceptor/src/index.ts
+++ b/membership-acceptor/src/index.ts
@@ -10,6 +10,7 @@
  */
 
 import {parseConfig} from "./config.js"
+import {sanitizeError} from "./contracts.js"
 import {createGraphQLClient} from "./graphql.js"
 import {composePolicies, editorPolicy} from "./policy.js"
 import {createApp} from "./server.js"
@@ -23,7 +24,7 @@ async function main() {
 		config = parseConfig()
 	} catch (err) {
 		// Misconfiguration — crash loudly so the deployment is visibly broken.
-		log.error("configuration error — refusing to start", {error: err})
+		log.error("configuration error — refusing to start", {error: sanitizeError(err)})
 		// Flush buffered telemetry before exiting, or the startup-failure event is
 		// lost (same reason the graceful-shutdown path flushes before exit).
 		await flush()
@@ -56,7 +57,9 @@ async function main() {
 			graphql,
 		})
 	} catch (err) {
-		log.error("failed to initialize acceptor wallet — refusing to start", {error: err})
+		// Sanitize: wallet/bundler init errors can embed the Pimlico API key (it's
+		// in the bundler URL), and this goes to logs/Sentry.
+		log.error("failed to initialize acceptor wallet — refusing to start", {error: sanitizeError(err)})
 		await flush()
 		process.exit(1)
 	}

--- a/membership-acceptor/src/policy.ts
+++ b/membership-acceptor/src/policy.ts
@@ -1,0 +1,80 @@
+/**
+ * Policy seam — the extension point for membership acceptors.
+ *
+ * A {@link Policy} decides whether a detected, allowlisted membership request
+ * should be accepted (voted YES). Policies receive a {@link PolicyContext} with a
+ * GraphQL client, so a space owner can express arbitrary rules backed by API data
+ * (editor status, reputation, payment, external auth, …) without touching the
+ * webhook/voting plumbing.
+ *
+ * The reference policy shipped here is {@link editorPolicy}: it confirms the
+ * acceptor is actually an editor of the target space (otherwise the vote would
+ * just revert on-chain). It fails OPEN — an API error never suppresses a vote;
+ * the chain remains the final authority.
+ */
+
+import {sanitizeError} from "./contracts.js"
+import type {MembershipRequest} from "./detect.js"
+import type {GraphQLClient} from "./graphql.js"
+
+export interface PolicyContext {
+	graphql: GraphQLClient
+	/** The acceptor's personal-space id (bytes16 hex, 0x-prefixed). */
+	acceptorSpaceId: string
+}
+
+export interface PolicyDecision {
+	accept: boolean
+	/** Human-readable explanation, logged on both accept and deny. */
+	reason: string
+}
+
+export type Policy = (request: MembershipRequest, ctx: PolicyContext) => Promise<PolicyDecision>
+
+/**
+ * Compose policies with AND semantics: every policy must accept. The first denial
+ * short-circuits and is returned (later policies are not run).
+ */
+export function composePolicies(...policies: Policy[]): Policy {
+	return async (request, ctx) => {
+		for (const policy of policies) {
+			const decision = await policy(request, ctx)
+			if (!decision.accept) return decision
+		}
+		return {accept: true, reason: "all policies passed"}
+	}
+}
+
+interface EditorQueryResult {
+	editor: {memberSpaceId: string} | null
+}
+
+/**
+ * Accept iff the acceptor's space is an editor of the request's DAO space.
+ *
+ * Queries `editor(spaceId, memberSpaceId)` — a non-null result means the acceptor
+ * can vote. The API accepts ids dashed or dashless, so `request.spaceId` is passed
+ * as-is (and it is already an allowlisted, operator-controlled value by this point,
+ * so it is safe to inline); only the `0x` prefix is stripped off the acceptor's
+ * bytes16 space id, which the query does not expect.
+ *
+ * Fails OPEN: if the query errors, we accept and let the on-chain vote be the
+ * authority (a genuine non-editor simply reverts).
+ */
+export const editorPolicy: Policy = async (request, ctx) => {
+	const spaceId = request.spaceId
+	const memberSpaceId = ctx.acceptorSpaceId.replace(/^0x/i, "")
+
+	const query = `query IsEditor { editor(spaceId: "${spaceId}", memberSpaceId: "${memberSpaceId}") { memberSpaceId } }`
+
+	try {
+		const data = await ctx.graphql.query<EditorQueryResult>(query)
+		if (data.editor) {
+			return {accept: true, reason: "acceptor is an editor of the space"}
+		}
+		return {accept: false, reason: `acceptor space ${memberSpaceId} is not an editor of ${spaceId}`}
+	} catch (err) {
+		// Fail open — never let API trouble block a legitimate vote.
+		return {accept: true, reason: `editor check skipped (api error): ${sanitizeError(err)}`}
+	}
+}

--- a/membership-acceptor/src/server.ts
+++ b/membership-acceptor/src/server.ts
@@ -5,16 +5,13 @@
  * it can be driven directly in unit tests (no bound port) and handed to
  * `Bun.serve` in production.
  *
- * Milestone 2 scope: verify the HMAC signature, then detect which deliveries are
- * membership requests and de-duplicate them. Voting (M3) is not here yet — a
- * detected request is logged as "would accept" and every authenticated webhook
- * is acknowledged with 200.
  */
 
-import type {AcceptorConfig} from "./config.js"
+import type {AppConfig} from "./config.js"
 import {detectMembershipRequest, SeenProposals} from "./detect.js"
 import {verifySignature} from "./signature.js"
 import {log} from "./telemetry.js"
+import type {Acceptor} from "./vote.js"
 
 const SIGNATURE_HEADER = "x-geo-signature"
 const SIGNATURE_PREFIX = "sha256="
@@ -41,7 +38,12 @@ function json(body: unknown, status: number): Response {
 	})
 }
 
-async function handleWebhook(req: Request, config: AcceptorConfig, seen: SeenProposals): Promise<Response> {
+async function handleWebhook(
+	req: Request,
+	config: AppConfig,
+	acceptor: Acceptor,
+	seen: SeenProposals,
+): Promise<Response> {
 	const signature = req.headers.get(SIGNATURE_HEADER)
 
 	// A missing or malformed signature header can never pass the HMAC check, so
@@ -82,7 +84,18 @@ async function handleWebhook(req: Request, config: AcceptorConfig, seen: SeenPro
 		return json({status: "ok"}, 200)
 	}
 
-	// Dedupe on proposal_id: the fan-out delivers one copy per editor.
+	// Policy gate: only act on spaces this acceptor serves.
+	if (!acceptor.allowsSpace(request.spaceId)) {
+		log.debug("membership request for an unserved space — ignored", {
+			proposal_id: request.proposalId,
+			space_id: request.spaceId,
+		})
+		return json({status: "ok"}, 200)
+	}
+
+	// Dedupe on proposal_id, marking BEFORE we evaluate/vote so the concurrent
+	// fan-out copies (one per editor) collapse to a single attempt — and so we
+	// only hit the policy's API once per proposal.
 	if (seen.seen(request.proposalId)) {
 		log.debug("membership request already seen — deduped", {
 			proposal_id: request.proposalId,
@@ -91,13 +104,49 @@ async function handleWebhook(req: Request, config: AcceptorConfig, seen: SeenPro
 		return json({status: "ok"}, 200)
 	}
 
-	// M2 ends here: detected, not yet voted. M3 verifies on-chain and casts YES.
-	log.info("membership request detected — would accept", {
-		proposal_id: request.proposalId,
-		space_id: request.spaceId,
-		requester_space_id: request.requesterSpaceId,
-	})
-	return json({status: "ok"}, 200)
+	// Policy seam: API-backed rules (editor check, and any space-defined policies).
+	const decision = await acceptor.evaluate(request)
+	if (!decision.accept) {
+		log.info("membership request denied by policy", {
+			proposal_id: request.proposalId,
+			space_id: request.spaceId,
+			reason: decision.reason,
+		})
+		return json({status: "ok"}, 200)
+	}
+
+	const result = await acceptor.vote(request)
+	switch (result.kind) {
+		case "voted":
+			log.info("membership request accepted — vote cast", {
+				proposal_id: request.proposalId,
+				space_id: request.spaceId,
+				requester_space_id: request.requesterSpaceId,
+				tx_hash: result.txHash,
+			})
+			return json({status: "ok"}, 200)
+
+		case "benign":
+			// The chain rejected the vote. Nothing to retry — ack so delivery stops.
+			log.warn("membership vote rejected on-chain — not retrying", {
+				proposal_id: request.proposalId,
+				space_id: request.spaceId,
+				reason: result.message,
+			})
+			return json({status: "ok"}, 200)
+
+		default: {
+			// Infrastructure failure — roll back the dedupe mark so the
+			// delivery-worker's retry isn't silently swallowed, and 5xx to retry.
+			seen.unmark(request.proposalId)
+			log.error("membership vote failed (infrastructure) — will retry", {
+				proposal_id: request.proposalId,
+				space_id: request.spaceId,
+				error: result.message,
+			})
+			return json({error: "vote failed"}, 503)
+		}
+	}
 }
 
 /**
@@ -107,7 +156,7 @@ async function handleWebhook(req: Request, config: AcceptorConfig, seen: SeenPro
  *  - `GET /health`        — liveness/readiness probe
  *  - `POST /webhooks/geo` — notification webhook sink (HMAC-verified)
  */
-export function createApp(config: AcceptorConfig): (req: Request) => Promise<Response> {
+export function createApp(config: AppConfig, acceptor: Acceptor): (req: Request) => Promise<Response> {
 	// Dedupe state lives for the lifetime of the process (see SeenProposals).
 	const seen = new SeenProposals()
 
@@ -120,7 +169,7 @@ export function createApp(config: AcceptorConfig): (req: Request) => Promise<Res
 
 		if (req.method === "POST" && pathname === "/webhooks/geo") {
 			try {
-				return await handleWebhook(req, config, seen)
+				return await handleWebhook(req, config, acceptor, seen)
 			} catch (err) {
 				// Unexpected failure — 500 makes the delivery-worker retry rather than
 				// silently dropping the event.

--- a/membership-acceptor/src/server.ts
+++ b/membership-acceptor/src/server.ts
@@ -8,6 +8,7 @@
  */
 
 import type {AppConfig} from "./config.js"
+import {sanitizeError} from "./contracts.js"
 import {detectMembershipRequest, SeenProposals} from "./detect.js"
 import {verifySignature} from "./signature.js"
 import {log} from "./telemetry.js"
@@ -104,48 +105,63 @@ async function handleWebhook(
 		return json({status: "ok"}, 200)
 	}
 
-	// Policy seam: API-backed rules (editor check, and any space-defined policies).
-	const decision = await acceptor.evaluate(request)
-	if (!decision.accept) {
-		log.info("membership request denied by policy", {
+	// Once marked seen, any non-terminal failure below must roll the mark back, or
+	// the delivery-worker's retry would be silently deduped and the vote never lands.
+	// A thrown error (e.g. an unexpected policy failure) is exactly such a case.
+	try {
+		// Policy seam: API-backed rules (editor check, and any space-defined policies).
+		const decision = await acceptor.evaluate(request)
+		if (!decision.accept) {
+			log.info("membership request denied by policy", {
+				proposal_id: request.proposalId,
+				space_id: request.spaceId,
+				reason: decision.reason,
+			})
+			return json({status: "ok"}, 200)
+		}
+
+		const result = await acceptor.vote(request)
+		switch (result.kind) {
+			case "voted":
+				log.info("membership request accepted — vote cast", {
+					proposal_id: request.proposalId,
+					space_id: request.spaceId,
+					requester_space_id: request.requesterSpaceId,
+					tx_hash: result.txHash,
+				})
+				return json({status: "ok"}, 200)
+
+			case "benign":
+				// The chain rejected the vote. Nothing to retry — ack so delivery stops.
+				log.warn("membership vote rejected on-chain — not retrying", {
+					proposal_id: request.proposalId,
+					space_id: request.spaceId,
+					reason: result.message,
+				})
+				return json({status: "ok"}, 200)
+
+			default: {
+				// Infrastructure failure — roll back the dedupe mark so the
+				// delivery-worker's retry isn't silently swallowed, and 5xx to retry.
+				seen.unmark(request.proposalId)
+				log.error("membership vote failed (infrastructure) — will retry", {
+					proposal_id: request.proposalId,
+					space_id: request.spaceId,
+					error: result.message,
+				})
+				return json({error: "vote failed"}, 503)
+			}
+		}
+	} catch (err) {
+		// Unexpected throw during evaluate/vote — roll back the dedupe mark and ask
+		// for a retry, instead of letting the outer catch 500 with the mark stuck.
+		seen.unmark(request.proposalId)
+		log.error("membership processing failed — will retry", {
 			proposal_id: request.proposalId,
 			space_id: request.spaceId,
-			reason: decision.reason,
+			error: sanitizeError(err),
 		})
-		return json({status: "ok"}, 200)
-	}
-
-	const result = await acceptor.vote(request)
-	switch (result.kind) {
-		case "voted":
-			log.info("membership request accepted — vote cast", {
-				proposal_id: request.proposalId,
-				space_id: request.spaceId,
-				requester_space_id: request.requesterSpaceId,
-				tx_hash: result.txHash,
-			})
-			return json({status: "ok"}, 200)
-
-		case "benign":
-			// The chain rejected the vote. Nothing to retry — ack so delivery stops.
-			log.warn("membership vote rejected on-chain — not retrying", {
-				proposal_id: request.proposalId,
-				space_id: request.spaceId,
-				reason: result.message,
-			})
-			return json({status: "ok"}, 200)
-
-		default: {
-			// Infrastructure failure — roll back the dedupe mark so the
-			// delivery-worker's retry isn't silently swallowed, and 5xx to retry.
-			seen.unmark(request.proposalId)
-			log.error("membership vote failed (infrastructure) — will retry", {
-				proposal_id: request.proposalId,
-				space_id: request.spaceId,
-				error: result.message,
-			})
-			return json({error: "vote failed"}, 503)
-		}
+		return json({error: "processing failed"}, 503)
 	}
 }
 
@@ -172,8 +188,9 @@ export function createApp(config: AppConfig, acceptor: Acceptor): (req: Request)
 				return await handleWebhook(req, config, acceptor, seen)
 			} catch (err) {
 				// Unexpected failure — 500 makes the delivery-worker retry rather than
-				// silently dropping the event.
-				log.error("unhandled error processing webhook", {error: err})
+				// silently dropping the event. Sanitize: the error may carry a bundler
+				// URL with an API key.
+				log.error("unhandled error processing webhook", {error: sanitizeError(err)})
 				return json({error: "internal error"}, 500)
 			}
 		}

--- a/membership-acceptor/src/vote.ts
+++ b/membership-acceptor/src/vote.ts
@@ -1,0 +1,119 @@
+/**
+ * Casting the membership YES vote.
+ *
+ * Build the enter(PROPOSAL_VOTED, Yes) calldata and send it.
+ * The contract is the authority — a duplicate / closed /
+ * already-executed / unauthorized vote simply reverts, which we classify as a
+ * *benign* outcome (nothing to retry). Only genuine infrastructure failures are
+ * retryable.
+ *
+ * Because fast-path spaces run with flatThreshold = 1, the single YES executes the
+ * AddMember in the same transaction — admitting the member.
+ */
+
+import {type Address, encodeFunctionData} from "viem"
+
+import {
+	EMPTY_SIGNATURE,
+	encodeVoteData,
+	isRevert,
+	PROPOSAL_VOTED_ACTION,
+	padBytes16ToBytes32,
+	SpaceRegistryAbi,
+	sanitizeError,
+	uuidToBytes16,
+	VOTE_YES,
+} from "./contracts.js"
+import type {MembershipRequest} from "./detect.js"
+import type {GraphQLClient} from "./graphql.js"
+import type {Policy, PolicyDecision} from "./policy.js"
+import type {SmartWallet} from "./wallet.js"
+
+/**
+ * Outcome of attempting a vote.
+ * - `voted`  — the YES vote landed (member admitted). txHash for tracing.
+ * - `benign` — the chain rejected it (already voted / executed / closed / not an
+ *              editor). Nothing to retry; ack the webhook so it stops retrying.
+ * - `infra`  — an infrastructure failure (RPC/bundler). The webhook should retry.
+ */
+export type VoteResult =
+	| {kind: "voted"; txHash: string}
+	| {kind: "benign"; message: string}
+	| {kind: "infra"; message: string}
+
+/**
+ * The acceptor's view used by the HTTP layer: which spaces it serves, and how to
+ * vote. Injected into `createApp` so tests can stub it without a real wallet.
+ */
+export interface Acceptor {
+	/** Cheap config gate: true if this acceptor serves `spaceId` (the whitelist). */
+	allowsSpace(spaceId: string): boolean
+	/** Run the policy seam (API-backed rules, e.g. the editor check) for a request. */
+	evaluate(request: MembershipRequest): Promise<PolicyDecision>
+	/** Cast the YES vote for a detected, allowed, accepted, not-yet-seen request. */
+	vote(request: MembershipRequest): Promise<VoteResult>
+}
+
+export interface AcceptorConfig {
+	wallet: SmartWallet
+	/** The acceptor's personal-space id (bytes16 hex) — the enter() `_fromSpaceId`. */
+	acceptorSpaceId: `0x${string}`
+	spaceRegistryAddress: Address
+	/** Spaces (UUIDs, lowercased) this acceptor auto-accepts. Empty ⇒ accept none. */
+	allowlist: ReadonlySet<string>
+	/** The (possibly composed) policy run before voting. */
+	policy: Policy
+	/** GraphQL client passed to policies for API-backed decisions. */
+	graphql: GraphQLClient
+}
+
+/** Build the real, wallet-backed acceptor. */
+export function createAcceptor(config: AcceptorConfig): Acceptor {
+	return {
+		allowsSpace(spaceId: string): boolean {
+			return config.allowlist.has(spaceId.toLowerCase())
+		},
+
+		evaluate(request: MembershipRequest): Promise<PolicyDecision> {
+			return config.policy(request, {graphql: config.graphql, acceptorSpaceId: config.acceptorSpaceId})
+		},
+
+		async vote(request: MembershipRequest): Promise<VoteResult> {
+			try {
+				const daoSpaceId = uuidToBytes16(request.spaceId)
+				const proposalIdHex = uuidToBytes16(request.proposalId)
+
+				const calldata = encodeFunctionData({
+					abi: SpaceRegistryAbi,
+					functionName: "enter",
+					args: [
+						config.acceptorSpaceId, // _fromSpaceId: acceptor's personal space
+						daoSpaceId, // _toSpaceId: DAO space being joined
+						PROPOSAL_VOTED_ACTION, // _action
+						padBytes16ToBytes32(proposalIdHex), // _topic: bytes32(proposalId)
+						encodeVoteData(proposalIdHex, VOTE_YES), // _data: abi.encode(proposalId, Yes)
+						EMPTY_SIGNATURE, // _signature: unused when msg.sender == _fromSpace
+					],
+				})
+
+				const account = config.wallet.smartAccountClient.account
+				if (!account) {
+					// Misconfigured wallet — retrying won't help, but it's not a chain
+					// revert either; surface as infra so it's loud and retried.
+					return {kind: "infra", message: "smart account client has no account"}
+				}
+
+				const txHash = await config.wallet.smartAccountClient.sendTransaction({
+					account,
+					chain: config.wallet.chain,
+					to: config.spaceRegistryAddress,
+					data: calldata,
+				})
+				return {kind: "voted", txHash}
+			} catch (error) {
+				const message = sanitizeError(error)
+				return isRevert(error) ? {kind: "benign", message} : {kind: "infra", message}
+			}
+		},
+	}
+}

--- a/membership-acceptor/src/vote.ts
+++ b/membership-acceptor/src/vote.ts
@@ -21,6 +21,7 @@ import {
 	padBytes16ToBytes32,
 	SpaceRegistryAbi,
 	sanitizeError,
+	toBytes16Hex,
 	uuidToBytes16,
 	VOTE_YES,
 } from "./contracts.js"
@@ -71,7 +72,9 @@ export interface AcceptorConfig {
 export function createAcceptor(config: AcceptorConfig): Acceptor {
 	return {
 		allowsSpace(spaceId: string): boolean {
-			return config.allowlist.has(spaceId.toLowerCase())
+			// Webhook space_id arrives as a dashed UUID; the allowlist is 0x bytes16.
+			// Canonicalize both to the same form before comparing.
+			return config.allowlist.has(toBytes16Hex(spaceId))
 		},
 
 		evaluate(request: MembershipRequest): Promise<PolicyDecision> {

--- a/membership-acceptor/src/wallet.ts
+++ b/membership-acceptor/src/wallet.ts
@@ -1,0 +1,66 @@
+/**
+ * Smart-wallet setup — a gas-sponsored Safe smart account (Pimlico paymaster).
+ *
+ * The acceptor votes via SpaceRegistry.enter() with `_fromSpaceId` = its own
+ * personal space; the protocol requires msg.sender to be that space's account, so
+ * the signer must be the Safe smart account that owns the acceptor's personal
+ * space. Ported from proposal-executor/src/execute.ts (de-Effect-ified).
+ */
+
+import {createSmartAccountClient, type SmartAccountClient} from "permissionless"
+import {toSafeSmartAccount} from "permissionless/accounts"
+import {createPimlicoClient} from "permissionless/clients/pimlico"
+import {type Address, type Chain, createPublicClient, http} from "viem"
+import {entryPoint07Address} from "viem/account-abstraction"
+import {privateKeyToAccount} from "viem/accounts"
+
+import {getChain, type SupportedChainId, TESTNET_SAFE_ADDRESSES} from "./contracts.js"
+
+export interface SmartWallet {
+	readonly smartAccountClient: SmartAccountClient
+	readonly chain: Chain
+	readonly safeAddress: Address
+}
+
+export interface WalletConfig {
+	privateKey: `0x${string}`
+	pimlicoApiKey: string
+	rpcUrl: string
+	chainId: SupportedChainId
+}
+
+/** Create a gas-sponsored Safe smart account. Called once at startup. */
+export async function createSmartWallet(config: WalletConfig): Promise<SmartWallet> {
+	const chain = getChain(config.chainId)
+	const bundlerUrl = `https://api.pimlico.io/v2/${config.chainId}/rpc?apikey=${config.pimlicoApiKey}`
+
+	const publicClient = createPublicClient({chain, transport: http(config.rpcUrl)})
+	const owner = privateKeyToAccount(config.privateKey)
+
+	const safeAccount = await toSafeSmartAccount({
+		client: publicClient,
+		owners: [owner],
+		entryPoint: {address: entryPoint07Address, version: "0.7" as const},
+		version: "1.4.1" as const,
+		...(config.chainId === 19411 ? TESTNET_SAFE_ADDRESSES : {}),
+	})
+
+	const bundlerTransport = http(bundlerUrl)
+	const paymasterClient = createPimlicoClient({
+		transport: bundlerTransport,
+		chain,
+		entryPoint: {address: entryPoint07Address, version: "0.7"},
+	})
+
+	const smartAccountClient = createSmartAccountClient({
+		chain,
+		account: safeAccount,
+		paymaster: paymasterClient,
+		bundlerTransport,
+		userOperation: {
+			estimateFeesPerGas: async () => (await paymasterClient.getUserOperationGasPrice()).fast,
+		},
+	})
+
+	return {smartAccountClient, chain, safeAddress: safeAccount.address}
+}

--- a/membership-acceptor/tests/config.test.ts
+++ b/membership-acceptor/tests/config.test.ts
@@ -2,35 +2,80 @@ import {describe, expect, test} from "bun:test"
 
 import {ConfigError, parseConfig} from "../src/config.js"
 
+/** A complete, valid environment. Individual tests clone and mutate it. */
+function validEnv(): NodeJS.ProcessEnv {
+	return {
+		GEO_WEBHOOK_SECRET: "s3cr3t",
+		ACCEPTOR_PRIVATE_KEY: `0x${"1".repeat(64)}`,
+		ACCEPTOR_SPACE_ID: `0x${"a".repeat(32)}`,
+		SPACE_REGISTRY_ADDRESS: `0x${"b".repeat(40)}`,
+		RPC_URL: "https://rpc.example",
+		PIMLICO_API_KEY: "pim_test",
+		GRAPHQL_ENDPOINT: "https://api.example/graphql",
+		MEMBERSHIP_AUTOACCEPT_SPACE_IDS: "d4f5a6b7-0000-0000-0000-000000000000",
+	}
+}
+
 describe("parseConfig", () => {
-	test("parses a valid environment with default port", () => {
-		const config = parseConfig({GEO_WEBHOOK_SECRET: "s3cr3t"})
-		expect(config).toEqual({port: 8080, webhookSecret: "s3cr3t"})
+	test("parses a full valid environment", () => {
+		const c = parseConfig(validEnv())
+		expect(c.port).toBe(8080)
+		expect(c.webhookSecret).toBe("s3cr3t")
+		expect(c.chainId).toBe(80451) // mainnet default
+		expect(c.spaceRegistryAddress).toBe(`0x${"b".repeat(40)}`)
+		expect([...c.autoacceptSpaceIds]).toEqual(["d4f5a6b7-0000-0000-0000-000000000000"])
 	})
 
-	test("honors a valid PORT", () => {
-		const config = parseConfig({GEO_WEBHOOK_SECRET: "s3cr3t", PORT: "3000"})
-		expect(config.port).toBe(3000)
+	test("adds the 0x prefix to a bare private key", () => {
+		const c = parseConfig({...validEnv(), ACCEPTOR_PRIVATE_KEY: "1".repeat(64)})
+		expect(c.acceptorPrivateKey).toBe(`0x${"1".repeat(64)}`)
 	})
 
-	test("trims the secret", () => {
-		const config = parseConfig({GEO_WEBHOOK_SECRET: "  s3cr3t  "})
-		expect(config.webhookSecret).toBe("s3cr3t")
+	test("lowercases and de-duplicates the allowlist, dropping blanks", () => {
+		const c = parseConfig({...validEnv(), MEMBERSHIP_AUTOACCEPT_SPACE_IDS: " AAA , aaa ,, BBB "})
+		expect([...c.autoacceptSpaceIds].sort()).toEqual(["aaa", "bbb"])
 	})
 
-	test("throws when GEO_WEBHOOK_SECRET is missing", () => {
-		expect(() => parseConfig({})).toThrow(ConfigError)
+	test("an empty allowlist is allowed (kill switch)", () => {
+		const c = parseConfig({...validEnv(), MEMBERSHIP_AUTOACCEPT_SPACE_IDS: ""})
+		expect(c.autoacceptSpaceIds.size).toBe(0)
 	})
 
-	test("throws when GEO_WEBHOOK_SECRET is blank", () => {
-		expect(() => parseConfig({GEO_WEBHOOK_SECRET: "   "})).toThrow(ConfigError)
+	test("honors a valid PORT and CHAIN_ID", () => {
+		const c = parseConfig({...validEnv(), PORT: "3000", CHAIN_ID: "19411"})
+		expect(c.port).toBe(3000)
+		expect(c.chainId).toBe(19411)
 	})
 
-	test("throws on a non-numeric PORT", () => {
-		expect(() => parseConfig({GEO_WEBHOOK_SECRET: "s", PORT: "abc"})).toThrow(ConfigError)
+	test.each([
+		["GEO_WEBHOOK_SECRET", {GEO_WEBHOOK_SECRET: ""}],
+		["ACCEPTOR_PRIVATE_KEY", {ACCEPTOR_PRIVATE_KEY: undefined}],
+		["ACCEPTOR_SPACE_ID", {ACCEPTOR_SPACE_ID: undefined}],
+		["SPACE_REGISTRY_ADDRESS", {SPACE_REGISTRY_ADDRESS: undefined}],
+		["RPC_URL", {RPC_URL: undefined}],
+		["PIMLICO_API_KEY", {PIMLICO_API_KEY: undefined}],
+		["GRAPHQL_ENDPOINT", {GRAPHQL_ENDPOINT: undefined}],
+	])("throws when %s is missing", (_label, override) => {
+		expect(() => parseConfig({...validEnv(), ...override})).toThrow(ConfigError)
+	})
+
+	test("throws on a malformed private key", () => {
+		expect(() => parseConfig({...validEnv(), ACCEPTOR_PRIVATE_KEY: "0xnothex"})).toThrow(ConfigError)
+	})
+
+	test("throws on a malformed ACCEPTOR_SPACE_ID (not bytes16)", () => {
+		expect(() => parseConfig({...validEnv(), ACCEPTOR_SPACE_ID: `0x${"a".repeat(40)}`})).toThrow(ConfigError)
+	})
+
+	test("throws on a malformed SPACE_REGISTRY_ADDRESS", () => {
+		expect(() => parseConfig({...validEnv(), SPACE_REGISTRY_ADDRESS: "0x1234"})).toThrow(ConfigError)
+	})
+
+	test("throws on an unsupported CHAIN_ID", () => {
+		expect(() => parseConfig({...validEnv(), CHAIN_ID: "1"})).toThrow(ConfigError)
 	})
 
 	test("throws on an out-of-range PORT", () => {
-		expect(() => parseConfig({GEO_WEBHOOK_SECRET: "s", PORT: "70000"})).toThrow(ConfigError)
+		expect(() => parseConfig({...validEnv(), PORT: "70000"})).toThrow(ConfigError)
 	})
 })

--- a/membership-acceptor/tests/config.test.ts
+++ b/membership-acceptor/tests/config.test.ts
@@ -23,7 +23,8 @@ describe("parseConfig", () => {
 		expect(c.webhookSecret).toBe("s3cr3t")
 		expect(c.chainId).toBe(80451) // mainnet default
 		expect(c.spaceRegistryAddress).toBe(`0x${"b".repeat(40)}`)
-		expect([...c.autoacceptSpaceIds]).toEqual(["d4f5a6b7-0000-0000-0000-000000000000"])
+		// Allowlist is canonicalized to 0x bytes16 (the dashed UUID's dashless form).
+		expect([...c.autoacceptSpaceIds]).toEqual(["0xd4f5a6b7000000000000000000000000"])
 	})
 
 	test("adds the 0x prefix to a bare private key", () => {
@@ -31,9 +32,23 @@ describe("parseConfig", () => {
 		expect(c.acceptorPrivateKey).toBe(`0x${"1".repeat(64)}`)
 	})
 
-	test("lowercases and de-duplicates the allowlist, dropping blanks", () => {
-		const c = parseConfig({...validEnv(), MEMBERSHIP_AUTOACCEPT_SPACE_IDS: " AAA , aaa ,, BBB "})
-		expect([...c.autoacceptSpaceIds].sort()).toEqual(["aaa", "bbb"])
+	test("canonicalizes, de-duplicates, and drops blanks in the allowlist", () => {
+		// Same space in 0x-upper, dashless-lower, and dashed-UUID forms → one entry;
+		// plus a distinct space. All canonicalize to 0x bytes16.
+		const dupA0x = `0x${"A".repeat(32)}`
+		const dupADashless = "a".repeat(32)
+		const distinctUuid = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+		const c = parseConfig({
+			...validEnv(),
+			MEMBERSHIP_AUTOACCEPT_SPACE_IDS: ` ${dupA0x} , ${dupADashless} ,, ${distinctUuid} `,
+		})
+		expect([...c.autoacceptSpaceIds].sort()).toEqual([`0x${"a".repeat(32)}`, `0x${"b".repeat(32)}`])
+	})
+
+	test("throws on an allowlist entry that isn't a valid space id", () => {
+		expect(() => parseConfig({...validEnv(), MEMBERSHIP_AUTOACCEPT_SPACE_IDS: "not-a-real-id"})).toThrow(
+			ConfigError,
+		)
 	})
 
 	test("an empty allowlist is allowed (kill switch)", () => {

--- a/membership-acceptor/tests/contracts.test.ts
+++ b/membership-acceptor/tests/contracts.test.ts
@@ -6,6 +6,7 @@ import {
 	isRevert,
 	padBytes16ToBytes32,
 	sanitizeError,
+	toBytes16Hex,
 	uuidToBytes16,
 	VOTE_YES,
 } from "../src/contracts.js"
@@ -17,6 +18,22 @@ describe("uuidToBytes16", () => {
 
 	test("throws on a non-UUID", () => {
 		expect(() => uuidToBytes16("not-a-uuid")).toThrow()
+	})
+})
+
+describe("toBytes16Hex", () => {
+	test("converts a dashed UUID to 0x bytes16", () => {
+		expect(toBytes16Hex("c9f267dc-b0d2-7071-8c2a-3c45a64afd32")).toBe("0xc9f267dcb0d270718c2a3c45a64afd32")
+	})
+
+	test("is idempotent on an already-0x bytes16 (lowercased)", () => {
+		expect(toBytes16Hex("0xC9F267DCB0D270718C2A3C45A64AFD32")).toBe("0xc9f267dcb0d270718c2a3c45a64afd32")
+	})
+
+	test("a dashed UUID and its 0x form canonicalize equal", () => {
+		expect(toBytes16Hex("c9f267dc-b0d2-7071-8c2a-3c45a64afd32")).toBe(
+			toBytes16Hex("0xc9f267dcb0d270718c2a3c45a64afd32"),
+		)
 	})
 })
 
@@ -65,14 +82,29 @@ describe("isRevert", () => {
 		expect(isRevert(new Error("wrap", {cause}))).toBe(true)
 	})
 
-	test("true on message patterns", () => {
+	test("true on definite revert message patterns", () => {
 		expect(isRevert(new Error("execution reverted: CanNotVote"))).toBe(true)
-		expect(isRevert("UserOperation reverted")).toBe(true)
+		expect(isRevert(new Error("ProposalAlreadyExecuted()"))).toBe(true)
+		expect(isRevert(new Error("reverted with AlreadyVoted"))).toBe(true)
 	})
 
 	test("false for plain infrastructure errors", () => {
 		expect(isRevert(new Error("ECONNREFUSED"))).toBe(false)
 		expect(isRevert(new Error("fetch failed"))).toBe(false)
+	})
+
+	test("false for the broad execution/call wrappers (not necessarily reverts)", () => {
+		// These wrap RPC/estimation failures too, so they must NOT be auto-benign.
+		const exec = new Error("call failed")
+		exec.name = "ContractFunctionExecutionError"
+		expect(isRevert(exec)).toBe(false)
+
+		const call = new Error("call failed")
+		call.name = "CallExecutionError"
+		expect(isRevert(call)).toBe(false)
+
+		// A bare "UserOperation reverted" with no revert reason is ambiguous → infra.
+		expect(isRevert(new Error("UserOperation reverted"))).toBe(false)
 	})
 })
 

--- a/membership-acceptor/tests/contracts.test.ts
+++ b/membership-acceptor/tests/contracts.test.ts
@@ -1,0 +1,85 @@
+import {describe, expect, test} from "bun:test"
+
+import {
+	encodeVoteData,
+	getChain,
+	isRevert,
+	padBytes16ToBytes32,
+	sanitizeError,
+	uuidToBytes16,
+	VOTE_YES,
+} from "../src/contracts.js"
+
+describe("uuidToBytes16", () => {
+	test("strips dashes and 0x-prefixes", () => {
+		expect(uuidToBytes16("550e8400-e29b-41d4-a716-446655440000")).toBe("0x550e8400e29b41d4a716446655440000")
+	})
+
+	test("throws on a non-UUID", () => {
+		expect(() => uuidToBytes16("not-a-uuid")).toThrow()
+	})
+})
+
+describe("padBytes16ToBytes32", () => {
+	test("right-pads a bytes16 to bytes32 with zeros", () => {
+		expect(padBytes16ToBytes32("0x550e8400e29b41d4a716446655440000")).toBe(
+			`0x550e8400e29b41d4a716446655440000${"0".repeat(32)}`,
+		)
+	})
+
+	test("throws when not 32 hex chars", () => {
+		expect(() => padBytes16ToBytes32("0x1234")).toThrow()
+	})
+})
+
+describe("encodeVoteData", () => {
+	test("encodes (bytes16 proposalId, uint8 YES) as two abi words", () => {
+		const encoded = encodeVoteData("0x550e8400e29b41d4a716446655440000", VOTE_YES)
+		// 2 × 32-byte words = 128 hex chars after 0x.
+		expect(encoded).toHaveLength(2 + 128)
+		// Word 1: bytes16 left-aligned (value then 16 zero bytes).
+		expect(encoded.startsWith("0x550e8400e29b41d4a716446655440000")).toBe(true)
+		// Word 2: uint8 right-aligned → all zeros except the final byte = 0x01 (YES).
+		const voteWord = encoded.slice(2 + 64)
+		expect(voteWord).toBe(`${"0".repeat(63)}1`)
+	})
+})
+
+describe("getChain", () => {
+	test("maps the supported chain ids", () => {
+		expect(getChain(80451).id).toBe(80451)
+		expect(getChain(19411).id).toBe(19411)
+	})
+})
+
+describe("isRevert", () => {
+	test("true for known revert error names", () => {
+		const e = new Error("boom")
+		e.name = "ContractFunctionRevertedError"
+		expect(isRevert(e)).toBe(true)
+	})
+
+	test("true when the cause is a revert", () => {
+		const cause = new Error("reverted")
+		cause.name = "ContractFunctionRevertedError"
+		expect(isRevert(new Error("wrap", {cause}))).toBe(true)
+	})
+
+	test("true on message patterns", () => {
+		expect(isRevert(new Error("execution reverted: CanNotVote"))).toBe(true)
+		expect(isRevert("UserOperation reverted")).toBe(true)
+	})
+
+	test("false for plain infrastructure errors", () => {
+		expect(isRevert(new Error("ECONNREFUSED"))).toBe(false)
+		expect(isRevert(new Error("fetch failed"))).toBe(false)
+	})
+})
+
+describe("sanitizeError", () => {
+	test("redacts a bundler apikey", () => {
+		const msg = sanitizeError(new Error("https://api.pimlico.io/v2/80451/rpc?apikey=pim_secret failed"))
+		expect(msg).toContain("apikey=<redacted>")
+		expect(msg).not.toContain("pim_secret")
+	})
+})

--- a/membership-acceptor/tests/detect.test.ts
+++ b/membership-acceptor/tests/detect.test.ts
@@ -110,6 +110,31 @@ describe("SeenProposals", () => {
 		expect(seen.seen("p2")).toBe(true)
 	})
 
+	test("unmark lets an id be processed again", () => {
+		const seen = new SeenProposals()
+		expect(seen.seen("p1")).toBe(false)
+		expect(seen.seen("p1")).toBe(true)
+		seen.unmark("p1")
+		expect(seen.seen("p1")).toBe(false) // forgotten → first sighting again
+		expect(seen.seen("p1")).toBe(true)
+	})
+
+	test("unmark of an unknown id is a no-op", () => {
+		const seen = new SeenProposals()
+		seen.unmark("never-seen")
+		expect(seen.seen("never-seen")).toBe(false)
+	})
+
+	test("unmark frees the capacity slot (no phantom eviction)", () => {
+		const seen = new SeenProposals(2)
+		expect(seen.seen("a")).toBe(false)
+		expect(seen.seen("b")).toBe(false)
+		seen.unmark("a") // {b}
+		expect(seen.seen("c")).toBe(false) // {b,c} — within capacity, nothing evicted
+		expect(seen.seen("b")).toBe(true)
+		expect(seen.seen("c")).toBe(true)
+	})
+
 	test("evicts oldest ids beyond capacity (FIFO)", () => {
 		const seen = new SeenProposals(2)
 		expect(seen.seen("a")).toBe(false) // {a}

--- a/membership-acceptor/tests/graphql.test.ts
+++ b/membership-acceptor/tests/graphql.test.ts
@@ -1,0 +1,62 @@
+import {afterEach, describe, expect, test} from "bun:test"
+
+import {createGraphQLClient, GraphQLError} from "../src/graphql.js"
+
+const realFetch = globalThis.fetch
+
+afterEach(() => {
+	globalThis.fetch = realFetch
+})
+
+function mockFetch(impl: (url: string, init: RequestInit) => Promise<Response> | Response) {
+	// biome-ignore lint/suspicious/noExplicitAny: test seam for the global fetch
+	globalThis.fetch = ((url: any, init: any) => Promise.resolve(impl(String(url), init))) as typeof fetch
+}
+
+const client = createGraphQLClient({endpoint: "https://api.example/graphql"})
+
+describe("createGraphQLClient", () => {
+	test("posts the query and returns data", async () => {
+		let capturedUrl = ""
+		mockFetch((url) => {
+			capturedUrl = url
+			return new Response(JSON.stringify({data: {editor: {memberSpaceId: "abc"}}}), {status: 200})
+		})
+
+		const data = await client.query<{editor: {memberSpaceId: string} | null}>("query { editor { memberSpaceId } }")
+		expect(data.editor?.memberSpaceId).toBe("abc")
+		expect(capturedUrl).toBe("https://api.example/graphql")
+	})
+
+	test("passes variables through", async () => {
+		let sentVars: unknown
+		mockFetch((_url, init) => {
+			sentVars = (JSON.parse(String(init.body)) as {variables: unknown}).variables
+			return new Response(JSON.stringify({data: {ok: true}}), {status: 200})
+		})
+		await client.query("query($x: String!){ ok }", {x: "y"})
+		expect(sentVars).toEqual({x: "y"})
+	})
+
+	test("throws GraphQLError on a non-empty errors array", async () => {
+		mockFetch(() => new Response(JSON.stringify({errors: [{message: "boom"}]}), {status: 200}))
+		await expect(client.query("query { x }")).rejects.toThrow(GraphQLError)
+	})
+
+	test("throws GraphQLError on an HTTP error", async () => {
+		mockFetch(() => new Response("nope", {status: 500, statusText: "Server Error"}))
+		await expect(client.query("query { x }")).rejects.toThrow(GraphQLError)
+	})
+
+	test("throws GraphQLError when data is absent", async () => {
+		mockFetch(() => new Response(JSON.stringify({}), {status: 200}))
+		await expect(client.query("query { x }")).rejects.toThrow(GraphQLError)
+	})
+
+	test("throws GraphQLError on a network failure", async () => {
+		mockFetch(() => {
+			throw new Error("ECONNREFUSED")
+		})
+		await expect(client.query("query { x }")).rejects.toThrow(GraphQLError)
+	})
+})

--- a/membership-acceptor/tests/policy.test.ts
+++ b/membership-acceptor/tests/policy.test.ts
@@ -1,0 +1,78 @@
+import {describe, expect, test} from "bun:test"
+
+import type {MembershipRequest} from "../src/detect.js"
+import type {GraphQLClient} from "../src/graphql.js"
+import {composePolicies, editorPolicy, type Policy, type PolicyContext} from "../src/policy.js"
+
+const REQUEST: MembershipRequest = {
+	proposalId: "c3e4f5a6-0000-0000-0000-000000000000",
+	spaceId: "a19c345a-b986-6679-b001-d7d2138d88a1",
+	requesterSpaceId: "1310f810-454c-d482-e35c-e81cb86ca383",
+}
+const ACCEPTOR_SPACE_ID = `0x${"a".repeat(32)}`
+
+/** A GraphQL client whose `query` is stubbed. */
+function graphqlReturning(impl: (query: string) => unknown): GraphQLClient {
+	return {query: async (query: string) => impl(query) as never}
+}
+
+function ctxWith(graphql: GraphQLClient): PolicyContext {
+	return {graphql, acceptorSpaceId: ACCEPTOR_SPACE_ID}
+}
+
+describe("editorPolicy", () => {
+	test("accepts when the editor query returns a record", async () => {
+		const graphql = graphqlReturning(() => ({editor: {memberSpaceId: "a".repeat(32)}}))
+		const decision = await editorPolicy(REQUEST, ctxWith(graphql))
+		expect(decision.accept).toBe(true)
+	})
+
+	test("denies when the editor query returns null", async () => {
+		const graphql = graphqlReturning(() => ({editor: null}))
+		const decision = await editorPolicy(REQUEST, ctxWith(graphql))
+		expect(decision.accept).toBe(false)
+	})
+
+	test("inlines spaceId as-is and the acceptor id with 0x stripped", async () => {
+		let sentQuery = ""
+		const graphql = graphqlReturning((q) => {
+			sentQuery = q
+			return {editor: {memberSpaceId: "x"}}
+		})
+		await editorPolicy(REQUEST, ctxWith(graphql))
+		expect(sentQuery).toContain('spaceId: "a19c345a-b986-6679-b001-d7d2138d88a1"') // dashed, as-is
+		expect(sentQuery).toContain(`memberSpaceId: "${"a".repeat(32)}"`) // 0x stripped
+	})
+
+	test("fails OPEN when the query throws (API error)", async () => {
+		const graphql = graphqlReturning(() => {
+			throw new Error("api down")
+		})
+		const decision = await editorPolicy(REQUEST, ctxWith(graphql))
+		expect(decision.accept).toBe(true)
+		expect(decision.reason).toContain("editor check skipped")
+	})
+})
+
+describe("composePolicies", () => {
+	const accept: Policy = async () => ({accept: true, reason: "yes"})
+
+	test("accepts only when every policy accepts", async () => {
+		const decision = await composePolicies(accept, accept)(REQUEST, ctxWith(graphqlReturning(() => ({}))))
+		expect(decision.accept).toBe(true)
+	})
+
+	test("short-circuits on the first denial", async () => {
+		let secondRan = false
+		const trackingDeny: Policy = async () => {
+			return {accept: false, reason: "first"}
+		}
+		const tracking: Policy = async () => {
+			secondRan = true
+			return {accept: true, reason: "second"}
+		}
+		const decision = await composePolicies(trackingDeny, tracking)(REQUEST, ctxWith(graphqlReturning(() => ({}))))
+		expect(decision).toEqual({accept: false, reason: "first"})
+		expect(secondRan).toBe(false)
+	})
+})

--- a/membership-acceptor/tests/server.test.ts
+++ b/membership-acceptor/tests/server.test.ts
@@ -1,13 +1,47 @@
 import {describe, expect, test} from "bun:test"
 import {createHmac} from "node:crypto"
 
-import type {AcceptorConfig} from "../src/config.js"
+import type {AppConfig} from "../src/config.js"
 import {createApp} from "../src/server.js"
+import type {Acceptor, VoteResult} from "../src/vote.js"
 
-const config: AcceptorConfig = {port: 8080, webhookSecret: "test-secret-0123456789abcdef"}
-const app = createApp(config)
+const SECRET = "test-secret-0123456789abcdef"
+const ALLOWED_SPACE = "d4f5a6b7-0000-0000-0000-000000000000"
 
-function sign(body: string, secret = config.webhookSecret): string {
+const baseConfig: AppConfig = {
+	port: 8080,
+	webhookSecret: SECRET,
+	acceptorPrivateKey: `0x${"1".repeat(64)}`,
+	acceptorSpaceId: `0x${"a".repeat(32)}`,
+	spaceRegistryAddress: `0x${"b".repeat(40)}`,
+	rpcUrl: "http://rpc.test",
+	pimlicoApiKey: "pim_test",
+	chainId: 80451,
+	graphqlEndpoint: "https://api.test/graphql",
+	autoacceptSpaceIds: new Set([ALLOWED_SPACE]),
+}
+
+/** A stub acceptor that records vote calls and returns configurable decisions/results. */
+function stubAcceptor(opts: {allows?: (s: string) => boolean; accept?: boolean; result?: VoteResult} = {}) {
+	const calls: string[] = []
+	const evaluated: string[] = []
+	const acceptor: Acceptor = {
+		allowsSpace: opts.allows ?? ((s) => baseConfig.autoacceptSpaceIds.has(s.toLowerCase())),
+		evaluate: async (req) => {
+			evaluated.push(req.proposalId)
+			return opts.accept === false
+				? {accept: false, reason: "denied by test policy"}
+				: {accept: true, reason: "ok"}
+		},
+		vote: async (req) => {
+			calls.push(req.proposalId)
+			return opts.result ?? {kind: "voted", txHash: "0xabc"}
+		},
+	}
+	return {acceptor, calls, evaluated}
+}
+
+function sign(body: string, secret = SECRET): string {
 	return "sha256=" + createHmac("sha256", secret).update(Buffer.from(body)).digest("hex")
 }
 
@@ -17,92 +51,133 @@ function webhookRequest(body: string, signature: string | null): Request {
 	return new Request("http://localhost:8080/webhooks/geo", {method: "POST", headers, body})
 }
 
-const SAMPLE = JSON.stringify({
+const NON_MEMBERSHIP = JSON.stringify({
 	version: 1,
 	event_type: "proposal_created",
 	category: "governance",
-	space_id: "d4f5a6b7-0000-0000-0000-000000000000",
+	space_id: ALLOWED_SPACE,
 	proposal_id: "c3e4f5a6-0000-0000-0000-000000000000",
 	idempotency_key: "12345:0:proposal_created:b2c3d4e5",
 })
 
+function membershipBody(proposalId = "c3e4f5a6-0000-0000-0000-000000000000", spaceId = ALLOWED_SPACE): string {
+	return JSON.stringify({
+		event_type: "proposal_created",
+		category: "governance",
+		space_id: spaceId,
+		proposal_id: proposalId,
+		voting_mode: "fast",
+		actions: [{type: "add_member", target_address: "a1b2c3d4-0000-0000-0000-000000000000"}],
+	})
+}
+
 describe("GET /health", () => {
 	test("returns 200 ok", async () => {
-		const res = await app(new Request("http://localhost:8080/health"))
+		const {acceptor} = stubAcceptor()
+		const res = await createApp(baseConfig, acceptor)(new Request("http://localhost:8080/health"))
 		expect(res.status).toBe(200)
 		expect(await res.json()).toEqual({status: "ok"})
 	})
 })
 
-describe("POST /webhooks/geo", () => {
-	test("accepts a correctly signed payload", async () => {
-		const res = await app(webhookRequest(SAMPLE, sign(SAMPLE)))
-		expect(res.status).toBe(200)
-		expect(await res.json()).toEqual({status: "ok"})
-	})
-
+describe("POST /webhooks/geo — signature & parsing", () => {
 	test("rejects an invalid signature with 401", async () => {
-		const res = await app(webhookRequest(SAMPLE, sign(SAMPLE, "wrong-secret")))
+		const {acceptor} = stubAcceptor()
+		const res = await createApp(baseConfig, acceptor)(webhookRequest(NON_MEMBERSHIP, sign(NON_MEMBERSHIP, "wrong")))
 		expect(res.status).toBe(401)
 	})
 
 	test("rejects a missing signature with 401", async () => {
-		const res = await app(webhookRequest(SAMPLE, null))
+		const {acceptor} = stubAcceptor()
+		const res = await createApp(baseConfig, acceptor)(webhookRequest(NON_MEMBERSHIP, null))
 		expect(res.status).toBe(401)
 	})
 
 	test("rejects a signed-but-non-JSON body with 400", async () => {
-		const body = "not json"
-		const res = await app(webhookRequest(body, sign(body)))
+		const {acceptor} = stubAcceptor()
+		const res = await createApp(baseConfig, acceptor)(webhookRequest("not json", sign("not json")))
 		expect(res.status).toBe(400)
 	})
 
-	test("rejects a tampered body with 401 (signature no longer matches)", async () => {
-		const signature = sign(SAMPLE)
-		const tampered = SAMPLE.replace("proposal_created", "proposal_executed")
-		const res = await app(webhookRequest(tampered, signature))
-		expect(res.status).toBe(401)
-	})
-
-	test("accepts and acks a membership-request payload (M2 detection path)", async () => {
-		const membership = JSON.stringify({
-			version: 1,
-			event_type: "proposal_created",
-			category: "governance",
-			space_id: "d4f5a6b7-0000-0000-0000-000000000000",
-			proposal_id: "c3e4f5a6-0000-0000-0000-000000000000",
-			voting_mode: "fast",
-			actions: [{type: "add_member", target_address: "0x1234"}],
-		})
-		const res = await app(webhookRequest(membership, sign(membership)))
+	test("acks a non-membership event with 200 and does not vote", async () => {
+		const {acceptor, calls} = stubAcceptor()
+		const res = await createApp(baseConfig, acceptor)(webhookRequest(NON_MEMBERSHIP, sign(NON_MEMBERSHIP)))
 		expect(res.status).toBe(200)
-		expect(await res.json()).toEqual({status: "ok"})
+		expect(calls).toHaveLength(0)
+	})
+})
+
+describe("POST /webhooks/geo — membership voting", () => {
+	test("votes once on a valid membership request and acks 200", async () => {
+		const {acceptor, calls} = stubAcceptor()
+		const body = membershipBody()
+		const res = await createApp(baseConfig, acceptor)(webhookRequest(body, sign(body)))
+		expect(res.status).toBe(200)
+		expect(calls).toEqual(["c3e4f5a6-0000-0000-0000-000000000000"])
 	})
 
-	test("acks a duplicate membership delivery with 200 (deduped, no error)", async () => {
-		const membership = JSON.stringify({
-			event_type: "proposal_created",
-			space_id: "d4f5a6b7-0000-0000-0000-000000000000",
-			proposal_id: "dupe-proposal-id",
-			voting_mode: "fast",
-			actions: [{type: "add_member", target_address: "0x1234"}],
-		})
-		const sig = sign(membership)
-		const first = await app(webhookRequest(membership, sig))
-		const second = await app(webhookRequest(membership, sig))
-		expect(first.status).toBe(200)
-		expect(second.status).toBe(200)
+	test("ignores a request for a space not in the allowlist (no vote)", async () => {
+		const {acceptor, calls} = stubAcceptor()
+		const body = membershipBody("c3e4f5a6-0000-0000-0000-000000000000", "ffffffff-0000-0000-0000-000000000000")
+		const res = await createApp(baseConfig, acceptor)(webhookRequest(body, sign(body)))
+		expect(res.status).toBe(200)
+		expect(calls).toHaveLength(0)
+	})
+
+	test("dedupes duplicate deliveries — votes once across N copies", async () => {
+		const {acceptor, calls} = stubAcceptor()
+		const app = createApp(baseConfig, acceptor)
+		const body = membershipBody()
+		const sig = sign(body)
+		await app(webhookRequest(body, sig))
+		await app(webhookRequest(body, sig))
+		await app(webhookRequest(body, sig))
+		expect(calls).toHaveLength(1)
+	})
+
+	test("policy denial acks 200 and does not vote", async () => {
+		const {acceptor, calls, evaluated} = stubAcceptor({accept: false})
+		const body = membershipBody()
+		const res = await createApp(baseConfig, acceptor)(webhookRequest(body, sign(body)))
+		expect(res.status).toBe(200)
+		expect(evaluated).toHaveLength(1) // policy was consulted
+		expect(calls).toHaveLength(0) // but no vote
+	})
+
+	test("benign on-chain rejection acks 200 (no retry)", async () => {
+		const {acceptor} = stubAcceptor({result: {kind: "benign", message: "already voted"}})
+		const body = membershipBody()
+		const res = await createApp(baseConfig, acceptor)(webhookRequest(body, sign(body)))
+		expect(res.status).toBe(200)
+	})
+
+	test("infra failure returns 5xx and a retry re-votes (dedupe rolled back)", async () => {
+		const {acceptor, calls} = stubAcceptor({result: {kind: "infra", message: "rpc down"}})
+		const app = createApp(baseConfig, acceptor)
+		const body = membershipBody()
+		const sig = sign(body)
+		const first = await app(webhookRequest(body, sig))
+		const second = await app(webhookRequest(body, sig))
+		expect(first.status).toBe(503)
+		expect(second.status).toBe(503)
+		// Both attempts actually reached the vote (the failed mark was rolled back).
+		expect(calls).toHaveLength(2)
 	})
 })
 
 describe("unknown routes", () => {
 	test("GET / returns 404", async () => {
-		const res = await app(new Request("http://localhost:8080/"))
+		const {acceptor} = stubAcceptor()
+		const res = await createApp(baseConfig, acceptor)(new Request("http://localhost:8080/"))
 		expect(res.status).toBe(404)
 	})
 
 	test("wrong method on /webhooks/geo returns 404", async () => {
-		const res = await app(new Request("http://localhost:8080/webhooks/geo", {method: "GET"}))
+		const {acceptor} = stubAcceptor()
+		const res = await createApp(
+			baseConfig,
+			acceptor,
+		)(new Request("http://localhost:8080/webhooks/geo", {method: "GET"}))
 		expect(res.status).toBe(404)
 	})
 })

--- a/membership-acceptor/tests/vote.test.ts
+++ b/membership-acceptor/tests/vote.test.ts
@@ -1,5 +1,6 @@
 import {describe, expect, test} from "bun:test"
 
+import {toBytes16Hex} from "../src/contracts.js"
 import type {MembershipRequest} from "../src/detect.js"
 import type {GraphQLClient} from "../src/graphql.js"
 import type {Policy} from "../src/policy.js"
@@ -31,7 +32,7 @@ function acceptorWith(send: () => Promise<string>, allowlist = [REQUEST.spaceId]
 		wallet: fakeWallet(send),
 		acceptorSpaceId: `0x${"a".repeat(32)}`,
 		spaceRegistryAddress: `0x${"b".repeat(40)}`,
-		allowlist: new Set(allowlist.map((s) => s.toLowerCase())),
+		allowlist: new Set(allowlist.map(toBytes16Hex)),
 		policy,
 		graphql: noopGraphql,
 	})

--- a/membership-acceptor/tests/vote.test.ts
+++ b/membership-acceptor/tests/vote.test.ts
@@ -1,0 +1,103 @@
+import {describe, expect, test} from "bun:test"
+
+import type {MembershipRequest} from "../src/detect.js"
+import type {GraphQLClient} from "../src/graphql.js"
+import type {Policy} from "../src/policy.js"
+import {createAcceptor} from "../src/vote.js"
+import type {SmartWallet} from "../src/wallet.js"
+
+const noopGraphql: GraphQLClient = {query: async () => ({}) as never}
+const acceptAll: Policy = async () => ({accept: true, reason: "ok"})
+
+const REQUEST: MembershipRequest = {
+	proposalId: "c3e4f5a6-0000-0000-0000-000000000000",
+	spaceId: "d4f5a6b7-0000-0000-0000-000000000000",
+	requesterSpaceId: "a1b2c3d4-0000-0000-0000-000000000000",
+}
+
+/** Build a SmartWallet whose sendTransaction is stubbed by `send`. */
+function fakeWallet(send: () => Promise<string>): SmartWallet {
+	return {
+		// biome-ignore lint/suspicious/noExplicitAny: minimal stub of the smart account client
+		smartAccountClient: {account: {address: "0xacct"}, sendTransaction: send} as any,
+		// biome-ignore lint/suspicious/noExplicitAny: chain shape is irrelevant to the test
+		chain: {id: 80451} as any,
+		safeAddress: "0xsafe",
+	}
+}
+
+function acceptorWith(send: () => Promise<string>, allowlist = [REQUEST.spaceId], policy: Policy = acceptAll) {
+	return createAcceptor({
+		wallet: fakeWallet(send),
+		acceptorSpaceId: `0x${"a".repeat(32)}`,
+		spaceRegistryAddress: `0x${"b".repeat(40)}`,
+		allowlist: new Set(allowlist.map((s) => s.toLowerCase())),
+		policy,
+		graphql: noopGraphql,
+	})
+}
+
+describe("allowsSpace", () => {
+	test("matches allowlisted spaces case-insensitively", () => {
+		const a = acceptorWith(async () => "0x", [REQUEST.spaceId.toUpperCase()])
+		expect(a.allowsSpace(REQUEST.spaceId)).toBe(true)
+		expect(a.allowsSpace("ffffffff-0000-0000-0000-000000000000")).toBe(false)
+	})
+
+	test("empty allowlist allows nothing", () => {
+		const a = acceptorWith(async () => "0x", [])
+		expect(a.allowsSpace(REQUEST.spaceId)).toBe(false)
+	})
+})
+
+describe("evaluate", () => {
+	test("delegates to the configured policy with the acceptor's space id", async () => {
+		let seenMember = ""
+		const policy: Policy = async (_req, ctx) => {
+			seenMember = ctx.acceptorSpaceId
+			return {accept: false, reason: "nope"}
+		}
+		const a = acceptorWith(async () => "0x", [REQUEST.spaceId], policy)
+		const decision = await a.evaluate(REQUEST)
+		expect(decision).toEqual({accept: false, reason: "nope"})
+		expect(seenMember).toBe(`0x${"a".repeat(32)}`)
+	})
+})
+
+describe("vote", () => {
+	test("returns voted with the tx hash on success", async () => {
+		const a = acceptorWith(async () => "0xdeadbeef")
+		const result = await a.vote(REQUEST)
+		expect(result).toEqual({kind: "voted", txHash: "0xdeadbeef"})
+	})
+
+	test("classifies an on-chain revert as benign", async () => {
+		const a = acceptorWith(async () => {
+			const e = new Error("execution reverted: CanNotVote")
+			e.name = "ContractFunctionRevertedError"
+			throw e
+		})
+		const result = await a.vote(REQUEST)
+		expect(result.kind).toBe("benign")
+	})
+
+	test("classifies an RPC/bundler failure as infra", async () => {
+		const a = acceptorWith(async () => {
+			throw new Error("fetch failed: ECONNREFUSED")
+		})
+		const result = await a.vote(REQUEST)
+		expect(result.kind).toBe("infra")
+	})
+
+	test("redacts an apikey leaked in an error message", async () => {
+		const a = acceptorWith(async () => {
+			throw new Error("https://api.pimlico.io/v2/80451/rpc?apikey=pim_secret down")
+		})
+		const result = await a.vote(REQUEST)
+		expect(result.kind).toBe("infra")
+		if (result.kind === "infra") {
+			expect(result.message).toContain("apikey=<redacted>")
+			expect(result.message).not.toContain("pim_secret")
+		}
+	})
+})


### PR DESCRIPTION
## What

Closes the loop on the acceptor: a detected, allowlisted membership request is now **voted YES on-chain**, admitting the member in real time. Adds an extensible, API-backed **policy layer** so a space can gate acceptance on custom rules.

This is **milestone 3 of 4** of the membership-acceptor stack. Stacked on #255 (M2); base is `feat/membership-acceptor`, diff is the M3 files only.

## Pipeline (cheap → expensive)

```
detect → WHITELIST (config Set, no I/O) → dedupe → POLICY (GraphQL) → vote → classify
```

Each gate filters before the next does any work, so the firehose is narrowed before we ever touch the API or the chain.

## The "simple" model (no on-chain pre-reads)

The contract is the source of truth, so there is no read-before-vote. We mark the proposal seen, run the policy, attempt the vote, and classify the result:

| Outcome | HTTP | Behavior |
|---|---|---|
| `voted` | `200` | YES landed; member admitted (fast-path threshold = 1 → AddMember executes in the same tx). |
| policy denied | `200` | Terminal for this proposal; ack so delivery stops. |
| `benign` (revert: already voted/executed/closed, or not an editor) | `200` | Nothing to retry. |
| `infra` (RPC/bundler failure) | `503` | Roll back the dedupe mark and signal a retry. |

This sidesteps the check-then-act race a read-before-vote design would have: a duplicate that slips past in-memory dedupe (restart, 2nd replica) just reverts on-chain → no double-admit. **Keep `replicas: 1`** — dedupe is per-process.

## Included

- **`vote.ts` / `wallet.ts` / `contracts.ts`** — cast `SpaceRegistry.enter(PROPOSAL_VOTED, Yes)` via a Pimlico-sponsored Safe smart account; classify the outcome (`isRevert` → benign vs. infra; bundler API key redacted from logs).
- **`policy.ts` / `graphql.ts`** — a `Policy = (request, ctx) => Promise<{accept, reason}>` seam with a thin GraphQL client in `ctx`. `composePolicies(...)` runs policies AND-wise (first denial wins). Ships **`editorPolicy`**, which confirms the acceptor is an editor of the target space and **fails open** (an API error/timeout never suppresses a vote — the chain stays the authority).
- **Whitelist** — `MEMBERSHIP_AUTOACCEPT_SPACE_IDS` gates which spaces are served, so the policy API is only hit for relevant proposals.
- **`SeenProposals.unmark()`** — supports the dedupe rollback on infra failure (mark before voting so the fan-out collapses to one attempt; roll back only when a retry should happen).
- **Config** — `ACCEPTOR_PRIVATE_KEY`, `ACCEPTOR_SPACE_ID`, `SPACE_REGISTRY_ADDRESS`, `RPC_URL`, `PIMLICO_API_KEY`, `CHAIN_ID`, `GRAPHQL_ENDPOINT` (fail-fast validation).

## Why not the SDK

The published `@geoprotocol/geo-sdk` voting helpers are hardcoded to testnet (`getSmartAccountWalletClient` → chain 19411 + a testnet bundler; `voteProposal` → testnet registry address), so they cannot drive a mainnet vote. The on-chain path is ported from `proposal-executor`'s proven viem implementation, parameterized by `chainId`. We can switch back if the SDK gains mainnet support.

## Operational prerequisite

The acceptor's Safe smart account (`ACCEPTOR_PRIVATE_KEY` / `ACCEPTOR_SPACE_ID`) must be an **editor** of every space in `MEMBERSHIP_AUTOACCEPT_SPACE_IDS`, or its votes revert (`benign`, logged loudly).

## Testing

- `bun run typecheck` ✓
- `bun run lint` (biome) ✓
- `bun test` — 86 tests ✓ (encoding + revert classification, GraphQL client error paths, editor policy incl. fail-open + id formatting, policy composition/short-circuit, vote classification + apikey redaction, dedupe + unmark, and the full server pipeline incl. whitelist/policy-deny/benign/infra paths)

## Follow-ups (not in this PR)

- M4: local e2e in `geo-e2e` (notification-service + acceptor in the stack, SDK-based proposal trigger, automated assertions).
- CI workflow to build/push the image and deploy.
- Automated **reject** (`vote: 'NO'`) — pending product/protocol confirmation of fast-path reject semantics.
