### PR TITLE
ci(membership-acceptor): add test, check, and deploy workflows

### DIFF
--- a/.github/workflows/membership-acceptor-check.yml
+++ b/.github/workflows/membership-acceptor-check.yml
@@ -32,7 +32,7 @@ jobs:
           bun-version: 1.3.9
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Check formatting
         run: bun run lint

--- a/.github/workflows/membership-acceptor-check.yml
+++ b/.github/workflows/membership-acceptor-check.yml
@@ -1,0 +1,41 @@
+name: Membership Acceptor Check
+
+on:
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - 'membership-acceptor/**'
+      - '.github/workflows/membership-acceptor-check.yml'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./membership-acceptor
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.9
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Check formatting
+        run: bun run lint
+
+      - name: Type check
+        run: bun run typecheck

--- a/.github/workflows/membership-acceptor-deploy.yml
+++ b/.github/workflows/membership-acceptor-deploy.yml
@@ -1,0 +1,68 @@
+name: Deploy Membership Acceptor (Production)
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'membership-acceptor/**'
+      - '.github/workflows/membership-acceptor-deploy.yml'
+
+concurrency:
+  group: membership-acceptor-production
+  cancel-in-progress: true
+
+env:
+  REGISTRY: registry.digitalocean.com/geo
+  IMAGE_NAME: membership-acceptor
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install doctl
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Log in to DigitalOcean Container Registry
+        run: doctl registry login --expiry-seconds 1200
+
+      - name: Build and push Docker image
+        run: |
+          docker build -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} \
+                       -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+                       -f membership-acceptor/Dockerfile membership-acceptor
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+
+      - name: Set up kubectl
+        uses: Azure/setup-kubectl@v5
+
+      - name: Configure kubectl for DigitalOcean
+        run: |
+          doctl kubernetes cluster kubeconfig save ${{ secrets.DIGITALOCEAN_CLUSTER_NAME }}
+
+      - name: Deploy to Kubernetes
+        run: |
+          # Pin the image to this commit's SHA and apply the Deployment + Service.
+          sed -i 's|image: registry.digitalocean.com/geo/membership-acceptor:latest|image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}|g' membership-acceptor/deployment/production/deployment.yaml
+          kubectl apply -f membership-acceptor/deployment/production/deployment.yaml
+
+      - name: Wait for rollout
+        run: kubectl rollout status deployment/membership-acceptor -n knowledge --timeout=120s
+
+      - name: Show deployment status
+        if: always()
+        run: |
+          echo "=== Membership Acceptor Deployment (Production) ==="
+          kubectl get deployment membership-acceptor -n knowledge || echo "Deployment not found"
+          echo ""
+          echo "=== Pods ==="
+          kubectl get pods -n knowledge -l app=membership-acceptor || echo "No pods found"
+          echo ""
+          echo "=== Recent Events ==="
+          kubectl get events -n knowledge --sort-by='.lastTimestamp' | tail -10

--- a/.github/workflows/membership-acceptor-tests.yml
+++ b/.github/workflows/membership-acceptor-tests.yml
@@ -32,7 +32,7 @@ jobs:
           bun-version: 1.3.9
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Run tests
         run: bun test

--- a/.github/workflows/membership-acceptor-tests.yml
+++ b/.github/workflows/membership-acceptor-tests.yml
@@ -1,0 +1,38 @@
+name: Membership Acceptor Tests
+
+on:
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - 'membership-acceptor/**'
+      - '.github/workflows/membership-acceptor-tests.yml'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./membership-acceptor
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.9
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run tests
+        run: bun test


### PR DESCRIPTION
## What

Adds CI for the `membership-acceptor` service, mirroring the workflows the other components (e.g. `proposal-executor`) already have. All three are path-filtered to `membership-acceptor/**` so they only run when the service changes.

| Workflow | Trigger | Does |
|---|---|---|
| `membership-acceptor-tests.yml` | PR → `main`/`dev` | `bun install` + `bun test` |
| `membership-acceptor-check.yml` | PR → `main`/`dev` | `bun install` + `bun run lint` (biome) + `bun run typecheck` |
| `membership-acceptor-deploy.yml` | push → `main` | build + push the image to the DO registry, pin it to the commit SHA, `kubectl apply` the Deployment + Service, and wait for rollout |

## Notes

- Tests + check gate every PR targeting `dev`/`main`; deploy runs only on merge to `main`.
- Deploy is adapted for this service vs. `proposal-executor`'s (which deploys a CronJob): it applies `deployment/production/deployment.yaml` (a Deployment + Service) and reports status via `kubectl rollout status` + `get pods -l app=membership-acceptor`. It reuses the existing `DIGITALOCEAN_ACCESS_TOKEN` / `DIGITALOCEAN_CLUSTER_NAME` secrets — no new CI secrets required.
- Bun version (1.3.9) matches the service's Dockerfile.

## Before the first deploy

The deploy job fires on merge to `main`. Before that, the `membership-acceptor-credentials` secret must exist in the `knowledge` namespace and the manifest's deployment values finalized, or the rollout will crash-loop on startup config validation. The tests/check workflows are side-effect-free.
