### PR TITLE
feat(notification-indexer): retention cleanup for outbox/deliveries (default 30d)

### DIFF
--- a/notification-service/notification-indexer/src/main.rs
+++ b/notification-service/notification-indexer/src/main.rs
@@ -141,6 +141,25 @@ async fn async_main() -> Result<(), IndexerError> {
         None => 86_400,
     };
 
+    // Rows deleted per batch by the retention task. Default 5000. Guard against
+    // <= 0: a non-positive LIMIT would make the drain loop never make progress
+    // (it stops when a batch deletes fewer than this many rows). Fall back to the
+    // default with a warning.
+    let retention_batch_size: i64 = match env::var("RETENTION_BATCH_SIZE")
+        .ok()
+        .and_then(|s| s.parse::<i64>().ok())
+    {
+        Some(v) if v > 0 => v,
+        Some(v) => {
+            warn!(
+                value = v,
+                "RETENTION_BATCH_SIZE must be a positive integer; using default 5000"
+            );
+            5_000
+        }
+        None => 5_000,
+    };
+
     let health_port: u16 = env::var("HEALTH_PORT")
         .ok()
         .and_then(|s| s.parse().ok())
@@ -352,10 +371,10 @@ async fn async_main() -> Result<(), IndexerError> {
         info!(
             retention_days = retention_days,
             interval_secs = retention_cleanup_interval_secs,
+            batch_size = retention_batch_size,
             "Retention cleanup enabled"
         );
         Some(tokio::spawn(async move {
-            const RETENTION_BATCH_SIZE: i64 = 5_000;
             let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(
                 retention_cleanup_interval_secs,
             ));
@@ -367,7 +386,7 @@ async fn async_main() -> Result<(), IndexerError> {
                     }
                     _ = interval.tick() => {
                         match retention_storage
-                            .delete_expired_notifications(retention_days, RETENTION_BATCH_SIZE)
+                            .delete_expired_notifications(retention_days, retention_batch_size)
                             .await
                         {
                             Ok((deliveries, outbox)) => {

--- a/notification-service/notification-indexer/src/main.rs
+++ b/notification-service/notification-indexer/src/main.rs
@@ -109,11 +109,18 @@ async fn async_main() -> Result<(), IndexerError> {
         .unwrap_or(60);
 
     // Retention: delete notification_outbox / notification_deliveries rows older
-    // than this many days. Default 30. Set to 0 to disable the cleanup task.
-    let retention_days: i32 = env::var("NOTIFICATION_RETENTION_DAYS")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(30);
+    // than this many days. Unset = default 30; 0 disables the cleanup task.
+    // Validate rather than silently default — a malformed value could mask a
+    // misconfig, and a NEGATIVE value would push the cutoff into the future and
+    // delete everything. Fail fast on anything that isn't a non-negative integer.
+    let retention_days: i32 = match env::var("NOTIFICATION_RETENTION_DAYS") {
+        Ok(s) => s.parse::<i32>().ok().filter(|&v| v >= 0).ok_or_else(|| {
+            IndexerError::Config(format!(
+                "NOTIFICATION_RETENTION_DAYS must be a non-negative integer (0 disables), got {s:?}"
+            ))
+        })?,
+        Err(_) => 30,
+    };
 
     // How often the retention cleanup task runs. Default 86400s (daily).
     // Guard against 0: tokio::time::interval panics on a zero period, and an

--- a/notification-service/notification-indexer/src/main.rs
+++ b/notification-service/notification-indexer/src/main.rs
@@ -108,6 +108,19 @@ async fn async_main() -> Result<(), IndexerError> {
         .and_then(|s| s.parse().ok())
         .unwrap_or(60);
 
+    // Retention: delete notification_outbox / notification_deliveries rows older
+    // than this many days. Default 30. Set to 0 to disable the cleanup task.
+    let retention_days: i32 = env::var("NOTIFICATION_RETENTION_DAYS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(30);
+
+    // How often the retention cleanup task runs. Default 86400s (daily).
+    let retention_cleanup_interval_secs: u64 = env::var("RETENTION_CLEANUP_INTERVAL_SECS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(86_400);
+
     let health_port: u16 = env::var("HEALTH_PORT")
         .ok()
         .and_then(|s| s.parse().ok())
@@ -219,6 +232,7 @@ async fn async_main() -> Result<(), IndexerError> {
     let mut shutdown_rx2 = shutdown_tx.subscribe();
     let mut shutdown_rx3 = shutdown_tx.subscribe();
     let mut shutdown_rx4 = shutdown_tx.subscribe();
+    let mut shutdown_rx5 = shutdown_tx.subscribe();
 
     let _signal_handle = tokio::spawn(async move {
         tokio::signal::ctrl_c().await.ok();
@@ -310,6 +324,52 @@ async fn async_main() -> Result<(), IndexerError> {
             }
         }
     });
+
+    // Spawn retention cleanup task: periodically delete notification rows older
+    // than the retention window, in batches. Disabled when retention_days == 0.
+    let retention_handle: Option<tokio::task::JoinHandle<()>> = if retention_days > 0 {
+        let retention_storage = Storage::new(storage.pool().clone());
+        info!(
+            retention_days = retention_days,
+            interval_secs = retention_cleanup_interval_secs,
+            "Retention cleanup enabled"
+        );
+        Some(tokio::spawn(async move {
+            const RETENTION_BATCH_SIZE: i64 = 5_000;
+            let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(
+                retention_cleanup_interval_secs,
+            ));
+            loop {
+                tokio::select! {
+                    _ = shutdown_rx5.recv() => {
+                        info!("Retention cleanup shutting down");
+                        break;
+                    }
+                    _ = interval.tick() => {
+                        match retention_storage
+                            .delete_expired_notifications(retention_days, RETENTION_BATCH_SIZE)
+                            .await
+                        {
+                            Ok((deliveries, outbox)) => {
+                                if deliveries > 0 || outbox > 0 {
+                                    info!(
+                                        deliveries_deleted = deliveries,
+                                        outbox_deleted = outbox,
+                                        retention_days = retention_days,
+                                        "Retention cleanup removed expired notifications"
+                                    );
+                                }
+                            }
+                            Err(e) => error!(error = %e, "Retention cleanup failed"),
+                        }
+                    }
+                }
+            }
+        }))
+    } else {
+        info!("Retention cleanup disabled (NOTIFICATION_RETENTION_DAYS=0)");
+        None
+    };
 
     // Spawn entity-vote-threshold poller task.
     //
@@ -1275,6 +1335,15 @@ async fn async_main() -> Result<(), IndexerError> {
             Ok(Ok(())) => info!("Vote poller stopped"),
             Ok(Err(e)) => warn!(error = %e, "Vote poller task failed"),
             Err(_) => warn!("Vote poller did not stop within 5s, aborting"),
+        }
+    }
+
+    // Wait for the retention cleanup task to finish (if enabled)
+    if let Some(handle) = retention_handle {
+        match tokio::time::timeout(tokio::time::Duration::from_secs(5), handle).await {
+            Ok(Ok(())) => info!("Retention cleanup stopped"),
+            Ok(Err(e)) => warn!(error = %e, "Retention cleanup task failed"),
+            Err(_) => warn!("Retention cleanup did not stop within 5s, aborting"),
         }
     }
 

--- a/notification-service/notification-indexer/src/main.rs
+++ b/notification-service/notification-indexer/src/main.rs
@@ -116,10 +116,23 @@ async fn async_main() -> Result<(), IndexerError> {
         .unwrap_or(30);
 
     // How often the retention cleanup task runs. Default 86400s (daily).
-    let retention_cleanup_interval_secs: u64 = env::var("RETENTION_CLEANUP_INTERVAL_SECS")
+    // Guard against 0: tokio::time::interval panics on a zero period, and an
+    // operator might set 0 expecting it to disable (the disable knob is actually
+    // NOTIFICATION_RETENTION_DAYS=0). Fall back to the default with a warning.
+    let retention_cleanup_interval_secs: u64 = match env::var("RETENTION_CLEANUP_INTERVAL_SECS")
         .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(86_400);
+        .and_then(|s| s.parse::<u64>().ok())
+    {
+        Some(0) => {
+            warn!(
+                "RETENTION_CLEANUP_INTERVAL_SECS=0 is invalid; using default 86400. \
+                     To disable retention cleanup, set NOTIFICATION_RETENTION_DAYS=0"
+            );
+            86_400
+        }
+        Some(v) => v,
+        None => 86_400,
+    };
 
     let health_port: u16 = env::var("HEALTH_PORT")
         .ok()

--- a/notification-service/notification-indexer/src/storage.rs
+++ b/notification-service/notification-indexer/src/storage.rs
@@ -660,6 +660,78 @@ impl Storage {
         Ok(expired)
     }
 
+    /// Delete notification rows older than `retention_days`, in batches of
+    /// `batch_size`, to enforce a retention window without long table locks.
+    ///
+    /// FK-safe order: `notification_deliveries` first (they reference
+    /// `notification_outbox`), then outbox rows past the window that no longer
+    /// have any delivery. Each table is drained in capped batches until a batch
+    /// removes fewer than `batch_size` rows. Returns
+    /// `(deliveries_deleted, outbox_deleted)`.
+    #[instrument(
+        name = "notification_indexer.storage.delete_expired_notifications",
+        skip(self),
+        fields(retention_days = retention_days, batch_size = batch_size)
+    )]
+    pub async fn delete_expired_notifications(
+        &self,
+        retention_days: i32,
+        batch_size: i64,
+    ) -> Result<(u64, u64), StorageError> {
+        // Deliveries first — they FK-reference notification_outbox.
+        let mut deliveries_deleted: u64 = 0;
+        loop {
+            let n = sqlx::query(
+                r#"
+                DELETE FROM notification_deliveries
+                WHERE id IN (
+                    SELECT id FROM notification_deliveries
+                    WHERE created_at < now() - make_interval(days => $1::int)
+                    LIMIT $2
+                )
+                "#,
+            )
+            .bind(retention_days)
+            .bind(batch_size)
+            .execute(&self.pool)
+            .await?
+            .rows_affected();
+            deliveries_deleted += n;
+            if (n as i64) < batch_size {
+                break;
+            }
+        }
+
+        // Then outbox rows past the window with no remaining delivery (FK-safe).
+        let mut outbox_deleted: u64 = 0;
+        loop {
+            let n = sqlx::query(
+                r#"
+                DELETE FROM notification_outbox
+                WHERE id IN (
+                    SELECT o.id FROM notification_outbox o
+                    WHERE o.created_at < now() - make_interval(days => $1::int)
+                      AND NOT EXISTS (
+                          SELECT 1 FROM notification_deliveries d WHERE d.outbox_id = o.id
+                      )
+                    LIMIT $2
+                )
+                "#,
+            )
+            .bind(retention_days)
+            .bind(batch_size)
+            .execute(&self.pool)
+            .await?
+            .rows_affected();
+            outbox_deleted += n;
+            if (n as i64) < batch_size {
+                break;
+            }
+        }
+
+        Ok((deliveries_deleted, outbox_deleted))
+    }
+
     // -----------------------------------------------------------------------
     // Enrichment lookups (best-effort — return None on failure)
     // -----------------------------------------------------------------------

--- a/notification-service/notification-indexer/src/storage.rs
+++ b/notification-service/notification-indexer/src/storage.rs
@@ -668,6 +668,14 @@ impl Storage {
     /// have any delivery. Each table is drained in capped batches until a batch
     /// removes fewer than `batch_size` rows. Returns
     /// `(deliveries_deleted, outbox_deleted)`.
+    ///
+    /// The pollers use the outbox as an idempotency ledger (the rejection poller
+    /// LEFT JOINs `proposal_rejected` rows; the vote poller checks an EXISTS on
+    /// `entity_votes_threshold` rows), and they re-derive from source tables on
+    /// every tick — so deleting those rows would re-emit. Those two event types
+    /// are therefore preserved. Kafka-sourced types are safe to prune: their
+    /// offsets are committed and events older than the min-age window are skipped,
+    /// so they are never re-processed.
     #[instrument(
         name = "notification_indexer.storage.delete_expired_notifications",
         skip(self),
@@ -711,6 +719,8 @@ impl Storage {
                 WHERE id IN (
                     SELECT o.id FROM notification_outbox o
                     WHERE o.created_at < now() - make_interval(days => $1::int)
+                      -- Preserve poller idempotency ledgers (see fn docs).
+                      AND o.event_type NOT IN ('proposal_rejected', 'entity_votes_threshold')
                       AND NOT EXISTS (
                           SELECT 1 FROM notification_deliveries d WHERE d.outbox_id = o.id
                       )

--- a/notification-service/notification-indexer/tests/retention.rs
+++ b/notification-service/notification-indexer/tests/retention.rs
@@ -29,12 +29,23 @@ CREATE TABLE notification_deliveries (
 
 /// Insert one outbox row (with an explicit age in days) and return its id.
 async fn seed_outbox(pool: &PgPool, key: &str, age_days: i64) -> uuid::Uuid {
+    seed_outbox_typed(pool, key, age_days, "proposal_created").await
+}
+
+/// Insert one outbox row of a given event_type and age; return its id.
+async fn seed_outbox_typed(
+    pool: &PgPool,
+    key: &str,
+    age_days: i64,
+    event_type: &str,
+) -> uuid::Uuid {
     let row = sqlx::query(
         "INSERT INTO notification_outbox (idempotency_key, event_type, created_at)
-         VALUES ($1, 'proposal_created', now() - make_interval(days => $2::int))
+         VALUES ($1, $2, now() - make_interval(days => $3::int))
          RETURNING id",
     )
     .bind(key)
+    .bind(event_type)
     .bind(age_days as i32)
     .fetch_one(pool)
     .await
@@ -95,6 +106,10 @@ async fn retention_deletes_old_rows_fk_safely() {
     seed_delivery(&pool, d, 0).await;
     // E: old outbox, no deliveries → removed.
     seed_outbox(&pool, "e", 40).await;
+    // F,G: old poller-ledger rows with no deliveries → KEPT (deleting them would
+    // let the rejection / vote-threshold pollers re-emit).
+    seed_outbox_typed(&pool, "f", 40, "proposal_rejected").await;
+    seed_outbox_typed(&pool, "g", 40, "entity_votes_threshold").await;
 
     // batch_size = 2 forces the drain loop to iterate more than once.
     let (deliveries_deleted, outbox_deleted) = storage
@@ -108,7 +123,7 @@ async fn retention_deletes_old_rows_fk_safely() {
     );
     assert_eq!(
         outbox_deleted, 3,
-        "old unreferenced outbox A,B,E removed (C kept; D kept — still referenced)"
+        "old unreferenced outbox A,B,E removed (C kept; D referenced; F,G are ledgers)"
     );
     assert_eq!(
         count(&pool, "notification_deliveries").await,
@@ -117,7 +132,7 @@ async fn retention_deletes_old_rows_fk_safely() {
     );
     assert_eq!(
         count(&pool, "notification_outbox").await,
-        2,
-        "C,D outbox remain"
+        4,
+        "C,D + ledger rows F,G remain"
     );
 }

--- a/notification-service/notification-indexer/tests/retention.rs
+++ b/notification-service/notification-indexer/tests/retention.rs
@@ -1,0 +1,123 @@
+//! Integration test for retention cleanup (`delete_expired_notifications`).
+//!
+//! Runs only when `NOTIF_TEST_DATABASE_URL` points at a throwaway Postgres
+//! (it DROPs/CREATEs the two tables it needs). Verifies the retention window,
+//! FK-safe delete order (deliveries before outbox), the "still-referenced
+//! outbox is kept" guard, and that batching drains everything.
+
+use notification_indexer::storage::Storage;
+use sqlx::{PgPool, Row};
+
+const SCHEMA: &str = r#"
+DROP TABLE IF EXISTS notification_deliveries;
+DROP TABLE IF EXISTS notification_outbox;
+CREATE TABLE notification_outbox (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    idempotency_key text NOT NULL UNIQUE,
+    event_type text NOT NULL,
+    payload jsonb NOT NULL DEFAULT '{}',
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE TABLE notification_deliveries (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    outbox_id uuid NOT NULL REFERENCES notification_outbox(id),
+    webhook_id uuid NOT NULL DEFAULT gen_random_uuid(),
+    status text NOT NULL DEFAULT 'pending',
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+"#;
+
+/// Insert one outbox row (with an explicit age in days) and return its id.
+async fn seed_outbox(pool: &PgPool, key: &str, age_days: i64) -> uuid::Uuid {
+    let row = sqlx::query(
+        "INSERT INTO notification_outbox (idempotency_key, event_type, created_at)
+         VALUES ($1, 'proposal_created', now() - make_interval(days => $2::int))
+         RETURNING id",
+    )
+    .bind(key)
+    .bind(age_days as i32)
+    .fetch_one(pool)
+    .await
+    .expect("insert outbox");
+    row.get("id")
+}
+
+async fn seed_delivery(pool: &PgPool, outbox_id: uuid::Uuid, age_days: i64) {
+    sqlx::query(
+        "INSERT INTO notification_deliveries (outbox_id, created_at)
+         VALUES ($1, now() - make_interval(days => $2::int))",
+    )
+    .bind(outbox_id)
+    .bind(age_days as i32)
+    .execute(pool)
+    .await
+    .expect("insert delivery");
+}
+
+async fn count(pool: &PgPool, table: &str) -> i64 {
+    let row = sqlx::query(&format!("SELECT count(*) AS c FROM {table}"))
+        .fetch_one(pool)
+        .await
+        .expect("count");
+    row.get::<i64, _>("c")
+}
+
+#[tokio::test]
+async fn retention_deletes_old_rows_fk_safely() {
+    let Ok(url) = std::env::var("NOTIF_TEST_DATABASE_URL") else {
+        eprintln!(
+            "skipping retention_deletes_old_rows_fk_safely: set NOTIF_TEST_DATABASE_URL to run"
+        );
+        return;
+    };
+
+    let storage = Storage::connect(&url).await.expect("connect");
+    let pool = storage.pool().clone();
+
+    for stmt in SCHEMA.split(';').map(str::trim).filter(|s| !s.is_empty()) {
+        sqlx::query(stmt)
+            .execute(&pool)
+            .await
+            .expect("apply schema");
+    }
+
+    // A,B: old outbox + old delivery → both removed.
+    let a = seed_outbox(&pool, "a", 40).await;
+    seed_delivery(&pool, a, 40).await;
+    let b = seed_outbox(&pool, "b", 40).await;
+    seed_delivery(&pool, b, 40).await;
+    // C: recent outbox + recent delivery → both kept.
+    let c = seed_outbox(&pool, "c", 0).await;
+    seed_delivery(&pool, c, 0).await;
+    // D: OLD outbox but a RECENT delivery → both kept (delivery survives the
+    // window, so the outbox is still referenced and must not be deleted).
+    let d = seed_outbox(&pool, "d", 40).await;
+    seed_delivery(&pool, d, 0).await;
+    // E: old outbox, no deliveries → removed.
+    seed_outbox(&pool, "e", 40).await;
+
+    // batch_size = 2 forces the drain loop to iterate more than once.
+    let (deliveries_deleted, outbox_deleted) = storage
+        .delete_expired_notifications(30, 2)
+        .await
+        .expect("retention cleanup");
+
+    assert_eq!(
+        deliveries_deleted, 2,
+        "old deliveries A,B removed (C,D survive)"
+    );
+    assert_eq!(
+        outbox_deleted, 3,
+        "old unreferenced outbox A,B,E removed (C kept; D kept — still referenced)"
+    );
+    assert_eq!(
+        count(&pool, "notification_deliveries").await,
+        2,
+        "C,D deliveries remain"
+    );
+    assert_eq!(
+        count(&pool, "notification_outbox").await,
+        2,
+        "C,D outbox remain"
+    );
+}


### PR DESCRIPTION
## What

`notification_outbox` and `notification_deliveries` previously grew **unbounded** — there is no `DELETE` anywhere in the notification services, and the outbox is already ~391k rows. This adds an in-process retention task (Option A) to the notification-indexer that prunes rows older than a configurable window.

## How

- **`Storage::delete_expired_notifications(retention_days, batch_size)`** — deletes `notification_deliveries` first, then `notification_outbox` rows past the window **with no remaining delivery** (FK-safe). Each table is drained in **capped batches** (loop until a batch removes `< batch_size`) to avoid long table locks. Returns `(deliveries_deleted, outbox_deleted)`.
- **Retention task** spawned alongside the rejection/vote pollers, gated on:
  - `NOTIFICATION_RETENTION_DAYS` (default **30**; `0` disables)
  - `RETENTION_CLEANUP_INTERVAL_SECS` (default **86400** / daily)
  - batch size 5000
  - graceful shutdown via the existing broadcast channel; logs counts only when non-zero.

## Tests

- `tests/retention.rs` (gated on `NOTIF_TEST_DATABASE_URL`): retention window, FK-safe ordering, the "old outbox kept because a recent delivery still references it" guard, and multi-batch draining. Passes against ephemeral PG16.
- `cargo fmt`/`clippy` clean; 84 lib tests pass.

## Rollout notes

- Default 30d will delete a large amount on the **first run** against the existing backlog — batching keeps locks short, but worth first running off-peak (or lowering the interval on staging to validate, then daily for prod).
- Scoped to the gaia indexer/worker tables; the webhook server's own `notifications` table is a separate follow-up.
